### PR TITLE
Add support for URL connection strings.

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,11 @@
 Dalli Changelog
 =====================
 
+unreleased
+=======
+
+- Accept connection string in the form of a URL (e.g., memcached://user:pass@hostname:port) [glenngillen]
+
 2.1.0
 =======
 

--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -232,7 +232,14 @@ module Dalli
     def ring
       @ring ||= Dalli::Ring.new(
         Array(@servers).map do |s|
-          Dalli::Server.new(s, @options)
+         server_options = {}
+          if s =~ %r{\Amemcached://}
+            uri = URI.parse(s)
+            server_options[:username] = uri.user
+            server_options[:password] = uri.password
+            s = "#{uri.host}:#{uri.port}"
+          end
+          Dalli::Server.new(s, @options.merge(server_options))
         end, @options
       )
     end


### PR DESCRIPTION
Came across [a previous pull request](https://github.com/mperham/dalli/pull/219) for URL connections, but I didn't like the implementation or the justification. I've got 2 different memcache setups hosted by 2 different 3rd party providers, and I want to failover between them. But they have different usernames/password.

This seemed the cleanest way to support that, and had the added benefit of collapsing my environment variables from 6 to 2.

I intend to use it like this

``` ruby
dc = Dalli::Client.new(["memcached://user:pass@host1:19124", "memcached://user2:pass2@host2:19124"])
```

If I have a pool of servers I can just continue listing each server as a separate URL within the ring, or combine it with the previous syntax:

``` ruby
dc = Dalli::Client.new(["memcached://user:pass@host1:19124", "host2:19124", "host3:19124", "host4:19124], :username => "genericuser", :password => "secrets")
```

The user/pass in the options hash will be used as a default unless overridden.

Also: I've added a test that checks it does what I want via stubbing/expects :cry: All the other SASL tests are `should_eventually` so hoping my expectations are reasonable assuming the contract in the other tests is eventually adhered to. Let me know if you have any issues or better suggestions.
