### PR TITLE
fix warning about valid :compress option

### DIFF
--- a/lib/active_support/cache/dalli_store.rb
+++ b/lib/active_support/cache/dalli_store.rb
@@ -20,7 +20,7 @@ module ActiveSupport
       def initialize(*addresses)
         addresses = addresses.flatten
         options = addresses.extract_options!
-        options[:compression] = options.delete(:compress) || options[:compression]
+        options[:compress] ||= options[:compression]
         addresses << 'localhost:11211' if addresses.empty?
         @data = Dalli::Client.new(addresses, options)
       end

--- a/test/test_dalli.rb
+++ b/test/test_dalli.rb
@@ -6,6 +6,13 @@ describe 'Dalli' do
     should 'handle deprecated options' do
       dc = Dalli::Client.new('foo', :compression => true)
       assert dc.instance_variable_get(:@options)[:compress]
+      refute dc.instance_variable_get(:@options)[:compression]
+    end
+
+    should 'not warn about valid options' do
+      dc = Dalli::Client.new('foo', :compress => true)
+      # Rails.logger.expects :warn
+      assert dc.instance_variable_get(:@options)[:compress]
     end
   end
 


### PR DESCRIPTION
I got the warning on startup about the :compression option with this config:

```
config.cache_store = :dalli_store, { :expires_in => 1.day, :compress => true }
```

This commit fixes the warning. Ideally the test would assert that Rails.logger receives a call to :warn. I left a comment of how I'd do it with mocha.
