### PR TITLE
Backport e21ded0, fix for compatibility get method, to 1.0.x

### DIFF
--- a/lib/dalli/compatibility.rb
+++ b/lib/dalli/compatibility.rb
@@ -38,7 +38,7 @@ class Dalli::Client
     def get(key, options = nil)
       value = super(key, options)
       if value && value.is_a?(String) && !options && value.size > 2 &&
-              bytes = value.unpack('cc') && bytes[0] == 4 && bytes[1] == 8
+              (bytes = value.unpack('cc')) && bytes[0] == 4 && bytes[1] == 8
         return Marshal.load(value) rescue value
       end
       value


### PR DESCRIPTION
Ran into same bug as e21ded0 fixed -- in 1.0.5 gem.
