### PR TITLE
Added option to Dalli::Client to write (perform SET) on all available servers for redundancy

### DIFF
--- a/Performance.md
+++ b/Performance.md
@@ -40,3 +40,12 @@ Testing 2.0.0 with ruby 1.9.3p125 (2012-02-16 revision 34643) [x86_64-darwin11.3
     mixed:ruby:dalli                  1.660000   0.640000   2.300000 (  3.320743)
     mixedq:ruby:dalli                 1.630000   0.510000   2.140000 (  2.629734)
     incr:ruby:dalli                   0.270000   0.100000   0.370000 (  0.547618)
+
+
+dalli with :redundant => true, 4 servers for SET requests
+Testing with Rails 3.2.7
+Using kgio socket IO
+Testing 2.1.0 with ruby 1.9.3p258 (2012-07-29 revision 36564) [x86_64-darwin11.4.0]
+                                         user     system      total        real
+redundant:set:plain:dalli            1.970000   1.080000   3.050000 (  4.050488)
+redundant:set:ruby:dalli             2.260000   1.110000   3.370000 (  4.503101)

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ Dalli::Client accepts the following options. All times are in seconds.
 
 **failover**: Boolean, if true Dalli will failover to another server if the main server for a key is down.
 
+**redundant**: Boolean, if true Dalli will perform SET command on all available servers. Default is false.
+
 **compress**: Boolean, if true Dalli will gzip-compress values larger than 1K.
 
 **socket_timeout**: Timeout for all socket operations (connect, read, write). Default is 0.5.

--- a/lib/dalli/ring.rb
+++ b/lib/dalli/ring.rb
@@ -25,6 +25,7 @@ module Dalli
 
       threadsafe! unless options[:threadsafe] == false
       @failover = options[:failover] != false
+      @redundant = options[:redundant] == true
     end
 
     def server_for_key(key)
@@ -51,6 +52,16 @@ module Dalli
         return yield
       ensure
         @servers.each { |s| s.unlock! }
+      end
+    end
+
+    def redundant?
+      @redundant
+    end
+
+    def request(op, *args)
+      @servers.each do |server|
+        server.request(op, *args)
       end
     end
 


### PR DESCRIPTION
Hello Mike,
hope you're doing good.
In one of our projects we encounter a need to perform SET request on all available servers in the Ring for redundancy. So, when one node goes away, we have a cache accessible on the other node.

Please consider adding this option to Dalli, maybe it will be useful for someone else as well.
Also, please let me know if you want me to change something in a better way.

Thanks,
Alex
