### PR TITLE
Resolve #375

### DIFF
--- a/History.md
+++ b/History.md
@@ -14,6 +14,7 @@ Unreleased
   * Set value with CAS:            `new_cas = set_cas(key, value, cas, ttl, options)`
   * Replace value with CAS:        `replace_cas(key, new_value, cas, ttl, options)`
   * Delete value with CAS:         `delete_cas(key, cas)`
+- Fix bug with get key with "Not found" value [uzzz, #375]
 
 2.6.4
 =======

--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -50,8 +50,7 @@ module Dalli
     ##
     # Get the value associated with the key.
     def get(key, options=nil)
-      resp = perform(:get, key)
-      resp.nil? || 'Not found' == resp ? nil : resp
+      perform(:get, key)
     end
 
     ##

--- a/test/test_dalli.rb
+++ b/test/test_dalli.rb
@@ -114,6 +114,19 @@ describe 'Dalli' do
       end
     end
 
+    it 'returns nil for nonexist key' do
+      memcached do |dc|
+        assert_equal nil, dc.get('notexist')
+      end
+    end
+
+    it 'allows "Not found" as value' do
+      memcached do |dc|
+        dc.set('key1', 'Not found')
+        assert_equal 'Not found', dc.get('key1')
+      end
+    end
+
     it "support stats" do
       memcached do |dc|
         # make sure that get_hits would not equal 0


### PR DESCRIPTION
generic_response method checks for status field of response header (it's !=0 when value is actually not found), so looks like 'Not found' check not needed anymore. I wrote few test (old tests passed ass well).
