### PR TITLE
Add namespace as local option

### DIFF
--- a/lib/active_support/cache/dalli_store.rb
+++ b/lib/active_support/cache/dalli_store.rb
@@ -155,8 +155,8 @@ module ActiveSupport
       # Reads multiple keys from the cache using a single call to the
       # servers for all keys. Keys must be Strings.
       def read_multi(*names)
-        names.extract_options!
-        mapping = names.inject({}) { |memo, name| memo[expanded_key(name)] = name; memo }
+        options  = names.extract_options!
+        mapping = names.inject({}) { |memo, name| memo[namespaced_key(name, options)] = name; memo }
         instrument(:read_multi, names) do
           results = {}
           if local_cache
@@ -186,7 +186,7 @@ module ActiveSupport
       # and the result will be written to the cache and returned.
       def fetch_multi(*names)
         options = names.extract_options!
-        mapping = names.inject({}) { |memo, name| memo[expanded_key(name)] = name; memo }
+        mapping = names.inject({}) { |memo, name| memo[namespaced_key(name, options)] = name; memo }
 
         instrument(:fetch_multi, names) do
           with do |connection|

--- a/test/test_active_support.rb
+++ b/test/test_active_support.rb
@@ -209,8 +209,7 @@ describe 'ActiveSupport' do
       end
     end
 
-
-    it 'support local namesapce' do
+    it 'support read, write and delete with local namespace' do
       with_activesupport do
         memcached_persistent(@port) do
           connect(@port, '')
@@ -229,6 +228,28 @@ describe 'ActiveSupport' do
 
           res = @dalli.read(key, :namespace => 'namespace')
           assert_equal "foo", res
+        end
+      end
+    end
+
+    it 'support multi_read and multi_fetch with local namespace' do
+      with_activesupport do
+        memcached_persistent(@port) do
+          connect(@port, '')
+          x         = rand_key.to_s
+          y         = rand_key
+          namespace = 'namespace'
+          hash      = { x => 'ABC', y => 'DEF' }
+
+          results = @dalli.fetch_multi(x, y, :namespace => namespace) { |key| hash[key] }
+
+          assert_equal({ x => 'ABC', y => 'DEF' }, results)
+          assert_equal('ABC', @dalli.read(x, :namespace => namespace))
+          assert_equal('DEF', @dalli.read(y, :namespace => namespace))
+
+          @dalli.write("abc", 5, :namespace => 'namespace')
+          @dalli.write("cba", 5, :namespace => 'namespace')
+          assert_equal({'abc' => 5, 'cba' => 5 }, @dalli.read_multi("abc", "cba", :namespace => 'namespace'))
         end
       end
     end


### PR DESCRIPTION
fixes #490 
- add namespaced_key method from active support
- add new test to ensure you can use a namespace locally

I am just not sure about read and write multi.
