### PR TITLE
Build under more ruby envs on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ rvm:
   - jruby
 matrix:
   allow_failures:
+    - rvm: rbx
     - rvm: rbx-18mode
     - rvm: rbx-19mode
 branches:


### PR DESCRIPTION
This adds ree, 1.9.2, rbx, ruby-head, rbx-18mode, rbx-19mode but allows rbx-18mode and rbx-19mode to fail (for now)
