### PR TITLE
Fixes bench tests under JRuby

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -7,7 +7,6 @@ gem 'rails', WANT_RAILS_VERSION
 require 'rails'
 puts "Testing with Rails #{Rails.version}"
 
-require 'minitest/spec'
 require 'mini_shoulda'
 require 'minitest/pride'
 require 'minitest/autorun'


### PR DESCRIPTION
- It appears that require 'minitest/spec' pulls in the stdlib version of
  minitest, as opposed to the > 2.1 gemified version required by
  mini_shoulda. This causes conflicts and bizarre errors messages. Since
  mini_shoulda pulls in 'minitest/spec' as well (but the correct
  version), this line can simply be removed.
