### PR TITLE
ADD - or `write(unless_exist:true)` -  is broken due to LocalStore

### DIFF
--- a/History.md
+++ b/History.md
@@ -4,6 +4,7 @@ Dalli Changelog
 HEAD
 =======
 
+- Fix ADD command, aka `write(unless_exist: true)` (pitr, #365)
 - Upgrade test suite from mini_shoulda to minitest.
 - Even more performance improvements for get\_multi (xaop, #331)
 

--- a/lib/active_support/cache/dalli_store.rb
+++ b/lib/active_support/cache/dalli_store.rb
@@ -201,6 +201,10 @@ module ActiveSupport
         nil
       end
 
+      # Clear any local cache
+      def cleanup(options=nil)
+      end
+
       # Get the statistics from the memcached servers.
       def stats
         @data.stats
@@ -233,6 +237,8 @@ module ActiveSupport
 
       # Write an entry to the cache.
       def write_entry(key, value, options) # :nodoc:
+        # cleanup LocalCache
+        cleanup if options[:unless_exist]
         method = options[:unless_exist] ? :add : :set
         expires_in = options[:expires_in]
         @data.send(method, key, value, expires_in, options)

--- a/test/test_active_support.rb
+++ b/test/test_active_support.rb
@@ -208,6 +208,30 @@ describe 'ActiveSupport' do
       end
     end
 
+    it 'support unless_exist with LocalCache' do
+      with_activesupport do
+        memcached do
+          connect
+          y = rand_key.to_s
+          @dalli.with_local_cache do
+            Dalli::Client.any_instance.expects(:add).with(y, 123, nil, {:unless_exist => true}).once.returns(true)
+            dres = @dalli.write(y, 123, :unless_exist => true)
+            assert_equal true, dres
+
+            Dalli::Client.any_instance.expects(:add).with(y, 321, nil, {:unless_exist => true}).once.returns(false)
+
+            dres = @dalli.write(y, 321, :unless_exist => true)
+            assert_equal false, dres
+
+            Dalli::Client.any_instance.expects(:get).with(y, {}).once.returns(123)
+
+            dres = @dalli.read(y)
+            assert_equal 123, dres
+          end
+        end
+      end
+    end
+
     it 'support increment/decrement commands' do
       with_activesupport do
         memcached do


### PR DESCRIPTION
adding a breaking spec. The ideal flow is:

``` ruby
@dalli = ActiveSupport::Cache.lookup_store(:dalli_store, 'localhost:11211')
@dalli.with_local_cache do
  @dalli.write('key', 123, unless_exist: true) # => true
  @dalli.write('key', 321, unless_exist: true) # => false
  @dalli.read('key') # => 123
end
```
