### PR TITLE
Add get-with-cas ('gets') / set-with-CAS functionality

### DIFF
--- a/History.md
+++ b/History.md
@@ -6,6 +6,14 @@ Unreleased
 
 - Implement `version` for retrieving version of connected servers [dterei, #384]
 - Implement `fetch_multi` for batched read/write [sorentwo, #380]
+- Add more support for safe updates with multiple writers: [philipmw]
+  `require 'dalli/cas/client'` augments Dalli::Client with the following methods:
+  * Get value with CAS:            [value, cas] = get_cas(key)
+                                   get_cas(key) {|value, cas| ...}
+  * Get multiple values with CAS:  get_multi_cas(k1, k2, ...) {|value, metadata| cas = metadata[:cas]}
+  * Set value with CAS:            new_cas = set_cas(key, value, cas, ttl, options)
+  * Replace value with CAS:        replace_cas(key, new_value, cas, ttl, options)
+  * Delete value with CAS:         delete_cas(key, cas)
 
 2.6.4
 =======

--- a/lib/dalli/cas/client.rb
+++ b/lib/dalli/cas/client.rb
@@ -1,0 +1,58 @@
+require 'dalli/client'
+
+module Dalli
+  class Client
+    ##
+    # Get the value and CAS ID associated with the key.  If a block is provided,
+    # value and CAS will be passed to the block.
+    def get_cas(key)
+      (value, cas) = perform(:cas, key)
+      value = (!value || value == 'Not found') ? nil : value
+      if block_given?
+        yield value, cas
+      else
+        [value, cas]
+      end
+    end
+
+    ##
+    # Fetch multiple keys efficiently, including available metadata such as CAS.
+    # If a block is given, yields key/data pairs one a time.  Data is an array:
+    # [value, cas_id]
+    # If no block is given, returns a hash of
+    #   { 'key' => [value, cas_id] }
+    def get_multi_cas(*keys)
+      if block_given?
+        get_multi_yielder(keys) {|*args| yield(*args)}
+      else
+        Hash.new.tap do |hash|
+          get_multi_yielder(keys) {|k, data| hash[k] = data}
+        end
+      end
+    end
+
+    ##
+    # Set the key-value pair, verifying existing CAS.
+    # Returns the resulting CAS value if succeeded, and false otherwise.
+    def set_cas(key, value, cas, ttl=nil, options=nil)
+      ttl ||= @options[:expires_in].to_i
+      perform(:set, key, value, ttl, cas, options)
+    end
+
+    ##
+    # Conditionally add a key/value pair, verifying existing CAS, only if the
+    # key already exists on the server.  Returns the new CAS value if the
+    # operation succeeded, or false otherwise.
+    def replace_cas(key, value, cas, ttl=nil, options=nil)
+      ttl ||= @options[:expires_in].to_i
+      perform(:replace, key, value, ttl, cas, options)
+    end
+
+    # Delete a key/value pair, verifying existing CAS.
+    # Returns true if succeeded, and false otherwise.
+    def delete_cas(key, cas=0)
+      perform(:delete, key, cas)
+    end
+
+  end
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -26,6 +26,19 @@ class MiniTest::Spec
     assert_match(regexp, ex.message, "#{ex.class.name}: #{ex.message}\n#{ex.backtrace.join("\n\t")}")
   end
 
+  def op_cas_succeeds(rsp)
+    rsp.is_a?(Integer) && rsp > 0
+  end
+
+  def op_replace_succeeds(rsp)
+    rsp.is_a?(Integer) && rsp > 0
+  end
+
+  # add and set must have the same return value because of DalliStore#write_entry
+  def op_addset_succeeds(rsp)
+    rsp.is_a?(Integer) && rsp > 0
+  end
+
   def with_activesupport
     require 'active_support/all'
     require 'active_support/cache/dalli_store'

--- a/test/memcached_mock.rb
+++ b/test/memcached_mock.rb
@@ -66,6 +66,17 @@ module MemcachedMock
     end
 
     def memcached(port=19122, args='', options={})
+      memcached_server(port, args)
+      yield Dalli::Client.new(["localhost:#{port}", "127.0.0.1:#{port}"], options)
+    end
+
+    def memcached_cas(port=19122, args='', options={})
+      memcached_server(port, args)
+      require 'dalli/cas/client'
+      yield Dalli::Client.new(["localhost:#{port}", "127.0.0.1:#{port}"], options)
+    end
+
+    def memcached_server(port=19122, args='')
       Memcached.path ||= find_memcached
 
       cmd = "#{Memcached.path}memcached #{args} -p #{port}"
@@ -83,7 +94,6 @@ module MemcachedMock
         sleep 0.1
         pid
       end
-      yield Dalli::Client.new(["localhost:#{port}", "127.0.0.1:#{port}"], options)
     end
 
     def supports_fork?

--- a/test/test_active_support.rb
+++ b/test/test_active_support.rb
@@ -18,7 +18,7 @@ describe 'ActiveSupport' do
     it 'allow mute and silence' do
       @dalli = ActiveSupport::Cache.lookup_store(:dalli_store, 'localhost:19122')
       @dalli.mute do
-        assert_equal true, @dalli.write('foo', 'bar', nil)
+        assert op_addset_succeeds(@dalli.write('foo', 'bar', nil))
         assert_equal 'bar', @dalli.read('foo', nil)
       end
       refute @dalli.silence?
@@ -28,7 +28,7 @@ describe 'ActiveSupport' do
 
     it 'handle nil options' do
       @dalli = ActiveSupport::Cache.lookup_store(:dalli_store, 'localhost:19122')
-      assert_equal true, @dalli.write('foo', 'bar', nil)
+      assert op_addset_succeeds(@dalli.write('foo', 'bar', nil))
       assert_equal 'bar', @dalli.read('foo', nil)
       assert_equal 18, @dalli.fetch('lkjsadlfk', nil) { 18 }
       assert_equal 18, @dalli.fetch('lkjsadlfk', nil) { 18 }
@@ -174,7 +174,7 @@ describe 'ActiveSupport' do
           y = rand_key
           assert_nil @dalli.read(y)
           dres = @dalli.write(y, 123)
-          assert_equal true, dres
+          assert op_addset_succeeds(dres)
 
           dres = @dalli.read(y)
           assert_equal 123, dres
@@ -184,7 +184,7 @@ describe 'ActiveSupport' do
 
           user = MockUser.new
           dres = @dalli.write(user.cache_key, "foo")
-          assert_equal true, dres
+          assert op_addset_succeeds(dres)
 
           dres = @dalli.read(user)
           assert_equal "foo", dres
@@ -256,7 +256,7 @@ describe 'ActiveSupport' do
       with_activesupport do
         memcached do
           connect
-          assert_equal true, @dalli.write('counter', 0, :raw => true)
+          assert op_addset_succeeds(@dalli.write('counter', 0, :raw => true))
           assert_equal 1, @dalli.increment('counter')
           assert_equal 2, @dalli.increment('counter')
           assert_equal 1, @dalli.decrement('counter')
@@ -281,7 +281,7 @@ describe 'ActiveSupport' do
           assert_equal nil, @dalli.read('counterZ2')
 
           user = MockUser.new
-          assert_equal true, @dalli.write(user, 0, :raw => true)
+          assert op_addset_succeeds(@dalli.write(user, 0, :raw => true))
           assert_equal 1, @dalli.increment(user)
           assert_equal 2, @dalli.increment(user)
           assert_equal 1, @dalli.decrement(user)
@@ -358,7 +358,7 @@ describe 'ActiveSupport' do
         connect
         key = "fooƒ"
         value = 'bafƒ'
-        assert_equal true, @dalli.write(key, value)
+        assert op_addset_succeeds(@dalli.write(key, value))
         assert_equal value, @dalli.read(key)
       end
     end
@@ -380,7 +380,7 @@ describe 'ActiveSupport' do
         connect
         key = "foo"
         key.freeze
-        assert_equal true, @dalli.write(key, "value")
+        assert op_addset_succeeds(@dalli.write(key, "value"))
       end
     end
   end
@@ -391,7 +391,7 @@ describe 'ActiveSupport' do
         connect
         map = { "one" => "one", "two" => "two" }
         map.each_pair do |k, v|
-          assert_equal true, @dalli.write(k, v)
+          assert op_addset_succeeds(@dalli.write(k, v))
         end
         assert_equal map, @dalli.read_multi(*(map.keys))
       end

--- a/test/test_cas_client.rb
+++ b/test/test_cas_client.rb
@@ -1,0 +1,107 @@
+require 'helper'
+require 'memcached_mock'
+
+describe 'Dalli::Cas::Client' do
+  describe 'using a live server' do
+    it 'supports get with CAS' do
+      memcached_cas do |dc|
+        dc.flush
+
+        expected = { 'blah' => 'blerg!' }
+        get_block_called = false
+        stored_value = stored_cas = nil
+        # Validate call-with-block
+        dc.get_cas('gets_key') do |v, cas|
+          get_block_called = true
+          stored_value = v
+          stored_cas = cas
+        end
+        assert get_block_called
+        assert_nil stored_value
+
+        dc.set('gets_key', expected)
+
+        # Validate call-with-return-value
+        stored_value, stored_cas = dc.get_cas('gets_key')
+        assert_equal stored_value, expected
+        assert (stored_cas != 0)
+      end
+    end
+
+    it 'supports multi-get with CAS' do
+      memcached_cas do |dc|
+        dc.close
+        dc.flush
+
+        expected_hash = {'a' => 'foo', 'b' => 123}
+        expected_hash.each_pair do |k, v|
+          dc.set(k, v)
+        end
+
+        # Invocation without block
+        resp = dc.get_multi_cas(%w(a b c d e f))
+        resp.each_pair do |k, data|
+          value, cas = [data.first, data.second]
+          assert_equal expected_hash[k], value
+          assert (cas && cas != 0)
+        end
+
+        # Invocation with block
+        dc.get_multi_cas(%w(a b c d e f)) do |k, data|
+          value, cas = [data.first, data.second]
+          assert_equal expected_hash[k], value
+          assert (cas && cas != 0)
+        end
+      end
+    end
+
+    it 'supports replace-with-CAS operation' do
+      memcached_cas do |dc|
+        dc.flush
+        cas = dc.set('key', 'value')
+
+        # Accepts CAS, replaces, and returns new CAS
+        cas = dc.replace_cas('key', 'value2', cas)
+        assert cas.is_a?(Integer)
+
+        assert_equal 'value2', dc.get('key')
+      end
+    end
+
+    it 'supports delete with CAS' do
+      memcached_cas do |dc|
+        cas = dc.set('some_key', 'some_value')
+        dc.delete_cas('some_key', cas)
+        assert_nil dc.get('some_key')
+      end
+    end
+
+    it 'handles CAS round-trip operations' do
+      memcached_cas do |dc|
+        dc.flush
+
+        expected = {'blah' => 'blerg!'}
+        dc.set('some_key', expected)
+
+        value, cas = dc.get_cas('some_key')
+        assert_equal value, expected
+        assert (!cas.nil? && cas != 0)
+
+        # Set operation, first with wrong then with correct CAS
+        expected = {'blah' => 'set succeeded'}
+        assert (dc.set_cas('some_key', expected, cas+1) == false)
+        assert op_addset_succeeds(cas = dc.set_cas('some_key', expected, cas))
+
+        # Replace operation, first with wrong then with correct CAS
+        expected = {'blah' => 'replace succeeded'}
+        assert (dc.replace_cas('some_key', expected, cas+1) == false)
+        assert op_addset_succeeds(cas = dc.replace_cas('some_key', expected, cas))
+
+        # Delete operation, first with wrong then with correct CAS
+        assert (dc.delete_cas('some_key', cas+1) == false)
+        assert dc.delete_cas('some_key', cas)
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
This patch allows safe updates of values in a scenario with multiple writers.
