### PR TITLE
Added LZ4Compressor.

### DIFF
--- a/Performance.md
+++ b/Performance.md
@@ -40,3 +40,42 @@ Testing 2.0.0 with ruby 1.9.3p125 (2012-02-16 revision 34643) [x86_64-darwin11.3
     mixed:ruby:dalli                  1.660000   0.640000   2.300000 (  3.320743)
     mixedq:ruby:dalli                 1.630000   0.510000   2.140000 (  2.629734)
     incr:ruby:dalli                   0.270000   0.100000   0.370000 (  0.547618)
+
+
+Zlib versus LZ4
+---------------
+
+Testing with ruby-1.9.3-p327 with the falcon-gc patch 
+homepage.html is the landing page for [betterific.com](http://betterific.com)
+
+    html = File.open('/home/bradcater/Desktop/homepage.html', 'rb').read
+    puts "html size: #{html.size}"
+    require 'benchmark'
+    require 'lz4-ruby'
+    require 'zlib'
+    zlib_compressed_html = Zlib::Deflate.deflate(html)
+    lz4_compressed_html = LZ4::compress(html)
+    lz4_hccompressed_html = LZ4::compressHC(html)
+    puts "zlib_compressed_html size: #{zlib_compressed_html.size}"
+    puts "lz4_compressed_html size: #{lz4_compressed_html.size}"
+    puts "lz4_hccompressed_html size: #{lz4_hccompressed_html.size}"
+    TRIALS = 1_000
+    Benchmark.benchmark do |bm|
+      bm.report('zlib compression'){TRIALS.times{Zlib::Deflate.deflate(html)}}
+      bm.report('lz4 compression'){TRIALS.times{LZ4::compress(html)}}
+      bm.report('lz4 hccompression'){TRIALS.times{LZ4::compressHC(html)}}
+      bm.report('zlib decompression'){TRIALS.times{Zlib::Inflate.inflate(zlib_compressed_html)}}
+      bm.report('lz4 decompression'){TRIALS.times{LZ4::uncompress(lz4_compressed_html)}}
+      bm.report('lz4 hcdecompression'){TRIALS.times{LZ4::uncompress(lz4_hccompressed_html)}}
+    end
+
+    html size:                   25724
+    zlib_compressed_html size:   7535
+    lz4_compressed_html size:    10823
+    lz4_hccompressed_html size:  9929
+    zlib compression     0.930000   0.000000   0.930000 (  0.934865)
+    lz4 compression      0.080000   0.000000   0.080000 (  0.080149)
+    lz4 hccompression    0.410000   0.000000   0.410000 (  0.412003)
+    zlib decompression   0.240000   0.000000   0.240000 (  0.238001)
+    lz4 decompression    0.040000   0.000000   0.040000 (  0.036594)
+    lz4 hcdecompression  0.040000   0.000000   0.040000 (  0.042084)

--- a/lib/dalli/compressor.rb
+++ b/lib/dalli/compressor.rb
@@ -1,6 +1,12 @@
 require 'zlib'
 require 'stringio'
 
+begin
+  require 'lz4-ruby'
+rescue LoadError
+  # This space intentionally left blank.
+end
+
 module Dalli
   class Compressor
     def self.compress(data)
@@ -26,4 +32,19 @@ module Dalli
       Zlib::GzipReader.new(io).read
     end
   end
+
+  class LZ4Compressor
+    def self.compress(data)
+      LZ4::compress(data)
+    end
+    def self.decompress(data)
+      LZ4::uncompress(data)
+    end
+  end
+  class LZ4HCCompressor < LZ4Compressor
+    def self.compress(data)
+      LZ4::compressHC(data)
+    end
+  end
+  
 end

--- a/test/test_compressor.rb
+++ b/test/test_compressor.rb
@@ -51,3 +51,16 @@ describe 'GzipCompressor' do
   end
 
 end
+
+describe 'LZ4Compressor' do
+
+  it 'compress and uncompress data using LZ4Compressor' do
+    memcached(19127,nil,{:compress=>true,:compressor=>Dalli::LZ4Compressor}) do |dc|
+      data = (0...1025).map{65.+(rand(26)).chr}.join
+      assert dc.set("test", data)
+      assert_equal Dalli::LZ4Compressor, dc.instance_variable_get('@ring').servers.first.compressor
+      assert_equal(data, dc.get("test"))
+    end
+  end
+
+end


### PR DESCRIPTION
Added [LZ4](https://code.google.com/p/lz4/) compression to be used with the new LZ4Compressor in place of the Compressor or the GzipCompressor. To use, just install the [lz4-ruby](https://github.com/komiya-atsushi/lz4-ruby) gem.

Benchmarks are included and show an order of magnitude compression/decompression speed improvement while increasing compressed data size by about 1/3.
