### PR TITLE
add missing method since DalliStore < AbstractStore not CacheStore

### DIFF
--- a/lib/action_dispatch/middleware/session/dalli_store.rb
+++ b/lib/action_dispatch/middleware/session/dalli_store.rb
@@ -77,6 +77,11 @@ module ActionDispatch
         false
       end
 
+      private
+        # Turn the session id into a cache key.
+        def cache_key(sid)
+          "_session_id:#{sid}"
+        end
     end
   end
 end


### PR DESCRIPTION
add cache_key method.

Upading the gem will invalidate all current session
