### PR TITLE
Patch for hash syntax

### DIFF
--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -69,6 +69,8 @@ module Dalli
       (!resp || resp == 'Not found') ? nil : resp
     end
 
+    alias [] get
+
     ##
     # Fetch multiple keys efficiently.
     # Returns a hash of { 'key' => 'value', 'key2' => 'value1' }
@@ -145,6 +147,10 @@ module Dalli
     def add(key, value, ttl=nil, options=nil)
       ttl ||= @options[:expires_in]
       perform(:add, key, value, ttl, options)
+    end
+
+    def []=(key, value)
+      set(key, value)
     end
 
     ##

--- a/test/test_dalli.rb
+++ b/test/test_dalli.rb
@@ -29,6 +29,14 @@ class TestDalli < Test::Unit::TestCase
   context 'using unix sockets' do
     should 'pass smoke test' do
       memcached(nil,'',{:unix => true}) do |dc|
+        # Hash syntax
+        dc[:a] = 42
+        dc.set(:b, 43)
+        assert_equal dc[:a], 42
+        assert_equal dc[:b], 43
+        assert_equal dc.get(:a), 42
+        assert_equal dc.get(:b), 43
+
         # get/set
         dc.flush
         assert_nil dc.get(:a)


### PR DESCRIPTION
I've added a small patch + tests for get and set using the ruby hash syntax on the client object;
aka client[:foo] = 42.

Thanks
-Brett
