### PR TITLE
Isolate errors in TTL arguments to Dalli::Client

### DIFF
--- a/lib/dalli/server.rb
+++ b/lib/dalli/server.rb
@@ -484,12 +484,10 @@ module Dalli
     # > An expiration time, in seconds. Can be up to 30 days. After 30 days, is treated as a unix timestamp of an exact date.
     MAX_ACCEPTABLE_EXPIRATION_INTERVAL = 30*24*60*60 # 30 days
     def sanitize_ttl(ttl)
-      if ttl > MAX_ACCEPTABLE_EXPIRATION_INTERVAL
-        Dalli.logger.debug "Expiration interval too long for Memcached, converting to an expiration timestamp"
-        Time.now.to_i + ttl.to_i
-      else
-        ttl.to_i
-      end
+      ttl_as_i = ttl.to_i
+      return ttl_as_i if ttl_as_i <= MAX_ACCEPTABLE_EXPIRATION_INTERVAL
+      Dalli.logger.debug "Expiration interval (ttl_as_i) too long for Memcached, converting to an expiration timestamp"
+      Time.now.to_i + ttl_as_i
     end
 
     # Implements the NullObject pattern to store an application-defined value for 'Key not found' responses.

--- a/test/test_dalli.rb
+++ b/test/test_dalli.rb
@@ -61,6 +61,16 @@ describe 'Dalli' do
     end
   end
 
+  describe 'ttl validation' do
+    it 'generated an ArgumentError for ttl that does not support to_i' do
+      memcached_persistent do |dc|
+        assert_raises ArgumentError do
+          dc.set('foo', 'bar', [])
+        end
+      end
+    end
+  end
+
   it "default to localhost:11211" do
     dc = Dalli::Client.new
     ring = dc.send(:ring)


### PR DESCRIPTION
If a ttl argument cannot be parsed to an integer with `to_i`, raise an error in the `Dalli::Client` as opposed to the `Dalli::Server`.  This ensures that a bad argument doesn't knock a server out of the ring.