### PR TITLE
dalli_store.rb: Make it default to whatever Dalli::Client said. Detail:

### DIFF
--- a/lib/active_support/cache/dalli_store.rb
+++ b/lib/active_support/cache/dalli_store.rb
@@ -39,8 +39,12 @@ module ActiveSupport
         @options = options.dup
         @options[:compress] ||= @options[:compression]
         @raise_errors = !!@options[:raise_errors]
-        addresses << 'localhost:11211' if addresses.empty?
-        @data = Dalli::Client.new(addresses, @options)
+        servers = if addresses.empty?
+                    nil # use the default from Dalli::Client
+                  else
+                    addresses
+                  end
+        @data = Dalli::Client.new(servers, @options)
       end
 
       def fetch(name, options=nil)


### PR DESCRIPTION
This commit: a5d3c692bd44077f0177220ccc799244dadc2fb2 broke our setup,
because we're relying on ENV, while ActiveSupport::Cache::DalliStore
is default to connect to localhost:11211 which would suppress the
default in Dalli::Client, making us connect to localhost:11211 but not
the one setup in ENV.

This would force us to setup servers manually for DalliStore instead of
letting it fall back to the one in ENV.

This fix is simply make DalliStore use whatever the default in
Dalli::Client. It would still eventually fall back to 127.0.0.1:11211
if you don't pass anything to DalliStore nor setup ENV.

Thanks!
