### PR TITLE
Add an explicit to_i on the ttl value

### DIFF
--- a/lib/dalli/server.rb
+++ b/lib/dalli/server.rb
@@ -471,9 +471,9 @@ module Dalli
     def sanitize_ttl(ttl)
       if ttl > MAX_ACCEPTABLE_EXPIRATION_INTERVAL
         Dalli.logger.debug "Expiration interval too long for Memcached, converting to an expiration timestamp"
-        Time.now.to_i + ttl
+        Time.now.to_i + ttl.to_i
       else
-        ttl
+        ttl.to_i
       end
     end
 


### PR DESCRIPTION
With the introduction of Rails 4.2, the return value of expressions like `7.days` has changed.  In Rails 4.1.x and below, this is a Fixnum.  In Rails 4.2 and up, it's an ActiveSupport::Duration.

JRuby does not handle converting this new type transparently to a Fixnum during the packing process.  So to eliminate the conversion error we explicitly call to_i.
