### PR TITLE
TTL defaults to 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Configuration
 ------------------------
 Dalli::Client accepts the following options. All times are in seconds.
 
-**expires_in**: Global default for key TTL.  No default.
+**expires_in**: Global default for key TTL.  Default is 0, which means no expiry.
 
 **failover**: Boolean, if true Dalli will failover to another server if the main server for a key is down.
 


### PR DESCRIPTION
Hi Mike,

thanks for making Dalli, it's a great gem!

I found that Dalli#set uses a default TTL of 0 (= no expiry), but the README says there is no default. If this is the intended behaviour, can you pull my commit? I updated the README accordingly. 

Cheers,
Stefan
