### PR TITLE
Implement fetch_multi for parity with current Rails

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,11 @@
 Dalli Changelog
 =====================
 
+Unreleased
+==========
+
+- Implement `fetch_multi` for batched read/write [sorentwo, #380]
+
 2.6.4
 =======
 

--- a/test/test_active_support.rb
+++ b/test/test_active_support.rb
@@ -147,6 +147,26 @@ describe 'ActiveSupport' do
       end
     end
 
+    it 'supports fetch_multi' do
+      with_activesupport do
+        memcached do
+          connect
+
+          x = rand_key.to_s
+          y = rand_key
+          hash = { x => 'ABC', y => 'DEF' }
+
+          @dalli.write(y, '123')
+
+          results = @dalli.fetch_multi(x, y) { |key| hash[key] }
+
+          assert_equal({ x => 'ABC', y => '123' }, results)
+          assert_equal('ABC', @dalli.read(x))
+          assert_equal('123', @dalli.read(y))
+        end
+      end
+    end
+
     it 'support read, write and delete' do
       with_activesupport do
         memcached do


### PR DESCRIPTION
As of Rails 4.1.X the base ActiveSupport::Cache implementation has a `fetch_mutli` method. This simply ports that method over into the DalliStore.

There is room for improvement in writing out the keys, possibly by pipelining them within a multi block.
