### PR TITLE
Re-enabled SASL tests and added note re: config on OSX.

### DIFF
--- a/test/memcached_mock.rb
+++ b/test/memcached_mock.rb
@@ -95,7 +95,7 @@ module MemcachedMock
     end
 
     def memcached_sasl_persistent(port=21397)
-      dc = start_and_flush_with_retry(port, '-S', sasl_credentials)
+      dc = start_and_flush_with_retry(port, '-S')
       yield dc, port if block_given?
     end
 


### PR DESCRIPTION
I contacted you earlier via Twitter (@imdonncha) so just wanted to follow up to say that Dalli + SASL + memcached does seem to work. Careful config of memcached and SASL is what’s required.

Specifically, I installed memcached + sasl via Macports, so I then had to ensure that the sasldb file was in /opt/local/etc instead of /etc and I also had to ensure that the memcached user had permissions to read that file.

I've re-enabled the SASL tests and they now pass the read/write aspects. I still see two failures with the contents of the results from the `dc.stats` calls, but am not sure what the objective is there so have left them alone.

As for specific setup on OSX (10.10.3)...

``` sh
$ sudo port install memcached +sasl
$ sudo saslpasswd2 -f /opt/local/etc/sasldb2 -a memcached -c testuser
$ sudo chown YOU /opt/local/etc/sasldb2.db
```

Tested on Ruby 2.1.5p273
