### PR TITLE
Don't try to use UNIXSocket on JRuby on Windows

### DIFF
--- a/lib/dalli/socket.rb
+++ b/lib/dalli/socket.rb
@@ -149,7 +149,8 @@ rescue LoadError
   puts "Could not define alternate em-synchrony socket IO" if defined?($TESTING) && $TESTING
 end
 
-if RUBY_PLATFORM =~ /mingw|mswin/
+require 'rbconfig'
+if RbConfig::CONFIG['host_os'] =~ /mingw|mswin/
   class Dalli::Server::USocket
     def initialize(*args)
       raise Dalli::DalliError, "Unix sockets are not supported on Windows platform."


### PR DESCRIPTION
JRuby reports it's RUBY_PLATFORM as 'java', however, following [JRUBY-4046](http://jira.codehaus.org/browse/JRUBY-4046), UNIXSocket is no longer defined on JRuby running on Windows. Therefore, fall-back to using rbconfig to detect Windows.
