### PR TITLE
Accept ENV['MEMCACHE_URL']

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,11 @@
 Dalli Changelog
 =====================
 
+unreleased
+=======
+
+- Accept ENV['MEMCACHE_URL'] in the form "memcached://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][?options]" [seamusabshere]
+
 2.1.0
 =======
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,14 @@ Dalli::Client accepts the following options. All times are in seconds.
 
 **keepalive**: Boolean, if true Dalli will enable keep-alives on the socket so inactivity
 
+You can also set the MEMCACHE_URL environment variable:
+
+    memcached://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][?options]
+
+so for example:
+
+    'memcached://1.2.3.4,5.6.7.8,9.10.11.12:19124?namespace=mytest&expires_in=4'
+
 Features and Changes
 ------------------------
 

--- a/lib/dalli.rb
+++ b/lib/dalli.rb
@@ -4,6 +4,7 @@ require 'dalli/server'
 require 'dalli/socket'
 require 'dalli/version'
 require 'dalli/options'
+require 'dalli/url_parser'
 require 'dalli/railtie' if defined?(Rails)
 
 module Dalli

--- a/lib/dalli/url_parser.rb
+++ b/lib/dalli/url_parser.rb
@@ -1,0 +1,46 @@
+require 'uri'
+
+module Dalli
+  # Inspired by https://github.com/mongodb/mongo-ruby-driver/blob/master/lib/mongo/util/uri_parser.rb
+  class UrlParser
+    class << self
+      # Extract the comma-separated hosts and single port from the URL
+      def multi_host_port(url)
+        stop = url.index(%r{[?/]}, 12)
+        start = url.rindex(%r{[@/]}, stop)
+        url[(start+1)..(stop-1)].split(':')
+      end
+    end
+
+    SPEC = "memcached://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][?options]"
+
+    attr_reader :username
+    attr_reader :password
+    attr_reader :servers
+    attr_reader :options
+
+    def initialize(url)
+      # Since we're breaking the rules by allowing multiple comma-separated hosts, extract hosts and port manually...
+      multi_host, port = UrlParser.multi_host_port url
+      
+      # ... and then we can use Ruby's URI class to get username, password, and querystring
+      parsed_uri = URI.parse url.sub multi_host, 'fakehost'
+
+      @servers = multi_host.split(',').map do |host|
+        "#{host}:#{port}"
+      end
+      @options = {}
+      if parsed_uri.user
+        @options[:username] = parsed_uri.user
+      end
+      if parsed_uri.password
+        @options[:password] = parsed_uri.password
+      end
+      URI.decode_www_form(parsed_uri.query).each do |k, v|
+        k = k.downcase.to_sym
+        v = v.to_f if k == :expires_in
+        @options[k] = v
+      end
+    end
+  end
+end

--- a/test/test_env_var.rb
+++ b/test/test_env_var.rb
@@ -1,0 +1,220 @@
+require 'helper'
+
+describe 'environment variables' do
+  before do
+    @old_memcache_url = ENV.delete 'MEMCACHE_URL'
+    @old_memcache_servers = ENV.delete 'MEMCACHE_SERVERS'
+    @old_memcache_username = ENV.delete 'MEMCACHE_USERNAME'
+    @old_memcache_password = ENV.delete 'MEMCACHE_PASSWORD'
+  end
+
+  after do
+    ENV['MEMCACHE_URL'] = @old_memcache_url
+    ENV['MEMCACHE_SERVERS'] = @old_memcache_servers
+    ENV['MEMCACHE_USERNAME'] = @old_memcache_username
+    ENV['MEMCACHE_PASSWORD'] = @old_memcache_password
+  end
+
+  context 'a single server' do
+    before do
+      ENV['MEMCACHE_URL'] = 'memcached://1.2.3.4:19124?namespace=mytest&expires_in=4'
+    end
+    should "use MEMCACHE_URL if no args are passed" do
+      dc = Dalli::Client.new
+      assert_equal 'mytest', dc.instance_variable_get(:@options)[:namespace]
+      assert_equal 4, dc.instance_variable_get(:@options)[:expires_in]
+      ring = dc.send(:ring)
+      assert_equal '1.2.3.4', ring.servers[0].hostname
+      assert_equal 19124, ring.servers[0].port
+      assert_equal 1, ring.servers.size
+      dc.close
+    end
+    should "ignore MEMCACHE_URL if args are passed" do
+      dc = Dalli::Client.new('9.9.9.9:4444')
+      assert_equal nil, dc.instance_variable_get(:@options)[:namespace]
+      assert_equal 0, dc.instance_variable_get(:@options)[:expires_in]
+      ring = dc.send(:ring)
+      assert_equal '9.9.9.9', ring.servers[0].hostname
+      assert_equal 4444, ring.servers[0].port
+      assert_equal 1, ring.servers.size
+      dc.close
+    end
+  end
+
+  context 'multiple servers in a pool' do
+    before do
+      ENV['MEMCACHE_URL'] = 'memcached://1.2.3.4,5.6.7.8,9.10.11.12:19124?namespace=mytest&expires_in=4'
+    end
+    should "use MEMCACHE_URL if no args are passed" do
+      dc = Dalli::Client.new
+      assert_equal 'mytest', dc.instance_variable_get(:@options)[:namespace]
+      assert_equal 4, dc.instance_variable_get(:@options)[:expires_in]
+      ring = dc.send(:ring)
+      assert_equal '1.2.3.4', ring.servers[0].hostname
+      assert_equal '5.6.7.8', ring.servers[1].hostname
+      assert_equal '9.10.11.12', ring.servers[2].hostname
+      assert_equal 3, ring.servers.size
+      dc.close
+    end
+  end
+
+  context 'a single server requiring authentication' do
+    before do
+      ENV['MEMCACHE_URL'] = 'memcached://testuser:testtest@1.2.3.4:19124?namespace=mytest&expires_in=4'
+    end
+    should "use MEMCACHE_URL if no args are passed" do
+      dc = Dalli::Client.new
+      assert_equal 'mytest', dc.instance_variable_get(:@options)[:namespace]
+      assert_equal 4, dc.instance_variable_get(:@options)[:expires_in]
+      ring = dc.send(:ring)
+      assert_equal '1.2.3.4', ring.servers.first.hostname
+      assert_equal 'testuser', ring.servers[0].send(:username)
+      assert_equal 'testtest', ring.servers[0].send(:password)
+      assert_equal 1, ring.servers.size
+      dc.close
+    end
+    should "ignore MEMCACHE_URL if args are passed" do
+      dc = Dalli::Client.new('9.9.9.9:4444')
+      assert_equal nil, dc.instance_variable_get(:@options)[:namespace]
+      assert_equal 0, dc.instance_variable_get(:@options)[:expires_in]
+      ring = dc.send(:ring)
+      assert_equal '9.9.9.9', ring.servers.first.hostname
+      assert_equal 4444, ring.servers.first.port
+      assert_equal nil, ring.servers[0].send(:username)
+      assert_equal nil, ring.servers[0].send(:password)
+      assert_equal 1, ring.servers.size
+      dc.close
+    end
+
+    # what follows are taken from test_sasl... not sure if they're 100% necessary
+
+    context 'without authentication credentials' do
+      should_eventually 'gracefully handle authentication failures' do
+        ENV['MEMCACHE_URL'] = 'memcached://localhost:19124'
+        memcached(19124, '-S') do |_|
+          dc = Dalli::Client.new
+          assert_raise Dalli::DalliError, /32/ do
+            dc.set('abc', 123)
+          end
+        end
+      end
+    end
+    should_eventually 'fail SASL authentication with wrong options' do
+      ENV['MEMCACHE_URL'] = 'memcached://foo:wrongpwd@localhost:19124'
+      memcached(19124, '-S') do |_|
+        dc = Dalli::Client.new
+        assert_raise Dalli::DalliError, /32/ do
+          dc.set('abc', 123)
+        end
+      end
+    end
+    context 'in an authenticated environment' do
+      should_eventually 'pass SASL authentication' do
+        ENV['MEMCACHE_URL'] = 'memcached://testuser:testtest@localhost:19124'
+        memcached(19124, '-S') do |_|
+          dc = Dalli::Client.new
+          # I get "Dalli::DalliError: Error authenticating: 32" in OSX
+          # but SASL works on Heroku servers. YMMV.
+          assert_equal true, dc.set('abc', 123)
+          assert_equal 123, dc.get('abc')
+          results = dc.stats
+          assert_equal 1, results.size
+          assert_equal 38, results.values.first.size
+        end
+      end
+    end
+  end
+
+  context 'a pool of servers requiring authentication' do
+    before do
+      ENV['MEMCACHE_URL'] = 'memcached://testuser:testtest@1.2.3.4,5.6.7.8,9.10.11.12:19124?namespace=mytest&expires_in=4'
+    end
+    should "use the same auth credentials everywhere" do
+      dc = Dalli::Client.new
+      assert_equal 'mytest', dc.instance_variable_get(:@options)[:namespace]
+      assert_equal 4, dc.instance_variable_get(:@options)[:expires_in]
+      ring = dc.send(:ring)
+      assert_equal '1.2.3.4', ring.servers[0].hostname
+      assert_equal '5.6.7.8', ring.servers[1].hostname
+      assert_equal '9.10.11.12', ring.servers[2].hostname
+      assert_equal 3, ring.servers.size
+      ring.servers.each do |server|
+        assert_equal 'testuser', server.send(:username)
+        assert_equal 'testtest', server.send(:password)
+      end
+      dc.close
+    end
+  end
+
+  describe "the interaction of MEMCACHE_URL and MEMCACHE_{SERVERS,USERNAME,PASSWORD}" do
+    context 'when MEMCACHE_URL is set but so is MEMCACHE_SERVERS' do
+      before do
+        ENV['MEMCACHE_URL'] = 'memcached://1.2.3.4:19124?namespace=mytest&expires_in=4'
+        ENV['MEMCACHE_SERVERS'] = '4.3.2.1'
+      end
+      should "ignore MEMCACHE_URL" do
+        dc = Dalli::Client.new
+        assert_equal nil, dc.instance_variable_get(:@options)[:namespace]
+        assert_equal 0, dc.instance_variable_get(:@options)[:expires_in]
+        ring = dc.send(:ring)
+        assert_equal '4.3.2.1', ring.servers[0].hostname
+        assert_equal 1, ring.servers.size
+      end
+    end
+
+    context 'when MEMCACHE_URL is set but so are MEMCACHE_{SERVERS,USERNAME,PASSWORD}' do
+      before do
+        ENV['MEMCACHE_URL'] = 'memcached://1.2.3.4:19124?namespace=mytest&expires_in=4'
+        ENV['MEMCACHE_SERVERS'] = '4.3.2.1'
+        ENV['MEMCACHE_USERNAME'] = 'foo'
+        ENV['MEMCACHE_PASSWORD'] = 'bar'
+      end
+      should "ignore MEMCACHE_URL" do
+        dc = Dalli::Client.new
+        assert_equal nil, dc.instance_variable_get(:@options)[:namespace]
+        assert_equal 0, dc.instance_variable_get(:@options)[:expires_in]
+        ring = dc.send(:ring)
+        assert_equal '4.3.2.1', ring.servers[0].hostname
+        assert_equal 'foo', ring.servers[0].send(:username)
+        assert_equal 'bar', ring.servers[0].send(:password)
+        assert_equal 1, ring.servers.size
+      end
+    end
+
+    # hmm
+    context 'when MEMCACHE_URL is set but so are MEMCACHE_{USERNAME,PASSWORD}' do
+      before do
+        ENV['MEMCACHE_USERNAME'] = 'foo'
+        ENV['MEMCACHE_PASSWORD'] = 'bar'
+      end
+      should "combine MEMCACHE_USERNAME and MEMCACHE_PASSWORD with MEMCACHE_USERNAME (!!)" do
+        ENV['MEMCACHE_URL'] = 'memcached://1.2.3.4:19124?namespace=mytest&expires_in=4'
+        dc = Dalli::Client.new
+        assert_equal 'mytest', dc.instance_variable_get(:@options)[:namespace]
+        assert_equal 4, dc.instance_variable_get(:@options)[:expires_in]
+        ring = dc.send(:ring)
+        assert_equal '1.2.3.4', ring.servers.first.hostname
+        assert_equal 'foo', ring.servers[0].send(:username)
+        assert_equal 'bar', ring.servers[0].send(:password)
+        assert_equal 1, ring.servers.size
+        dc.close
+      end
+      should "combine properly when there's a pool" do
+        ENV['MEMCACHE_URL'] = 'memcached://1.2.3.4,5.6.7.8,9.10.11.12:19124?namespace=mytest&expires_in=4'
+        dc = Dalli::Client.new
+        assert_equal 'mytest', dc.instance_variable_get(:@options)[:namespace]
+        assert_equal 4, dc.instance_variable_get(:@options)[:expires_in]
+        ring = dc.send(:ring)
+        assert_equal '1.2.3.4', ring.servers[0].hostname
+        assert_equal '5.6.7.8', ring.servers[1].hostname
+        assert_equal '9.10.11.12', ring.servers[2].hostname
+        assert_equal 3, ring.servers.size
+        ring.servers.each do |server|
+          assert_equal 'foo', server.send(:username)
+          assert_equal 'bar', server.send(:password)
+        end
+        dc.close
+      end
+    end
+  end
+end

--- a/test/test_url_parser.rb
+++ b/test/test_url_parser.rb
@@ -1,0 +1,15 @@
+# encoding: utf-8
+require 'helper'
+
+describe 'URL parser' do
+  context "what may appear in ENV['MEMCACHE_URL']" do
+    should "pull out various parts" do
+      parser = Dalli::UrlParser.new 'memcached://testuser:testtest@1.2.3.4,5.6.7.8,9.10.11.12:19124?namespace=mytest&expires_in=4'
+      assert_equal 'testuser', parser.options[:username]
+      assert_equal 'testtest', parser.options[:password]
+      assert_equal ['1.2.3.4:19124','5.6.7.8:19124','9.10.11.12:19124'], parser.servers
+      assert_equal 'mytest', parser.options[:namespace]
+      assert_equal 4, parser.options[:expires_in]
+    end
+  end
+end


### PR DESCRIPTION
hi Mike,

What do you think of accepting all of the configuration params in a single env var?

[Redis has started doing it](https://github.com/redis/redis-rb/commit/06b2a58b2ea33112728eae901ed242e7615ebcd7), [Rails has done it for a while](https://github.com/rails/rails/commit/4605b5639db4fa15f8b6627245c74b899241f38a), and I just submitted [a similar patch to mongo-ruby-driver](https://github.com/mongodb/mongo-ruby-driver/pull/99).

Thanks!
Seamus

PS. Added lots of tests, existing tests pass
PPS. I made sure it doesn't do anything if the traditional MEMCACHE_SERVERS env var is set.
