### PR TITLE
Raise a DalliError if the hostname cannot be parsed

### DIFF
--- a/lib/dalli/server.rb
+++ b/lib/dalli/server.rb
@@ -694,6 +694,7 @@ module Dalli
 
     def parse_hostname(str)
       res = str.match(/\A(\[([\h:]+)\]|[^:]+)(:(\d+))?(:(\d+))?\z/)
+      raise Dalli::DalliError, "Could not parse hostname #{str}" if res.nil?
       return res[2] || res[1], res[4], res[6]
     end
   end

--- a/test/test_server.rb
+++ b/test/test_server.rb
@@ -64,6 +64,12 @@ describe Dalli::Server do
       assert_equal 11212, s.port
       assert_equal 2, s.weight
     end
+
+    it 'throws an exception if the hostname cannot be parsed' do
+      lambda { Dalli::Server.new('my.fqdn.com:') }.must_raise Dalli::DalliError
+      lambda { Dalli::Server.new('my.fqdn.com:11212,:2') }.must_raise Dalli::DalliError
+      lambda { Dalli::Server.new('my.fqdn.com:11212:abc') }.must_raise Dalli::DalliError
+    end
   end
 
   describe 'ttl translation' do


### PR DESCRIPTION
If a hostname was provided that did not match the regex in
`parse_hostname` then using the `res` variable would cause a
NoMethodError with the message "undefined method '[]' for
nil:NilClass". It was a bit vague so this commit will make the
failure more explicit.
