### PR TITLE
Minor Bug Fix: continuum not sorted

### DIFF
--- a/History.md
+++ b/History.md
@@ -15,6 +15,7 @@ HEAD
       dc.set 'c', 3
       dc.delete 'd'
     end
+ - Minor fix to set the continuum sorted by value
 
 0.9.8
 -----

--- a/lib/dalli/ring.rb
+++ b/lib/dalli/ring.rb
@@ -20,8 +20,7 @@ module Dalli
             continuum << Dalli::Ring::Entry.new(value, server)
           end
         end
-        continuum.sort { |a, b| a.value <=> b.value }
-        @continuum = continuum
+        @continuum = continuum.sort { |a, b| a.value <=> b.value }
       end
 
       threadsafe! unless options[:threadsafe] == false

--- a/test/test_dalli.rb
+++ b/test/test_dalli.rb
@@ -26,6 +26,17 @@ class TestDalli < Test::Unit::TestCase
     assert_equal s2, s3
   end
 
+  should "have the continuum sorted by value" do
+    servers = [stub(:hostname => "localhost", :port => "11211", :weight => 1),
+               stub(:hostname => "localhost", :port => "9500", :weight => 1)]
+    ring = Dalli::Ring.new(servers, {})
+    previous_value = 0
+    ring.continuum.each do |entry|
+      assert entry.value > previous_value
+      previous_value = entry.value
+    end
+  end
+
   context 'using a live server' do
 
     should "support get/set" do


### PR DESCRIPTION
Hi Mike,

I was running into a problem where with multiple memcached servers running, all my objects were being cached to a single memcached server. I traced it down to the continuum not being sorted when the ring is initialized. I've included a test case which I hope reflects the verification that the continuum is sorted by value.

Thanks for your work on this memcached client!
