### PR TITLE
Fixes broken API documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ socket.
 
 Note that Dalli does not require ActiveSupport or Rails.  You can safely use it in your own Ruby projects.
 
-[View the API](http://www.ruby-doc.org/gems/docs/d/dalli-2.6.2/Dalli/Client.html)
+[View the Client API](http://www.rubydoc.info/github/mperham/dalli/Dalli/Client)
 
 Helping Out
 -------------


### PR DESCRIPTION
The rubydoc.info docs were last generated on Oct 3rd, so fairly recent.
