### PR TITLE
do not write nil in fetch()

### DIFF
--- a/lib/active_support/cache/dalli_store.rb
+++ b/lib/active_support/cache/dalli_store.rb
@@ -104,7 +104,7 @@ module ActiveSupport
             result = instrument(:generate, name, options) do |payload|
               yield
             end
-            write(name, result, options)
+            write(name, result, options) unless result.nil?
             result
           end
         else


### PR DESCRIPTION
The write op doesn't do any help. Is there any reason for doing that?
