### PR TITLE
Swap priority of servers argument

### DIFF
--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -25,7 +25,7 @@ module Dalli
     #   sending them to memcached.
     #
     def initialize(servers=nil, options={})
-      @servers = env_servers || servers || '127.0.0.1:11211'
+      @servers = servers || env_servers || '127.0.0.1:11211'
       @options = normalize_options(options)
       @ring = nil
     end


### PR DESCRIPTION
Currently MEMCACHE_SERVERS environment variable is used over a passed in, explicit servers argument to the client. Because this disagrees with the priority for username and password, this causes hard to debug problems when environment variables are set _and_ explicit options are passed in (but the two are not the same). Specifically, Dalii will choose the server from the environment but the username and password from the options.

The change is a simple one liner swapping the environment variables and option when setting the server instance variable. If there is a more appropriate solution I'd be happy to revise.

Thanks!
