### PR TITLE
Fix some build issues with the new Travis environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 cache: bundler
 rvm:
-  - 2.2
-  - 2.1
+  - 2.2.3
+  - 2.1.7
   - 2.0.0
   - 1.9.3
   - rbx-2

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ matrix:
     - rvm: rbx-2
 env: JRUBY_OPTS='--1.9'
 before_install:
+  - gem install bundler
   - sudo apt-get -y remove memcached
   - echo "yes" | sudo add-apt-repository ppa:travis-ci/memcached-sasl
   - sudo apt-get update

--- a/Rakefile
+++ b/Rakefile
@@ -14,8 +14,6 @@ Rake::TestTask.new(:bench) do |test|
   test.pattern = 'test/benchmark_test.rb'
 end
 
-require 'metric_fu'
-
 task :test_all do
   system('rake test RAILS_VERSION="~> 3.0.0"')
   system('rake test RAILS_VERSION=">= 3.0.0"')

--- a/dalli.gemspec
+++ b/dalli.gemspec
@@ -24,6 +24,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'connection_pool'
   s.add_development_dependency 'rdoc'
   s.add_development_dependency 'simplecov'
-  s.add_development_dependency 'metric_fu'
 end
 


### PR DESCRIPTION
1. Call `gem install bundler` to ensure we have the latest bundler
2. Remove metric_fu dependency
3. Update Travis CI to use latest patches for Ruby 2.1 and 2.2