### PR TITLE
less encryptic error message when version is < 1.4

### DIFF
--- a/lib/dalli/server.rb
+++ b/lib/dalli/server.rb
@@ -55,7 +55,7 @@ module Dalli
     # Chokepoint method for instrumentation
     def request(op, *args)
       verify_state
-      raise Dalli::NetworkError, "#{hostname}:#{port} is down: #{@error} #{@msg}" unless alive?
+      raise Dalli::NetworkError, "#{hostname}:#{port} is down: #{@error} #{@msg}. If you are sure it is running, ensure memcached version is > 1.4." unless alive?
       begin
         send(op, *args)
       rescue Dalli::NetworkError


### PR DESCRIPTION
@error and @msg are both nil, thus the message says it's down
even though you've verified it is definitely up...something is lying!
Then you read the docs.
