### PR TITLE
Dalli doesn't properly reconnect async connection if memcache remotely closes connection

### DIFF
--- a/lib/dalli/server.rb
+++ b/lib/dalli/server.rb
@@ -62,13 +62,8 @@ module Dalli
     end
 
     def alive?
-      if @sock
-        if @sock.respond_to?(:closed?)
-          return @sock.closed?
-        else
-          return true
-        end
-      end
+      # #closed? exists in EM::Synchrony::Socket class (inherited by Dalli::Server::AsyncSocket)
+      return true if @sock && (!@sock.respond_to?(:closed?) || !@sock.closed?)
 
       if @last_down_at && @last_down_at + options[:down_retry_delay] >= Time.now
         time = @last_down_at + options[:down_retry_delay] - Time.now


### PR DESCRIPTION
Dalli doesn't check whether the async socket was closed remotely by the memcached server, so all read/write operations hang when trying to read from socket (most likely from yielding the Fiber and not hearing any responses back).

Added a conditional to call the EM::Synchrony::Socket#closed? method to correctly check whether the async connection is truly alive. (I made a [fix to the em-synchrony gem](https://github.com/igrigorik/em-synchrony/pull/115#issuecomment-4443982) that fixes the #closed? behavior just for this scenario).

Love the Dalli gem, keep up the good work guys.
