### PR TITLE
Alter behavior of read_multi to match ActiveSupport::Cache::Store

### DIFF
--- a/lib/active_support/cache/dalli_store.rb
+++ b/lib/active_support/cache/dalli_store.rb
@@ -128,7 +128,6 @@ module ActiveSupport
       # servers for all keys. Keys must be Strings.
       def read_multi(*names)
         names.extract_options!
-        names = names.flatten
         mapping = names.inject({}) { |memo, name| memo[expanded_key(name)] = name; memo }
         instrument(:read_multi, names) do
           results = {}

--- a/test/test_active_support.rb
+++ b/test/test_active_support.rb
@@ -98,7 +98,9 @@ describe 'ActiveSupport' do
           assert_equal({}, @dalli.read_multi([x, y]))
           @dalli.write(x, '123')
           @dalli.write(y, 123)
-          assert_equal({ x => '123', y => 123 }, @dalli.read_multi([x, y]))
+          assert_equal({}, @dalli.read_multi([x, y]))
+          @dalli.write([x, y], '123')
+          assert_equal({ [x, y] => '123' }, @dalli.read_multi([x, y]))
         end
       end
     end
@@ -347,7 +349,7 @@ describe 'ActiveSupport' do
         map.each_pair do |k, v|
           assert_equal true, @dalli.write(k, v)
         end
-        assert_equal map, @dalli.read_multi(map.keys)
+        assert_equal map, @dalli.read_multi(*(map.keys))
       end
     end
   end


### PR DESCRIPTION
### Summary

In the base implementation of `ActiveSupport::Cache::Store` (and all other implementing stores), an array of strings passed as argument to `read_multi` is treated as a single key. In `DalliStore`, it is treated as several keys. This alters the spec and implementation of `DalliStore#read_multi` to match `ActiveSupport::Cache::Store`.
### Motivating Example

``` ruby
file_store = ActiveSupport::Cache::FileStore.new("demo")
file_store.write("foo", 1)
file_store.write("bar", 2)
file_store.write(["foo", "bar"], 3)
file_store.read_multi(["foo", "bar"])
# => {["foo", "bar"]=>3}

dalli_store = ActiveSupport::Cache::DalliStore.new
dalli_store.write("foo", 1)
dalli_store.write("bar", 2)
dalli_store.write(["foo", "bar"], 3)
dalli_store.read_multi(["foo", "bar"])
# => {"foo"=>1, "bar"=>2}

```
