### PR TITLE
update Client rdoc for compress option

### DIFF
--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -21,9 +21,8 @@ module Dalli
     # - :failover - if a server is down, look for and store values on another server in the ring.  Default: true.
     # - :threadsafe - ensure that only one thread is actively using a socket at a time. Default: true.
     # - :expires_in - default TTL in seconds if you do not pass TTL as a parameter to an individual operation, defaults to 0 or forever
-    # - :compress - defaults to false, if true Dalli will compress values larger than 1024 bytes before
+    # - :compress - defaults to false, if true Dalli will compress values larger than 1024 bytes before sending them to memcached.
     # - :serializer - defaults to Marshal
-    #   sending them to memcached.
     # - :compressor - defaults to zlib
     #
     def initialize(servers=nil, options={})


### PR DESCRIPTION
While looking at the documentation for `Client` it appears that the rdoc for compress was broken up. It doesn't appear that a max chars/line limit is strictly enforced so I put it all one line vs. adhering to 80 chars.
