### PR TITLE
Include reason for failure in log

### DIFF
--- a/lib/dalli/server.rb
+++ b/lib/dalli/server.rb
@@ -202,7 +202,7 @@ module Dalli
       failure!(RuntimeError.new('Cannot share client between multiple processes')) if @pid && @pid != Process.pid
     end
 
-    def failure!(exception = nil)
+    def failure!(exception)
       message = "#{hostname}:#{port} failed (count: #{@fail_count}) #{exception.class}: #{exception.message}"
       Dalli.logger.info { message }
 


### PR DESCRIPTION
We encountered an issue where we saw the failure message (`memcached:11211 failed (count: 0)`) appearing in our Resque logs. The reason turned out to be that we were sharing a client instance between parent process and subprocess without closing the connection before forking. To help diagnose the issue, I added additional logging to the `failure!` method. I thought this could be a useful addition to the library. Let me know what you think.
