### PR TITLE
Accept a comma separated string for servers

### DIFF
--- a/test/test_dalli.rb
+++ b/test/test_dalli.rb
@@ -67,6 +67,24 @@ describe 'Dalli' do
     assert_equal s2, s3
   end
 
+  should "accept comma separated string" do
+    dc = Dalli::Client.new("server1.example.com:11211,server2.example.com:11211")
+    ring = dc.send(:ring)
+    assert_equal 2, ring.servers.size
+    s1,s2 = ring.servers.map(&:hostname)
+    assert_equal "server1.example.com", s1
+    assert_equal "server2.example.com", s2
+  end
+
+  should "accept array of servers" do
+    dc = Dalli::Client.new(["server1.example.com:11211","server2.example.com:11211"])
+    ring = dc.send(:ring)
+    assert_equal 2, ring.servers.size
+    s1,s2 = ring.servers.map(&:hostname)
+    assert_equal "server1.example.com", s1
+    assert_equal "server2.example.com", s2
+  end
+
   context 'using a live server' do
 
     should "support get/set" do


### PR DESCRIPTION
In the client, accept as and argument either a comma separated string of
servers, or an array.

When the environment variable is set to a comma separated string, this already works fine, but if the programmer passes in the same string (e.g. with `ENV["MEMCACHE_SERVERS"]` explicitly), it's not parsed. This changes/fixes that by parsing immediately in the constructor instead of waiting until `ring` is called.
