### PR TITLE
Replace logging on delete with instrumentation

### DIFF
--- a/lib/active_support/cache/dalli_store.rb
+++ b/lib/active_support/cache/dalli_store.rb
@@ -106,8 +106,9 @@ module ActiveSupport
         options ||= {}
         name = expanded_key name
 
-        log(:delete, name, options)
-        delete_entry(name, options)
+        instrument(:delete, name, options) do |payload|
+          delete_entry(name, options)
+        end
       end
 
       # Reads multiple keys from the cache using a single call to the


### PR DESCRIPTION
Noticed there was no instrumentation on delete, which we've found useful for verifying cache sweeping behavior.
