### PR TITLE
fixed "uninitialized constant Rack::Session::Dalli::Client"

### DIFF
--- a/lib/rack/session/dalli.rb
+++ b/lib/rack/session/dalli.rb
@@ -14,7 +14,7 @@ module Rack
         super
         mserv = @default_options[:memcache_server]
         mopts = @default_options.reject{|k,v| !DEFAULT_OPTIONS.include? k }
-        @pool = options[:cache] || Dalli::Client.new(mserv, mopts)
+        @pool = options[:cache] || ::Dalli::Client.new(mserv, mopts)
       end
 
       def generate_sid


### PR DESCRIPTION
Just started using Dalli. Found you guys through Heroku Memcache recommendation. Like what you guys are doing. Needed Rack::Session::Dalli as well, fixed line 17.
