### PR TITLE
Fixed an error in the memcache client compatibility module

### DIFF
--- a/lib/dalli/compatibility.rb
+++ b/lib/dalli/compatibility.rb
@@ -38,7 +38,7 @@ class Dalli::Client
     def get(key, options = nil)
       value = super(key, options)
       if value && value.is_a?(String) && !options && value.size > 2 &&
-              bytes = value.unpack('cc') && bytes[0] == 4 && bytes[1] == 8
+              (bytes = value.unpack('cc')) && bytes[0] == 4 && bytes[1] == 8
         return Marshal.load(value) rescue value
       end
       value


### PR DESCRIPTION
This was giving a 

NoMethodError: undefined method `[]' for nil:NilClass
        from /opt/ruby-enterprise-1.8.7-2010.02/lib/ruby/gems/1.8/gems/dalli-1.0.5/lib/dalli/compatibility.rb:41:in`get'
        from (irb):17

in both ree 1.8.7 and ruby 1.9.1 due to using a variable in an if statement that was also defined in the same if statement without parenthesis.
