### PR TITLE
Non ascii keys

### DIFF
--- a/History.md
+++ b/History.md
@@ -57,7 +57,7 @@ Notes:
     require 'rack/session/dalli'
     use Rack::Session::Dalli, :memcache_server => 'localhost:11211', :compression => true
 
-- Add support for non-ascii keys when desired
+- Add support for non-ascii keys
 
 1.1.3
 =======

--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -17,7 +17,6 @@ module Dalli
     # Options:
     # - :namespace - prepend each key with this value to provide simple namespacing.
     # - :failover - if a server is down, look for and store values on another server in the ring.  Default: true.
-    # - :nonascii - allow the use of nonascii key names.  Default: false.
     # - :threadsafe - ensure that only one thread is actively using a socket at a time. Default: true.
     # - :expires_in - default TTL in seconds if you do not pass TTL as a parameter to an individual operation, defaults to 0 or forever
     # - :compress - defaults to false, if true Dalli will compress values larger than 100 bytes before

--- a/test/test_encoding.rb
+++ b/test/test_encoding.rb
@@ -8,15 +8,13 @@ describe 'Encoding' do
     should 'support i18n content' do
       memcached do |dc|
         key = 'foo'
-        bad_key = utf8 = 'ƒ©åÍÎ'
+        nonascii_key = utf8 = 'ƒ©åÍÎ'
 
         assert dc.set(key, utf8)
         assert_equal utf8, dc.get(key)
 
-        # keys must be ASCII
-        assert_raises ArgumentError, /illegal character/ do
-          dc.set(bad_key, utf8)
-        end
+        assert dc.set(nonascii_key, utf8)
+        assert_equal utf8, dc.get(nonascii_key)
       end
     end
 
@@ -30,17 +28,8 @@ describe 'Encoding' do
       end
     end
 
-    should 'not allow non-ASCII keys' do
+    should 'support non-ASCII keys' do
       memcached do |dc|
-        key = 'fooƒ'
-        assert_raises ArgumentError do
-          dc.set(key, 'bar')
-        end
-      end
-    end
-
-    should 'allow non-ASCII keys when desired' do
-      memcached(19122,'',:nonascii => true) do |dc|
         key = 'fooƒ'
         assert dc.set(key, 'bar')
         assert_equal 'bar', dc.get(key)


### PR DESCRIPTION
We have a number of existing non-ascii keys, so this allows us to enable non-ascii support via the `:nonascii` option.
