### PR TITLE
convert tests to minitest/spec

### DIFF
--- a/dalli.gemspec
+++ b/dalli.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.summary = %q{High performance memcached client for Ruby}
   s.test_files = Dir.glob("test/**/*")
-  s.add_development_dependency(%q<shoulda>, [">= 0"])
+  s.add_development_dependency(%q<mini_shoulda>, [">= 0"])
   s.add_development_dependency(%q<mocha>, [">= 0"])
   s.add_development_dependency(%q<rails>, [">= 3.0"])
   s.add_development_dependency(%q<memcache-client>, [">= 1.8.5"])

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -7,8 +7,9 @@ gem 'rails', WANT_RAILS_VERSION
 require 'rails'
 puts "Testing with Rails #{Rails.version}"
 
-require 'test/unit'
-require 'shoulda'
+require 'minitest/spec'
+require 'mini_shoulda'
+require 'minitest/autorun'
 require 'memcached_mock'
 require 'mocha'
 
@@ -18,16 +19,17 @@ require 'logger'
 Dalli.logger = Logger.new(STDOUT)
 Dalli.logger.level = Logger::ERROR
 
-class Test::Unit::TestCase
+class MiniTest::Spec
   include MemcachedMock::Helper
 
   def assert_error(error, regexp=nil, &block)
-    ex = assert_raise(error, &block)
+    ex = assert_raises(error, &block)
     assert_match(regexp, ex.message, "#{ex.class.name}: #{ex.message}\n#{ex.backtrace.join("\n\t")}")
   end
 
   def with_activesupport
     require 'active_support/all'
+    require 'active_support/cache/dalli_store'
     yield
   end
 

--- a/test/test_active_support.rb
+++ b/test/test_active_support.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 require 'helper'
 
-class TestActiveSupport < Test::Unit::TestCase
+describe 'ActiveSupport' do
   context 'active_support caching' do
 
     should 'support fetch' do

--- a/test/test_compatibility.rb
+++ b/test/test_compatibility.rb
@@ -1,8 +1,8 @@
 require 'helper'
 
-class TestCompatibility < Test::Unit::TestCase
+describe 'Compatibility' do
 
-  def setup
+  before do
     require 'dalli/memcache-client'
   end
 
@@ -26,7 +26,7 @@ class TestCompatibility < Test::Unit::TestCase
 
   end
 
-  def teardown
+  after do
     Dalli::Client.compatibility_mode = false
   end
 

--- a/test/test_dalli.rb
+++ b/test/test_dalli.rb
@@ -1,7 +1,7 @@
 require 'helper'
 require 'memcached_mock'
 
-class TestDalli < Test::Unit::TestCase
+describe 'Dalli' do
 
   should "default to localhost:11211" do
     dc = Dalli::Client.new
@@ -251,7 +251,7 @@ class TestDalli < Test::Unit::TestCase
 
         # rollover the 64-bit value, we'll get something undefined.
         resp = dc.incr('big', 1)
-        assert_not_equal 0x10000000000000000, resp
+        0x10000000000000000.wont_equal resp
         dc.reset
       end
     end
@@ -273,7 +273,7 @@ class TestDalli < Test::Unit::TestCase
     should "pass a simple smoke test" do
       memcached do |dc|
         resp = dc.flush
-        assert_not_nil resp
+        resp.wont_be_nil
         assert_equal [true, true], resp
 
         assert_equal true, dc.set(:foo, 'bar')
@@ -343,7 +343,7 @@ class TestDalli < Test::Unit::TestCase
               cache.set('b', 11)
               inc = cache.incr('cat', 10, 0, 10)
               cache.set('f', 'zzz')
-              assert_not_nil(cache.cas('f') do |value|
+              wont_be_nil(cache.cas('f') do |value|
                 value << 'z'
               end)
               assert_equal false, cache.add('a', 11)
@@ -399,7 +399,7 @@ class TestDalli < Test::Unit::TestCase
           dalli = Dalli::Client.new(dc.instance_variable_get(:@servers), :compression => true)
 
           value = "0"*1024*1024
-          assert_raise Dalli::DalliError, /too large/ do
+          assert_raises Dalli::DalliError, /too large/ do
             dc.set('verylarge', value)
           end
           dalli.set('verylarge', value)

--- a/test/test_encoding.rb
+++ b/test/test_encoding.rb
@@ -2,7 +2,7 @@
 require 'helper'
 require 'memcached_mock'
 
-class TestEncoding < Test::Unit::TestCase
+describe 'Encoding' do
 
   context 'using a live server' do
     should 'support i18n content' do
@@ -14,7 +14,7 @@ class TestEncoding < Test::Unit::TestCase
         assert_equal utf8, dc.get(key)
 
         # keys must be ASCII
-        assert_raise ArgumentError, /illegal character/ do
+        assert_raises ArgumentError, /illegal character/ do
           dc.set(bad_key, utf8)
         end
       end
@@ -33,7 +33,7 @@ class TestEncoding < Test::Unit::TestCase
     should 'not allow non-ASCII keys' do
       memcached do |dc|
         key = 'fooƒ'
-        assert_raise ArgumentError do
+        assert_raises ArgumentError do
           dc.set(key, 'bar')
         end
       end

--- a/test/test_failover.rb
+++ b/test/test_failover.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-class TestFailover < Test::Unit::TestCase
+describe 'FailOver' do
   context 'assuming some bad servers' do
 
     should 'silently reconnect if server hiccups' do
@@ -37,7 +37,7 @@ class TestFailover < Test::Unit::TestCase
 
           memcached_kill(29126)
 
-          assert_raise Dalli::RingError, :message => "No server available" do
+          assert_raises Dalli::RingError, :message => "No server available" do
             dc.set 'foo', 'bar'
           end
         end

--- a/test/test_network.rb
+++ b/test/test_network.rb
@@ -1,11 +1,11 @@
 require 'helper'
 
-class TestNetwork < Test::Unit::TestCase
+describe 'Network' do
 
   context 'assuming a bad network' do
 
     should 'handle no server available' do
-      assert_raise Dalli::RingError, :message => "No server available" do
+      assert_raises Dalli::RingError, :message => "No server available" do
         dc = Dalli::Client.new 'localhost:19333'
         dc.get 'foo'
       end
@@ -14,7 +14,7 @@ class TestNetwork < Test::Unit::TestCase
     context 'with a fake server' do
       should 'handle connection reset' do
         memcached_mock(lambda {|sock| sock.close }) do
-          assert_raise Dalli::RingError, :message => "No server available" do
+          assert_raises Dalli::RingError, :message => "No server available" do
             dc = Dalli::Client.new('localhost:19123')
             dc.get('abc')
           end
@@ -23,7 +23,7 @@ class TestNetwork < Test::Unit::TestCase
 
       should 'handle malformed response' do
         memcached_mock(lambda {|sock| sock.write('123') }) do
-          assert_raise Dalli::RingError, :message => "No server available" do
+          assert_raises Dalli::RingError, :message => "No server available" do
             dc = Dalli::Client.new('localhost:19123')
             dc.get('abc')
           end
@@ -32,7 +32,7 @@ class TestNetwork < Test::Unit::TestCase
 
       should 'handle connect timeouts' do
         memcached_mock(lambda {|sock| sleep(0.6); sock.close }, :delayed_start) do
-          assert_raise Dalli::RingError, :message => "No server available" do
+          assert_raises Dalli::RingError, :message => "No server available" do
             dc = Dalli::Client.new('localhost:19123')
             dc.get('abc')
           end
@@ -41,7 +41,7 @@ class TestNetwork < Test::Unit::TestCase
 
       should 'handle read timeouts' do
         memcached_mock(lambda {|sock| sleep(0.6); sock.write('giraffe') }) do
-          assert_raise Dalli::RingError, :message => "No server available" do
+          assert_raises Dalli::RingError, :message => "No server available" do
             dc = Dalli::Client.new('localhost:19123')
             dc.get('abc')
           end

--- a/test/test_ring.rb
+++ b/test/test_ring.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-class TestRing < Test::Unit::TestCase
+describe 'Ring' do
 
   context 'a ring of servers' do
 
@@ -17,7 +17,7 @@ class TestRing < Test::Unit::TestCase
 
     should 'raise when no servers are available/defined' do
       ring = Dalli::Ring.new([], {})
-      assert_raise Dalli::RingError, :message => "No server available" do
+      assert_raises Dalli::RingError, :message => "No server available" do
         ring.server_for_key('test')
       end
     end
@@ -28,7 +28,7 @@ class TestRing < Test::Unit::TestCase
           Dalli::Server.new("localhost:12345"),
         ]
         ring = Dalli::Ring.new(servers, {})
-        assert_raise Dalli::RingError, :message => "No server available" do
+        assert_raises Dalli::RingError, :message => "No server available" do
           ring.server_for_key('test')
         end
       end
@@ -52,7 +52,7 @@ class TestRing < Test::Unit::TestCase
           Dalli::Server.new("localhost:12346"),
         ]
         ring = Dalli::Ring.new(servers, {})
-        assert_raise Dalli::RingError, :message => "No server available" do
+        assert_raises Dalli::RingError, :message => "No server available" do
           ring.server_for_key('test')
         end
       end
@@ -71,12 +71,12 @@ class TestRing < Test::Unit::TestCase
     end
 
     should 'detect when a dead server is up again' do
-      memcached(29125) do
+      memcached(19997) do
         down_retry_delay = 0.5
-        dc = Dalli::Client.new(['localhost:29125', 'localhost:29126'], :down_retry_delay => down_retry_delay)
+        dc = Dalli::Client.new(['localhost:19997', 'localhost:19998'], :down_retry_delay => down_retry_delay)
         assert_equal 1, dc.stats.values.compact.count
 
-        memcached(29126) do
+        memcached(19998) do
           assert_equal 2, dc.stats.values.compact.count
         end
       end

--- a/test/test_sasl.rb
+++ b/test/test_sasl.rb
@@ -1,16 +1,16 @@
 require 'helper'
 
-class TestSasl < Test::Unit::TestCase
+describe 'Sasl' do
 
   context 'a server requiring authentication' do
 
     context 'without authentication credentials' do
-      setup do
+      before do
         ENV['MEMCACHE_USERNAME'] = 'foo'
         ENV['MEMCACHE_PASSWORD'] = 'wrongpwd'
       end
 
-      teardown do
+      after do
         ENV['MEMCACHE_USERNAME'] = nil
         ENV['MEMCACHE_PASSWORD'] = nil
       end
@@ -43,12 +43,12 @@ class TestSasl < Test::Unit::TestCase
     #
     # with password 'testtest'
     context 'in an authenticated environment' do
-      setup do
+      before do
         ENV['MEMCACHE_USERNAME'] = 'testuser'
         ENV['MEMCACHE_PASSWORD'] = 'testtest'
       end
 
-      teardown do
+      after do
         ENV['MEMCACHE_USERNAME'] = nil
         ENV['MEMCACHE_PASSWORD'] = nil
       end

--- a/test/test_synchrony.rb
+++ b/test/test_synchrony.rb
@@ -4,7 +4,7 @@ if defined?(RUBY_ENGINE) && RUBY_ENGINE != 'jruby'
 begin
 require 'em-spec/test'
 
-class TestSynchrony < Test::Unit::TestCase
+describe 'Synchrony' do
   include EM::TestHelper
 
   context 'using a live server' do
@@ -156,7 +156,7 @@ class TestSynchrony < Test::Unit::TestCase
             dalli = Dalli::Client.new(dc.instance_variable_get(:@servers), :compression => true, :async => true)
 
             value = "0"*1024*1024
-            assert_raise Dalli::DalliError, /too large/ do
+            assert_raises Dalli::DalliError, /too large/ do
               dc.set('verylarge', value)
             end
             dalli.set('verylarge', value)


### PR DESCRIPTION
I used mini_shoulda which is just a bunch of aliases https://github.com/metaskills/mini_shoulda/blob/93a4bcf70211ffe615e7fe1b2e70fb442adde456/lib/mini_shoulda/spec.rb

I used ruby 1.9.3. Minitest on ruby 1.9.2 p290 has a bug where some tests run more than once and failed. 

https://gist.github.com/8c4b3a7220a60c0d31b7
