### PR TITLE
Identify the MIT license in the gemspec

### DIFF
--- a/dalli.gemspec
+++ b/dalli.gemspec
@@ -3,6 +3,7 @@ require './lib/dalli/version'
 Gem::Specification.new do |s|
   s.name = %q{dalli}
   s.version = Dalli::VERSION
+  s.license = "MIT"
 
   s.authors = ["Mike Perham"]
   s.description = %q{High performance memcached client for Ruby}


### PR DESCRIPTION
Trivial PR: Identify the license type in the gemspec.  This allows automated services to more easily determine the OSS (or otherwise) license used by the library... it is also indicated on the RubyGems.org gem info page.
