### PR TITLE
fix timeout issue with Dalli::Client#get_multi_yielder

### DIFF
--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -401,12 +401,10 @@ module Dalli
               # calculate remaining timeout
               elapsed = Time.now - start
               timeout = servers.first.options[:socket_timeout]
-              if elapsed > timeout
-                readable = nil
-              else
-                sockets = servers.map(&:sock)
-                readable, _ = IO.select(sockets, nil, nil, timeout - elapsed)
-              end
+              time_left = (elapsed > timeout) ? 0 : timeout - elapsed
+
+              sockets = servers.map(&:sock)
+              readable, _ = IO.select(sockets, nil, nil, time_left)
 
               if readable.nil?
                 # no response within timeout; abort pending connections


### PR DESCRIPTION
Fix Dalli::Client#get_multi_yielder so it doesn't timeout as long as
data is immediately available for reading.  We were seeing spurious
timeout errors such as:

    memcache-host:11211 failed (count: 0) RuntimeError: External timeout

when doing large (100+ item) multi-get operations.  This fixes the problem.