### PR TITLE
Allow different compressors per client

### DIFF
--- a/History.md
+++ b/History.md
@@ -9,6 +9,7 @@ Dalli Changelog
 - Removed lots of old session_store test code, tests now all run without a default memcached server [#275]
 - Changed Dalli ActiveSupport adapter to always attempt instrumentation [brianmario, #284]
 - Change write operations (add/set/replace) to return false when value is too large to store [brianmario, #283]
+- Allowing different compressors per client [naseem]
 
 2.4.0
 =======

--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ Default is Marshal.
 
 **keepalive**: Boolean, if true Dalli will enable keep-alives on the socket so inactivity
 
+**compressor**: The compressor to use for objects being stored.
+Default is zlib.
+
 Features and Changes
 ------------------------
 

--- a/lib/dalli.rb
+++ b/lib/dalli.rb
@@ -1,10 +1,10 @@
+require 'dalli/compressor'
 require 'dalli/client'
 require 'dalli/ring'
 require 'dalli/server'
 require 'dalli/socket'
 require 'dalli/version'
 require 'dalli/options'
-require 'dalli/compressor'
 require 'dalli/railtie' if defined?(::Rails::Railtie)
 
 module Dalli
@@ -39,16 +39,6 @@ module Dalli
     @logger = logger
   end
 
-  # Default serialization to Dalli::Compressor
-  @compressor = Compressor
-
-  def self.compressor
-    @compressor
-  end
-
-  def self.compressor=(compressor)
-    @compressor = compressor
-  end
 end
 
 if defined?(RAILS_VERSION) && RAILS_VERSION < '3'

--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -24,6 +24,7 @@ module Dalli
     # - :compress - defaults to false, if true Dalli will compress values larger than 1024 bytes before
     # - :serializer - defaults to Marshal
     #   sending them to memcached.
+    # - :compressor - defaults to zlib
     #
     def initialize(servers=nil, options={})
       @servers = servers || env_servers || '127.0.0.1:11211'

--- a/test/test_compressor.rb
+++ b/test/test_compressor.rb
@@ -16,21 +16,21 @@ end
 describe 'Compressor' do
 
   should 'default to Dalli::Compressor' do
-    assert_equal Dalli::Compressor, Dalli.compressor
+    memcache = Dalli::Client.new('127.0.0.1:11211')
+    memcache.set 1,2
+    assert_equal Dalli::Compressor, memcache.instance_variable_get('@ring').servers.first.compressor
   end
 
   should 'support a custom compressor' do
-    original_compressor = Dalli.compressor
+    memcache = Dalli::Client.new('127.0.0.1:11211', :compressor => NoopCompressor)
+    memcache.set 1,2
     begin
-      Dalli.compressor = NoopCompressor
-      assert_equal NoopCompressor, Dalli.compressor
+      assert_equal NoopCompressor, memcache.instance_variable_get('@ring').servers.first.compressor
 
       memcached(19127) do |dc|
         assert dc.set("string-test", "a test string")
         assert_equal("a test string", dc.get("string-test"))
       end
-    ensure
-      Dalli.compressor = original_compressor
     end
   end
 end


### PR DESCRIPTION
This change moves the configuration for compressor from being a class-level accessor to being client-specific. So you can set up different clients to use different compressors using the :compressor option on client creation.

The default is still zlib.

Per Brian's request in: https://github.com/mperham/dalli/pull/287
