### PR TITLE
Lower minitest dependency to >= 4.2.0.

### DIFF
--- a/dalli.gemspec
+++ b/dalli.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.summary = %q{High performance memcached client for Ruby}
   s.test_files = Dir.glob("test/**/*")
-  s.add_development_dependency(%q<minitest>, [">= 5.0.0"])
+  s.add_development_dependency(%q<minitest>, [">= 4.2.0"])
   s.add_development_dependency(%q<mocha>, [">= 0"])
   s.add_development_dependency(%q<rails>, ["~> 3"])
 end


### PR DESCRIPTION
Rails 4.0.0 [requires](https://github.com/rails/rails/blob/v4.0.0/activesupport/activesupport.gemspec#L26) minitest `~> 4.2.0`, which is incompatible with Dalli's `>= 5.0.0` requirement. This is making the Travis tests fail for the rails4 gemfile.
