### PR TITLE
Double namespacing

### DIFF
--- a/lib/active_support/cache/dalli_store.rb
+++ b/lib/active_support/cache/dalli_store.rb
@@ -28,7 +28,7 @@ module ActiveSupport
       #
       # If no addresses are specified, then DalliStore will connect to
       # localhost port 11211 (the default memcached port).
-      #
+      # 
       def initialize(*addresses)
         addresses = addresses.flatten
         options = addresses.extract_options!


### PR DESCRIPTION
The current version of Dalli causes double namespacing in rails 3.0.X. I have not tested in rails 3.1+. This happens because both Dalli and Rails support namespacing, and both of them get the namespace parameter, which causes them to both apply the namespace to the key. For example, if we set it up with {:namespace => 'e'}, then Rails.cache.read("abc") issues a request to memcached for "e:e:abc". This causes a problem when attempting to get multiple sites to work together properly (since site 1 might use normal namespacing 'e:abc' while site 2 uses 'e:e:abc')

This commit fixes it in the simplest way possible, by removing the namespace parameter before it passes the configuration options from activesupport/dailli_store to Dalli::Client. This change did not break any existing tests, and I did not add any new tests for it.
