### PR TITLE
Support for keepalive connections

### DIFF
--- a/History.md
+++ b/History.md
@@ -11,6 +11,7 @@ HEAD
 =======
 
 - Added reset\_stats operation [#155]
+- Added support for configuring keepalive on TCP connections to memcached servers (@bianster, #180)
 
 1.1.5
 =======
@@ -89,7 +90,7 @@ v1.1.0 was a bad release.  Yanked.
  - Allow browser session cookies (blindsey)
  - Compatibility fixes (mwynholds)
  - Add backwards compatibility module for memcache-client, require 'dalli/memcache-client'.  It makes
-   Dalli more compatible with memcache-client and prints out a warning any time you do something that 
+   Dalli more compatible with memcache-client and prints out a warning any time you do something that
    is no longer supported so you can fix your code.
 
 1.0.1

--- a/lib/dalli/server.rb
+++ b/lib/dalli/server.rb
@@ -23,6 +23,7 @@ module Dalli
       :username => nil,
       :password => nil,
       :async => false,
+      :keepalive => false
     }
 
     def initialize(attribs, options = {})
@@ -398,7 +399,7 @@ module Dalli
           raise Dalli::DalliError, "EM support not enabled, as em-synchrony is not installed." if not defined?(AsyncSocket)
           @sock = AsyncSocket.open(hostname, port, :timeout => options[:socket_timeout])
         else
-          @sock = KSocket.open(hostname, port, :timeout => options[:socket_timeout])
+          @sock = KSocket.open(hostname, port, :timeout => options[:socket_timeout], :keepalive => options[:keepalive])
         end
         @version = version # trigger actual connect
         sasl_authentication if need_auth?

--- a/lib/dalli/socket.rb
+++ b/lib/dalli/socket.rb
@@ -16,6 +16,7 @@ begin
     def self.open(host, port, options = {})
       addr = Socket.pack_sockaddr_in(port, host)
       sock = start(addr)
+      sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_KEEPALIVE, true) if options[:keepalive]
       sock.options = options
       sock.kgio_wait_writable
       sock
@@ -51,6 +52,7 @@ rescue LoadError
 
       def self.open(host, port, options = {})
         sock = new(host, port)
+        sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_KEEPALIVE, true) if options[:keepalive]
         sock.options = { :host => host, :port => port }.merge(options)
         sock
       end
@@ -83,6 +85,7 @@ rescue LoadError
         # All this ugly code to ensure proper Socket connect timeout
         addr = Socket.getaddrinfo(host, nil)
         sock = new(Socket.const_get(addr[0][0]), Socket::SOCK_STREAM, 0)
+        sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_KEEPALIVE, true) if options[:keepalive]
         sock.options = { :host => host, :port => port }.merge(options)
         begin
           sock.connect_nonblock(Socket.pack_sockaddr_in(port, addr[0][3]))

--- a/test/test_dalli.rb
+++ b/test/test_dalli.rb
@@ -294,6 +294,20 @@ describe 'Dalli' do
       end
     end
 
+    should 'allow TCP connections to be configured for keepalive' do
+      memcached(19122, '', :keepalive => true) do |dc|
+        dc.set(:a, 1)
+        ring = dc.send(:ring)
+        server = ring.servers.first
+        socket = server.instance_variable_get('@sock')
+
+        optval = socket.getsockopt(Socket::SOL_SOCKET, Socket::SO_KEEPALIVE)
+        optval = optval.unpack 'i'
+
+        assert_equal true, (optval[0] != 0)
+      end
+    end
+
     should "pass a simple smoke test" do
       memcached do |dc|
         resp = dc.flush

--- a/test/test_synchrony.rb
+++ b/test/test_synchrony.rb
@@ -93,6 +93,22 @@ describe 'Synchrony' do
       end
     end
 
+    should 'allow TCP connections to be configured for keepalive' do
+      em do
+        memcached(19122, '', :async => true, :keepalive => true) do |dc|
+          dc.set(:a, 1)
+          ring = dc.send(:ring)
+          server = ring.servers.first
+          socket = server.instance_variable_get('@sock')
+
+          optval = socket.getsockopt(Socket::SOL_SOCKET, Socket::SO_KEEPALIVE)
+          optval = optval.unpack 'i'
+
+          assert_equal true, (optval[0] != 0)
+        end
+      end
+    end
+
     should "pass a simple smoke test" do
       em do
         memcached(19122,'',:async => true) do |dc|


### PR DESCRIPTION
This patch adds optional support for turning on keepalive TCP/IP connections to memcached servers for the master branch.
