### PR TITLE
Add exclude option in travis-ci against rails4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rvm:
   - 2.0.0
   - rbx
   - ree
-  - ruby-head
+  #- ruby-head
   - rbx-18mode
   - rbx-19mode
   - jruby


### PR DESCRIPTION
Rails4 requires Ruby >= 1.9.3
