### PR TITLE
better fix for blank session cookie

### DIFF
--- a/lib/rack/session/dalli.rb
+++ b/lib/rack/session/dalli.rb
@@ -22,15 +22,15 @@ module Rack
       def generate_sid
         loop do
           sid = super
-          break sid unless @pool.get(cache_key(sid))
+          break sid unless @pool.get(sid)
         end
       end
 
       def get_session(env, sid)
         with_lock(env, [nil, {}]) do
-          unless sid and session = @pool.get(cache_key(sid))
+          unless sid and !sid.empty? and session = @pool.get(sid)
             sid, session = generate_sid, {}
-            unless @pool.add(cache_key(sid), session)
+            unless @pool.add(sid, session)
               raise "Session collision on '#{sid.inspect}'"
             end
           end
@@ -39,20 +39,19 @@ module Rack
       end
 
       def set_session(env, session_id, new_session, options)
-        key = cache_key(session_id)
         return false unless session_id
         expiry = options[:expire_after]
         expiry = expiry.nil? ? 0 : expiry + 1
 
         with_lock(env, false) do
-          @pool.set key, new_session, expiry
+          @pool.set session_id, new_session, expiry
           session_id
         end
       end
 
       def destroy_session(env, session_id, options)
         with_lock(env) do
-          @pool.delete(cache_key(session_id))
+          @pool.delete(session_id)
           generate_sid unless options[:drop]
         end
       end
@@ -71,11 +70,6 @@ module Rack
         @mutex.unlock if @mutex.locked?
       end
 
-      private
-        # Turn the session id into a cache key.
-        def cache_key(sid)
-          "_session_id:#{sid}"
-        end
     end
   end
 end


### PR DESCRIPTION
My coworkers do not like my patch which will invalidate current session. They suggest a better fix : generate a new sid if empty one (as it's already done with nil sid)
