### PR TITLE
Use hash.each_key instead of hash.keys.each

### DIFF
--- a/lib/active_support/cache/dalli_store.rb
+++ b/lib/active_support/cache/dalli_store.rb
@@ -160,7 +160,7 @@ module ActiveSupport
         instrument(:read_multi, names) do
           results = {}
           if local_cache
-            mapping.keys.each do |key|
+            mapping.each_key do |key|
               if value = local_cache.read_entry(key, options)
                 results[key] = value
               end


### PR DESCRIPTION
each_key is faster than keys.each
