### PR TITLE
Support SASL tests on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,10 @@ gemfile:
 matrix:
   allow_failures:
     - rvm: rbx
-branches:
-  only:
-    - master
 env: JRUBY_OPTS='--1.9'
+before_install:
+  - sudo apt-get -y remove memcached
+  - sudo apt-get -y install software-properties-common
+  - echo "yes" | sudo add-apt-repository ppa:travis-ci/memcached-sasl
+  - sudo apt-get update
+  - sudo apt-get install -y memcached=1.4.13-0ubuntu2+travis1

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -52,8 +52,4 @@ class MiniTest::Spec
     require 'action_controller'
     yield
   end
-
-  def ci?
-    ENV['TRAVIS']
-  end
 end

--- a/test/test_sasl.rb
+++ b/test/test_sasl.rb
@@ -31,7 +31,6 @@ describe 'Sasl' do
       end
 
       it 'gracefully handle authentication failures' do
-        skip if ci?
         memcached(19124, '-S') do |dc|
           assert_error Dalli::DalliError, /32/ do
             dc.set('abc', 123)
@@ -41,7 +40,6 @@ describe 'Sasl' do
     end
 
     it 'fail SASL authentication with wrong options' do
-      skip if ci?
       memcached(19124, '-S') do |dc|
         dc = Dalli::Client.new('localhost:19124', :username => 'foo', :password => 'wrongpwd')
         assert_error Dalli::DalliError, /32/ do


### PR DESCRIPTION
The tests are still a little flakey, in that some Travis jobs will fail with various errors but then pass when re-run. The tests that fail are not all SASL-related, so I believe there are other issues at play. This at least removes any technical limitations from running these tests via CI.
