### PR TITLE
Make reset_stats accessible from DalliStore

### DIFF
--- a/lib/active_support/cache/dalli_store.rb
+++ b/lib/active_support/cache/dalli_store.rb
@@ -203,6 +203,11 @@ module ActiveSupport
         @data.stats
       end
 
+      # Reset the statistics from the memcached servers.
+      def reset_stats
+        @data.reset_stats
+      end
+
       def reset
         @data.reset
       end

--- a/test/test_active_support.rb
+++ b/test/test_active_support.rb
@@ -263,13 +263,25 @@ describe 'ActiveSupport' do
       end
     end
 
-    should 'support other esoteric commands' do
+    should 'support stats command' do
       with_activesupport do
         memcached do
           connect
           ds = @dalli.stats
           assert_equal 1, ds.keys.size
           assert ds[ds.keys.first].keys.size > 0
+
+          @dalli.reset
+        end
+      end
+    end
+
+    should 'support resetting stats' do
+      with_activesupport do
+        memcached do
+          connect
+          Dalli::Client.any_instance.expects(:reset_stats)
+          @dalli.reset_stats
 
           @dalli.reset
         end


### PR DESCRIPTION
This make calling Dalli::Client#reset_stats feasible without requiring the user to monkey patch; useful in a Rails 3.x application where the client is already initialized, and only the store is easily accessible via Rail.cache.

Example usage: https://gist.github.com/eprothro/5065310
