### PR TITLE
Documentation typo and Passenger handling proposal

### DIFF
--- a/History.md
+++ b/History.md
@@ -8,6 +8,7 @@ Dalli Changelog
   whose classes have not be required yet, GH-129
 - Support Unix sockets for connectivity.  Shows a 2x performance
   increase but keep in mind they only work on localhost. (dfens)
+- Automatically handle forking under Passenger (PaulSD)
 
 1.1.2
 =======

--- a/README.md
+++ b/README.md
@@ -97,19 +97,7 @@ Dalli v1.1+ does not support Rails 2.3.  Please use an earlier version: gem inst
 Usage with Passenger
 ------------------------
 
-Put this at the bottom of `config/environment.rb`:
-
-    if defined?(PhusionPassenger)
-      PhusionPassenger.on_event(:starting_worker_process) do |forked|
-        # Reset Rails's object cache
-        # Only works with DalliStore
-        Rails.cache.reset if forked
-
-        # Reset Rails's session store
-        # If you know a cleaner way to find the session store instance, please let me know
-        ObjectSpace.each_object(ActionDispatch::Session::DalliStore) { |obj| obj.reset }
-      end
-    end
+Dalli v1.4+ automatically resets itself when passenger forks.  Adding code to environment.rb to reset MemCache connections is no longer required.
 
 
 Configuration


### PR DESCRIPTION
For the passenger commit ... I've been using something like the following in config/preinitializer.rb for several years now (of course, updated slightly when I switched from memcache-client to Dalli):
unless defined? DALLI_PASSENGER_RECONNECT
  DALLI_PASSENGER_RECONNECT = true
  require 'dalli'
  module Dalli
    class Client
      alias_method :orig_initialize, :initialize
      def initialize(_args)
        if defined?(PhusionPassenger)
          PhusionPassenger.on_event(:starting_worker_process) do |forked|
            close if forked
          end
        end
        orig_initialize(_args)
      end
    end
  end
end

The advantage to this over the example currently listed in the Dalli readme is that you don't have to worry about finding a clean way to get at Rails's session store, and you also don't have to worry about remembering to update environment.rb again if you end up using Dalli under Passenger outside of Rails's object cache and session store ... just set and forget.

I was thinking of simply proposing this as a better example to put in the README file, but then I thought ... is there any good reason not to just put this in Dalli itself?  The code doesn't do anything if it's not run under Passenger, so why not simply add it to Dalli directly and relieve developers of this burden entirely?
