### PR TITLE
Don't explicitly specify default server for session.

### DIFF
--- a/lib/action_dispatch/middleware/session/dalli_store.rb
+++ b/lib/action_dispatch/middleware/session/dalli_store.rb
@@ -12,10 +12,7 @@ module ActionDispatch
 
         super
 
-        @default_options = {
-          :namespace => 'rack:session',
-          :memcache_server => 'localhost:11211',
-        }.merge(@default_options)
+        @default_options = { :namespace => 'rack:session' }.merge(@default_options)
 
         @pool = options[:cache] || begin
           Dalli::Client.new( 


### PR DESCRIPTION
The default will be set in Dalli::Client as far as I can tell. This removes the need to config the session store.
