### PR TITLE
Fix existence check for stored false values

### DIFF
--- a/lib/active_support/cache/dalli_store.rb
+++ b/lib/active_support/cache/dalli_store.rb
@@ -68,7 +68,7 @@ module ActiveSupport
 
       def exist?(name, options=nil)
         options ||= {}
-        !!read_entry(name, options)
+        !read_entry(name, options).nil?
       end
 
       def delete(name, options=nil)

--- a/test/test_active_support.rb
+++ b/test/test_active_support.rb
@@ -133,6 +133,21 @@ describe 'ActiveSupport' do
       end
     end
 
+    should 'support exist command' do
+      with_activesupport do
+        memcached do
+          connect
+          @dalli.write(:foo, 'a')
+          @dalli.write(:false_value, false)
+
+          assert_equal true, @dalli.exist?(:foo)
+          assert_equal true, @dalli.exist?(:false_value)
+
+          assert_equal false, @dalli.exist?(:bar)
+        end
+      end
+    end
+
     should 'support other esoteric commands' do
       with_activesupport do
         memcached do
@@ -140,10 +155,6 @@ describe 'ActiveSupport' do
           ds = @dalli.stats
           assert_equal 1, ds.keys.size
           assert ds[ds.keys.first].keys.size > 0
-
-          assert_equal true, @dalli.write(:foo, 'a')
-          assert_equal true, @dalli.exist?(:foo)
-          assert_equal false, @dalli.exist?(:bar)
 
           @dalli.reset
         end


### PR DESCRIPTION
Relates to #197.
If you set `false` value and then check for its existence with `exists?` you get `false`. Patch fixes this quite strange behavior
