### PR TITLE
Gracefully handle errors in DalliStore#read_multi

### DIFF
--- a/History.md
+++ b/History.md
@@ -10,6 +10,7 @@ Dalli Changelog
 - Gracefully handle write timeouts, GH-99
 - Only issue bug warning for unexpected StandardErrors, GH-102
 - Add travis-ci build support (ryanlecompte)
+- Gracefully handle errors in get_multi (michaelfairley)
 - Misc fixes from crash2burn, fphilipe, igreg, raggi
 
 1.0.5

--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -71,7 +71,12 @@ module Dalli
       options = keys.pop if keys.last.is_a?(Hash) || keys.last.nil?
       ring.lock do
         keys.flatten.each do |key|
-          perform(:getkq, key)
+          begin
+            perform(:getkq, key)
+          rescue Dalli::DalliError => e
+            Dalli.logger.debug { e.message }
+            Dalli.logger.debug { "unable to get key #{key}" }
+          end
         end
 
         values = {}

--- a/test/test_failover.rb
+++ b/test/test_failover.rb
@@ -78,9 +78,8 @@ class TestFailover < Test::Unit::TestCase
 
           memcached_kill(29126)
 
-          assert_raise Dalli::RingError, :message => "No server available" do
-            dc.get_multi ['foo', 'bar']
-          end
+          result = dc.get_multi ['foo', 'bar']
+          assert_equal result, {}
         end
       end
     end


### PR DESCRIPTION
Dalli::RingError leaks out of DalliStore#read_multi when the server is down.
