### PR TITLE
Protect against objects with custom equality checking

### DIFF
--- a/History.md
+++ b/History.md
@@ -5,6 +5,7 @@ HEAD
 =======
 - Support specific stats by passing `:items` or `:slabs` to `stats` method [bukhamseen]
 - Fix 'can't modify frozen String' errors in `ActiveSupport::Cache::DalliStore` [dblock]
+- Protect against objects with custom equality checking [theron17]
 
 2.6.2
 =======

--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -61,7 +61,7 @@ module Dalli
 
     def get(key, options=nil)
       resp = perform(:get, key)
-      resp.nil? || resp == 'Not found' ? nil : resp
+      resp.nil? || 'Not found' == resp ? nil : resp
     end
 
     ##


### PR DESCRIPTION
Relates to #343. The money gem isn't being a great citizen in this very specific edge case. Dalli can guard against this behavior by using the String equality method instead of any custom equality method from any unmarshalled response objects.
