### PR TITLE
Reading data by #fetch method with block returns different object fix #451

### DIFF
--- a/lib/active_support/cache/dalli_store.rb
+++ b/lib/active_support/cache/dalli_store.rb
@@ -88,7 +88,7 @@ module ActiveSupport
         if block_given?
           unless options[:force]
             entry = instrument(:read, name, options) do |payload|
-              read_entry(name, options).tap do |result|
+              read_entry(name, options) do |result|
                 if payload
                   payload[:super_operation] = :fetch
                   payload[:hit] = !!result


### PR DESCRIPTION
``` ruby
irb(main):095:0> Marshal.dump Rails.cache.fetch('test2'){a = Sunspot::Search::PaginatedCollection.new([1,2,3],1,1,1); a}
=> "\x04\bo:)Sunspot::Search::PaginatedCollection\t:\x10@collection[\bi\x06i\ai\b:\x12@current_pagei\x06:\x0E@per_pagei\x06:\x11@total_counti\x06"
irb(main):096:0> Marshal.dump Rails.cache.fetch('test2'){a = Sunspot::Search::PaginatedCollection.new([1,2,3],1,1,1); a}
=> "\x04\b[\bi\x06i\ai\b"
irb(main):097:0> Marshal.dump Rails.cache.fetch('test2')
=> "\x04\bo:)Sunspot::Search::PaginatedCollection\t:\x10@collection[\bi\x06i\ai\b:\x12@current_pagei\x06:\x0E@per_pagei\x06:\x11@total_counti\x06"
irb(main):098:0> Marshal.dump Rails.cache.read('test2')
=> "\x04\bo:)Sunspot::Search::PaginatedCollection\t:\x10@collection[\bi\x06i\ai\b:\x12@current_pagei\x06:\x0E@per_pagei\x06:\x11@total_counti\x06"
```
