### PR TITLE
Make the ring class injectable

### DIFF
--- a/test/test_ring.rb
+++ b/test/test_ring.rb
@@ -82,4 +82,18 @@ describe 'Ring' do
       end
     end
   end
+
+  it 'defaults to Dalli::Ring' do
+    client = Dalli::Client.new('127.0.0.1:29199')
+    assert_kind_of Dalli::Ring, client.send(:ring)
+  end
+
+  it 'can be passed a custom ring class' do
+    class NoopRing
+      def initialize(*args); end
+    end
+
+    client = Dalli::Client.new('127.0.0.1:29199', :ring_class => NoopRing)
+    assert_kind_of NoopRing, client.send(:ring)
+  end
 end


### PR DESCRIPTION
This adds the ability to pass a class into the options hash to be used as a ring.

The rationale behind it is that there are many other memcache libs using different hash ring logic, and being able to enforce that logic consistently throughout your applications shouldn't involve actually hacking dalli.

If you guys feel this would be a useful addition, I'll most likely add some documentation to this, just to be sure the use case for this is clear.