### PR TITLE
Here's the one line fix for expires_in

### DIFF
--- a/lib/action_controller/session/dalli_store.rb
+++ b/lib/action_controller/session/dalli_store.rb
@@ -37,7 +37,7 @@ begin
 
           def set_session(env, sid, session_data)
             options = env['rack.session.options']
-            expiry  = options[:expire_after] || 0
+            expiry  = options[:expire_after]
             @pool.set(sid, session_data, expiry)
             return true
           rescue Dalli::DalliError

--- a/lib/action_dispatch/middleware/session/dalli_store.rb
+++ b/lib/action_dispatch/middleware/session/dalli_store.rb
@@ -45,7 +45,7 @@ module ActionDispatch
 
         def set_session(env, sid, session_data, options = nil)
           options ||= env[ENV_SESSION_OPTIONS_KEY]
-          expiry  = options[:expire_after] || 0
+          expiry  = options[:expire_after]
           @pool.set(sid, session_data, expiry)
           sid
         rescue Dalli::DalliError


### PR DESCRIPTION
The default ttl is 0 in DalliClient so there is no reason to set it in DalliStore. That way you can not set expires_after and set expires_on instead of you want a browser session cookie. 
