### PR TITLE
Add connection timeout to jruby socket connect

### DIFF
--- a/lib/dalli/socket.rb
+++ b/lib/dalli/socket.rb
@@ -50,9 +50,11 @@ rescue LoadError
       attr_accessor :options
 
       def self.open(host, port, options = {})
-        sock = new(host, port)
-        sock.options = { :host => host, :port => port }.merge(options)
-        sock
+        Timeout.timeout options[:timeout] do
+          sock = new(host, port)
+          sock.options = { :host => host, :port => port }.merge(options)
+          sock
+        end
       end
 
       def readfull(count)


### PR DESCRIPTION
This just adds a Timeout.timeout block around the jruby specific socket connect.   Without this jruby connects can  hang for whatever the socket level connect timeout is, which is quite long.
