### PR TITLE
Add support for `:race_condition_ttl` option

### DIFF
--- a/History.md
+++ b/History.md
@@ -6,6 +6,7 @@ Dalli Changelog
 
 - Support rcvbuff and sndbuff byte configuration. (btatnall)
 - Add `:cache_nils` option to support nil values in `DalliStore#fetch` and `Dalli::Client#fetch` (wjordan, #559)
+- Support `:race_condition_ttl` option for `DalliStore#write` and `#fetch` (wjordan, #560)
 
 2.7.4
 ==========


### PR DESCRIPTION
This PR adds support for the `:race_condition_ttl` option from `ActiveSupport::Cache`. This implementation uses an `Entry` wrapper object to append the secondary expiration to the value being stored.

An alternative approach avoids using a wrapper object by writing/reading an extra metadata-only key with the secondary expiration (as attempted in #378). However, this approach performed worse in my local tests, likely due to the need to send multiple `get` requests to the server on each `#fetch` (`multi_get` was even slower for some reason).

To avoid performance regressions, the wrapper object is only used when the `:race_condition_ttl` option is explicitly specified in a `#write` or `#fetch` call. A single instance object is reused to reduce garbage creation, and custom serialization/deserialization methods limit the total per-object overhead to only 8 bytes (storing the `expires_at` timestamp as a double-precision float).

The included tests are adapted from the ActiveSupport tests, however the test objects are expired via `sleep` commands instead of stubbing `Time.now` as done in `ActiveSupport::Cache`\- if it's possible to stub Dalli to manually-expire objects on the server, that would help here.

This should support the `:stale_after` use-case described in #286 (see the `is safe` test in particular), but I'm not 100% sure about this.
