### PR TITLE
Fix: can't modify frozen String errors in ActiveSupport::Cache::DalliStore

### DIFF
--- a/History.md
+++ b/History.md
@@ -5,6 +5,7 @@ HEAD
 =======
 
 - Add lambda support for cache namespaces [joshwlewis, #311]
+- Fix 'can't modify frozen String' errors in `ActiveSupport::Cache::DalliStore` [dblock]
 
 2.6.0
 =======

--- a/lib/active_support/cache/dalli_store.rb
+++ b/lib/active_support/cache/dalli_store.rb
@@ -267,7 +267,10 @@ module ActiveSupport
         end
 
         key = key.to_param
-        key.force_encoding('binary') if key.respond_to? :force_encoding
+        if key.respond_to? :force_encoding
+          key = key.dup
+          key.force_encoding('binary')
+        end
         key
       end
 

--- a/test/test_active_support.rb
+++ b/test/test_active_support.rb
@@ -328,6 +328,30 @@ describe 'ActiveSupport' do
     end
   end
 
+  should 'allow keys to be frozen' do
+    with_activesupport do
+      memcached do
+        connect
+        key = "foo"
+        key.freeze
+        assert_equal true, @dalli.write(key, "value")
+      end
+    end
+  end
+
+  should 'allow keys from a hash' do
+    with_activesupport do
+      memcached do
+        connect
+        map = { "one" => "one", "two" => "two" }
+        map.each_pair do |k, v|
+          assert_equal true, @dalli.write(k, v)
+        end
+        assert_equal map, @dalli.read_multi(map.keys)
+      end
+    end
+  end
+
   def connect
     @dalli = ActiveSupport::Cache.lookup_store(:dalli_store, 'localhost:19122', :expires_in => 10.seconds, :namespace => lambda{33.to_s(36)})
     @dalli.clear


### PR DESCRIPTION
If you try to use keys from, say, a Hash.keys, you will get this:

```
RuntimeError: can't modify frozen String
    /home/dblock/source/dalli/dblock/lib/active_support/cache/dalli_store.rb:272:in `force_encoding'
    /home/dblock/source/dalli/dblock/lib/active_support/cache/dalli_store.rb:272:in `expanded_key'
    /home/dblock/source/dalli/dblock/lib/active_support/cache/dalli_store.rb:99:in `write'
    /home/dblock/source/dalli/dblock/test/test_active_support.rb:337:in `block (4 levels) in <top (required)>'
    /home/dblock/source/dalli/dblock/test/memcached_mock.rb:87:in `memcached'
    /home/dblock/source/dalli/dblock/test/test_active_support.rb:333:in `block (3 levels) in <top (required)>'
    /home/dblock/source/dalli/dblock/test/helper.rb:33:in `with_activesupport'
    /home/dblock/source/dalli/dblock/test/test_active_support.rb:332:in `block (2 levels) in <top (required)>'
```

Generally, modifying data passed in in-place is a bad idea, because the caller is getting back a binary encoded string, not a side effect you really expect.
