### PR TITLE
Add logger accessors to DalliStore instance

### DIFF
--- a/lib/active_support/cache/dalli_store.rb
+++ b/lib/active_support/cache/dalli_store.rb
@@ -186,6 +186,14 @@ module ActiveSupport
         @data.reset
       end
 
+      def logger
+        Dalli.logger
+      end
+
+      def logger=(new_logger)
+        Dalli.logger = new_logger
+      end
+
       protected
 
       # Read an entry from the cache.
@@ -262,10 +270,6 @@ module ActiveSupport
       def log(operation, key, options=nil)
         return unless logger && logger.debug? && !silence?
         logger.debug("Cache #{operation}: #{key}#{options.blank? ? "" : " (#{options.inspect})"}")
-      end
-
-      def logger
-        Dalli.logger
       end
 
     end


### PR DESCRIPTION
As described in #268:

ActiveSupport::Cache::Store uses cattr_accessor to set logger, which
creates a public getter/setter for the logger at both the class and
instance level. This patch restores the #logger and #logger= methods
on the DalliStore instance.

Happy to write a test for this if you feel it's necessary.
