### PR TITLE
Better AS instrumentation for read via fetch

### DIFF
--- a/lib/active_support/cache/dalli_store.rb
+++ b/lib/active_support/cache/dalli_store.rb
@@ -63,8 +63,12 @@ module ActiveSupport
         if block_given?
           unless options[:force]
             entry = instrument(:read, name, options) do |payload|
-              payload[:super_operation] = :fetch if payload
-              read_entry(name, options)
+              read_entry(name, options).tap do |entry|
+                if payload
+                  payload[:super_operation] = :fetch
+                  payload[:hit] = !!entry
+                end
+              end
             end
           end
 


### PR DESCRIPTION
Hey Mike,

When the cache_read.active_support notification is fired from a fetch, there is no way to tell if it was a hit or miss.  This commit fixes that:

``` ruby
ActiveSupport::Notifications.subscribe("cache_read.active_support") do |*args|
  event = ActiveSupport::Notifications::Event.new(*args)
  puts event.inspect
end

d.fetch("chris"){ 2 }
#<ActiveSupport::Notifications::Event:0x007fe3429e9a08 @name="cache_read.active_support", @payload={:key=>"chris", :super_operation=>:fetch, :hit=>false}, @time=2013-03-28 15:55:37 -0500, @transaction_id="a80629976560437da29d", @end=2013-03-28 15:55:37 -0500, @duration=0.307>
=> 2

d.fetch("chris"){ 2 }
#<ActiveSupport::Notifications::Event:0x007fe3408ea8c0 @name="cache_read.active_support", @payload={:key=>"chris", :super_operation=>:fetch, :hit=>true}, @time=2013-03-28 15:55:42 -0500, @transaction_id="a80629976560437da29d", @end=2013-03-28 15:55:42 -0500, @duration=0.301>
=> 2
```

Notice the `:hit` key in `@payload` changes.

Hope you're doing well,
-- C
