### PR TITLE
read_multi with empty array

### DIFF
--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -58,10 +58,11 @@ module Dalli
     # If a block is given, yields key/value pairs one at a time.
     # Otherwise returns a hash of { 'key' => 'value', 'key2' => 'value1' }
     def get_multi(*keys)
+      return {} if keys.flatten.compact.empty?
       if block_given?
         get_multi_yielder(keys) {|k, data| yield k, data.first}
       else
-         Hash.new.tap do |hash|
+        Hash.new.tap do |hash|
           get_multi_yielder(keys) {|k, data| hash[k] = data.first}
         end
       end

--- a/test/test_active_support.rb
+++ b/test/test_active_support.rb
@@ -106,6 +106,15 @@ describe 'ActiveSupport' do
       end
     end
 
+    it 'support read_multi with an empty array' do
+      with_activesupport do
+        memcached_persistent(@port) do
+          connect(@port)
+          assert_equal({}, @dalli.read_multi([]))
+        end
+      end
+    end
+
     it 'support raw read_multi' do
       with_activesupport do
         memcached do


### PR DESCRIPTION
This behaviour changed from 1.1.5 to 2.x.

It appears it was never tested for, but just happened to work in 1.1.5.
