### PR TITLE
Silence warning more efficiently

### DIFF
--- a/lib/dalli/socket.rb
+++ b/lib/dalli/socket.rb
@@ -1,6 +1,6 @@
 begin
   require 'kgio'
-  puts "Using kgio socket IO" if defined?($TESTING)
+  puts "Using kgio socket IO" if defined?($TESTING) && $TESTING
 
   class Dalli::Server::KSocket < Kgio::Socket
     attr_accessor :options
@@ -41,7 +41,7 @@ begin
 
 rescue LoadError
 
-  puts "Using standard socket IO (#{RUBY_DESCRIPTION})" if defined?($TESTING)
+  puts "Using standard socket IO (#{RUBY_DESCRIPTION})" if defined?($TESTING) && $TESTING
   if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby'
 
     class Dalli::Server::KSocket < TCPSocket


### PR DESCRIPTION
For some reason, in our production environment, $TESTING is defined but is assigned to nil.
We use many gems and quite a few could be causing this.
However, having checked most of these, they all seem to rely on $TESTING to be assigned _true_ to toggle their testing logic.
