### PR TITLE
Raise an ArgumentError if setting an :expires_in longer than memcache can handle

### DIFF
--- a/test/test_active_support.rb
+++ b/test/test_active_support.rb
@@ -328,6 +328,14 @@ describe 'ActiveSupport' do
     end
   end
 
+  should 'raise an error if expires_in is too far in the future' do
+    with_activesupport do
+      assert_raises(ArgumentError, :message => "expires_in cannot be larger than 30 days") do
+        ActiveSupport::Cache::DalliStore.new('localhost:19122', :expires_in => 30.days + 1)
+      end
+    end
+  end
+
   def connect
     @dalli = ActiveSupport::Cache.lookup_store(:dalli_store, 'localhost:19122', :expires_in => 10.seconds, :namespace => lambda{33.to_s(36)})
     @dalli.clear


### PR DESCRIPTION
Our team got bit by setting an :expires_in of longer than 30 days and it looks like we're not alone, see #55 and #251.

This pull raises an ArgumentError if the :expires_in value is larger than 30 days.
