### PR TITLE
add travis configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+rvm:
+  - 1.9.2
+  - jruby
+  - rbx-2.0
+branches:
+  only:
+    - master
+env: JRUBY_OPTS='--1.9 -X+O -J-Djruby.launch.inproc=false'


### PR DESCRIPTION
I just grabbed the travis configuration file from the girl_friday gem for this pull request. I think someone who has access needs to login to Travis and add the dalli project to it. Also, I'm wondering if Travis gives us the ability to launch a memcached server in the background for some of the tests, etc. I will investigate further.
