### PR TITLE
Some stability improvements 

### DIFF
--- a/lib/dalli/ring.rb
+++ b/lib/dalli/ring.rb
@@ -35,7 +35,7 @@ module Dalli
       20.times do |try|
         entryidx = self.class.binary_search(@continuum, hkey)
         server = @continuum[entryidx].server
-        return server if server.alive?
+        return server # if server.alive?
         break unless @failover
         hkey = hash_for("#{try}#{key}")
       end

--- a/lib/dalli/server.rb
+++ b/lib/dalli/server.rb
@@ -295,7 +295,7 @@ module Dalli
         value = ''
         begin
           loop do
-            value << socket.sysread(count)
+            value << socket.sysread(count - value.size)
             break if value.size == count
           end
         rescue Errno::EAGAIN, Errno::EWOULDBLOCK


### PR DESCRIPTION
Hi,

just went live with dalli 0.9.8 and had major issues.
- getting a Timeout error (in server/read)
- not reconnecting in a multi server environment

These two fixes should improve
- if you really have to loop you should account for the bytes you've already read
- when asking for the server for a key in a key ring, you should return a server even when it is not alive, otherwise there will be no reconnect (maybe I'm missing something there)

Last change is a guess, a review would be great.

Christian
