### PR TITLE
Silence warnings

### DIFF
--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -25,6 +25,7 @@ module Dalli
       @servers = env_servers || servers || 'localhost:11211'
       @options = { :expires_in => 0 }.merge(options)
       self.extend(Dalli::Client::MemcacheClientCompatibility) if Dalli::Client.compatibility_mode
+      @ring = nil
     end
 
     ##

--- a/lib/dalli/server.rb
+++ b/lib/dalli/server.rb
@@ -34,6 +34,8 @@ module Dalli
       @down_at = nil
       @last_down_at = nil
       @options = DEFAULTS.merge(options)
+      @sock = nil
+      @msg = nil
     end
     
     # Chokepoint method for instrumentation

--- a/lib/dalli/socket.rb
+++ b/lib/dalli/socket.rb
@@ -1,6 +1,6 @@
 begin
   require 'kgio'
-  puts "Using kgio socket IO" if $TESTING
+  puts "Using kgio socket IO" if defined?($TESTING)
 
   class Dalli::Server::KSocket < Kgio::Socket
     attr_accessor :options
@@ -41,7 +41,7 @@ begin
 
 rescue LoadError
 
-  puts "Using standard socket IO (#{RUBY_DESCRIPTION})" if $TESTING
+  puts "Using standard socket IO (#{RUBY_DESCRIPTION})" if defined?($TESTING)
   if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby'
 
     class Dalli::Server::KSocket < TCPSocket


### PR DESCRIPTION
Silence a bunch of warnings that dalli generates. Run the tests with `rake RUBYOPT="-v"` to see what I'm talking about.
