### PR TITLE
Adds failing test for #fetch-ing false and nil values

### DIFF
--- a/test/test_dalli.rb
+++ b/test/test_dalli.rb
@@ -127,6 +127,20 @@ describe 'Dalli' do
       end
     end
 
+    should "support the fetch operation with falsey values" do
+      memcached do |dc|
+        dc.flush
+
+        dc.set("fetch_key", false)
+        res = dc.fetch("fetch_key") { flunk "fetch block called" }
+        assert_equal false, res
+
+        dc.set("fetch_key", nil)
+        res = dc.fetch("fetch_key") { flunk "fetch block called" }
+        assert_equal nil, res
+      end
+    end
+
     should "support the cas operation" do
       memcached do |dc|
         dc.flush


### PR DESCRIPTION
When using `DalliStore` and `#fetch`, the block is always called even if there is a cached value, if that value is `false` or `nil`.

This does not happen with other `Rails.cache` stores (e.g., I've tested against `MemoryStore`).
