### PR TITLE
Accommodate nil server setting via ActiveSupport

### DIFF
--- a/lib/active_support/cache/dalli_store.rb
+++ b/lib/active_support/cache/dalli_store.rb
@@ -54,6 +54,8 @@ module ActiveSupport
         pool_options[:timeout] = options[:pool_timeout] if options[:pool_timeout]
 
         @options[:compress] ||= @options[:compression]
+
+        addresses.compact!
         servers = if addresses.empty?
                     nil # use the default from Dalli::Client
                   else

--- a/test/test_active_support.rb
+++ b/test/test_active_support.rb
@@ -371,6 +371,18 @@ describe 'ActiveSupport' do
         @dalli = ActiveSupport::Cache::DalliStore.new('localhost:19122', :expires_in => 1, :namespace => 'foo', :compress => true)
         assert_equal 1, @dalli.instance_variable_get(:@data).instance_variable_get(:@options)[:expires_in]
         assert_equal 'foo', @dalli.instance_variable_get(:@data).instance_variable_get(:@options)[:namespace]
+        assert_equal ["localhost:19122"], @dalli.instance_variable_get(:@data).instance_variable_get(:@servers)
+      end
+    end
+  end
+
+  it 'handles nil server with additional options' do
+    with_activesupport do
+      memcached do
+        @dalli = ActiveSupport::Cache::DalliStore.new(nil, :expires_in => 1, :namespace => 'foo', :compress => true)
+        assert_equal 1, @dalli.instance_variable_get(:@data).instance_variable_get(:@options)[:expires_in]
+        assert_equal 'foo', @dalli.instance_variable_get(:@data).instance_variable_get(:@options)[:namespace]
+        assert_equal ["127.0.0.1:11211"], @dalli.instance_variable_get(:@data).instance_variable_get(:@servers)
       end
     end
   end


### PR DESCRIPTION
This wasn't actually working before :). `@servers` would end up being `[nil]`

All tests pass if i had changed `addresses = addresses.flatten` to `addresses = addresses.flatten.compact`, but I felt it was more conservative to do it after the options parsing was done, just in case there were edge cases not covered in specs.

I threw in the server check in the "normalize options" test for good measure
