### PR TITLE
flag to enable exception bubbling

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ To use Dalli for Rails session storage, in `config/initializers/session_store.rb
     require 'action_dispatch/middleware/session/dalli_store'
     Rails.application.config.session_store :dalli_store, :memcache_server => ['host1', 'host2'], :namespace => 'sessions', :key => '_foundation_session', :expire_after => 30.minutes
 
-Both cache and session stores support `:bang` parameter, which propagates exceptions (e.g. if all memcache servers are down) instead of silently hiding errors.
+Both cache and session stores support `:raise_errors` parameter, which propagates exceptions (e.g. if all memcache servers are down) instead of silently hiding errors.
 
 Dalli does not support Rails 2.x any longer.
 

--- a/lib/action_dispatch/middleware/session/dalli_store.rb
+++ b/lib/action_dispatch/middleware/session/dalli_store.rb
@@ -20,7 +20,7 @@ module ActionDispatch
         end
         @namespace = @default_options[:namespace]
 
-        @bang = !!@default_options[:bang]
+        @raise_errors = !!@default_options[:raise_errors]
 
         super
       end
@@ -51,7 +51,7 @@ module ActionDispatch
         sid
       rescue Dalli::DalliError
         Rails.logger.warn("Session::DalliStore#set: #{$!.message}")
-        raise if @bang
+        raise if @raise_errors
         false
       end
 
@@ -60,7 +60,7 @@ module ActionDispatch
           @pool.delete(session_id)
         rescue Dalli::DalliError
           Rails.logger.warn("Session::DalliStore#destroy_session: #{$!.message}")
-          raise if @bang
+          raise if @raise_errors
         end
         return nil if options[:drop]
         generate_sid
@@ -72,7 +72,7 @@ module ActionDispatch
         end
       rescue Dalli::DalliError
         Rails.logger.warn("Session::DalliStore#destroy: #{$!.message}")
-        raise if @bang
+        raise if @raise_errors
         false
       end
 

--- a/lib/active_support/cache/dalli_store.rb
+++ b/lib/active_support/cache/dalli_store.rb
@@ -21,7 +21,7 @@ module ActiveSupport
         addresses = addresses.flatten
         options = addresses.extract_options!
         options[:compress] ||= options[:compression]
-        @bang = !!options[:bang]
+        @raise_errors = !!options[:raise_errors]
         addresses << 'localhost:11211' if addresses.empty?
         @data = Dalli::Client.new(addresses, options)
       end
@@ -108,7 +108,7 @@ module ActiveSupport
         end
       rescue Dalli::DalliError => e
         logger.error("DalliError: #{e.message}") if logger
-        raise if @bang
+        raise if @raise_errors
         nil
       end
 
@@ -126,7 +126,7 @@ module ActiveSupport
         end
       rescue Dalli::DalliError => e
         logger.error("DalliError: #{e.message}") if logger
-        raise if @bang
+        raise if @raise_errors
         nil
       end
 
@@ -154,7 +154,7 @@ module ActiveSupport
         entry.is_a?(ActiveSupport::Cache::Entry) ? entry.value : entry
       rescue Dalli::DalliError => e
         logger.error("DalliError: #{e.message}") if logger
-        raise if @bang
+        raise if @raise_errors
         nil
       end
 
@@ -165,7 +165,7 @@ module ActiveSupport
         @data.send(method, escape(key), value, expires_in, options)
       rescue Dalli::DalliError => e
         logger.error("DalliError: #{e.message}") if logger
-        raise if @bang
+        raise if @raise_errors
         false
       end
 
@@ -174,7 +174,7 @@ module ActiveSupport
         @data.delete(escape(key))
       rescue Dalli::DalliError => e
         logger.error("DalliError: #{e.message}") if logger
-        raise if @bang
+        raise if @raise_errors
         false
       end
 

--- a/test/test_active_support.rb
+++ b/test/test_active_support.rb
@@ -161,7 +161,7 @@ describe 'ActiveSupport' do
       end
     end
 
-    should 'respect bang option' do
+    should 'respect "raise_errors" option' do
       with_activesupport do
         memcached(29125) do
           @dalli = ActiveSupport::Cache.lookup_store(:dalli_store, 'localhost:29125')
@@ -172,7 +172,7 @@ describe 'ActiveSupport' do
 
           assert_equal @dalli.read('foo'), nil
 
-          @dalli = ActiveSupport::Cache.lookup_store(:dalli_store, 'localhost:29125', :bang => true)
+          @dalli = ActiveSupport::Cache.lookup_store(:dalli_store, 'localhost:29125', :raise_errors => true)
 
           exception = [Dalli::RingError, :message => "No server available"]
 

--- a/test/test_session_store.rb
+++ b/test/test_session_store.rb
@@ -204,7 +204,7 @@ class TestSessionStore < ActionController::IntegrationTest
       end
     end
 
-    def test_without_bang_option
+    def test_without_raise_errors_option
       memcached(29125) do
         with_test_route_set(:memcache_server => '127.0.0.1:29125') do
           get '/set_session_value'
@@ -223,9 +223,9 @@ class TestSessionStore < ActionController::IntegrationTest
       end
     end
 
-    def test_with_bang_option
+    def test_with_raise_errors_option
       memcached(29125) do
-        with_test_route_set(:memcache_server => '127.0.0.1:29125', :bang => true) do
+        with_test_route_set(:memcache_server => '127.0.0.1:29125', :raise_errors => true) do
           get '/set_session_value'
           assert_response :success
 


### PR DESCRIPTION
Add `:bang` option to both cache and session stores, which propagates exceptions (e.g. if all memcache servers are down) instead of silently hiding errors.
