### PR TITLE
loop do -> while true

### DIFF
--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -408,7 +408,7 @@ module Dalli
             servers = perform_multi_response_start(servers)
 
             start = Time.now
-            loop do
+            while true
               # remove any dead servers
               servers.delete_if { |s| s.sock.nil? }
               break if servers.empty?

--- a/lib/dalli/server.rb
+++ b/lib/dalli/server.rb
@@ -528,7 +528,7 @@ module Dalli
 
     def keyvalue_response
       hash = {}
-      loop do
+      while true
         (key_length, _, body_length, _) = read_header.unpack(KV_HEADER)
         return hash if key_length == 0
         key = read(key_length)
@@ -539,7 +539,7 @@ module Dalli
 
     def multi_response
       hash = {}
-      loop do
+      while true
         (key_length, _, body_length, _) = read_header.unpack(KV_HEADER)
         return hash if key_length == 0
         flags = read(4).unpack('N')[0]

--- a/lib/dalli/socket.rb
+++ b/lib/dalli/socket.rb
@@ -28,7 +28,7 @@ begin
 
     def readfull(count)
       value = ''
-      loop do
+      while true
         value << kgio_read!(count - value.bytesize)
         break if value.bytesize == count
       end
@@ -37,7 +37,7 @@ begin
 
     def read_available
       value = ''
-      loop do
+      while true
         ret = kgio_tryread(8196)
         case ret
         when nil
@@ -90,7 +90,7 @@ rescue LoadError
       def readfull(count)
         value = ''
         begin
-          loop do
+          while true
             value << read_nonblock(count - value.bytesize)
             break if value.bytesize == count
           end
@@ -106,7 +106,7 @@ rescue LoadError
 
       def read_available
         value = ''
-        loop do
+        while true
           begin
             value << read_nonblock(8196)
           rescue Errno::EAGAIN, Errno::EWOULDBLOCK

--- a/lib/rack/session/dalli.rb
+++ b/lib/rack/session/dalli.rb
@@ -20,7 +20,7 @@ module Rack
       end
 
       def generate_sid
-        loop do
+        while true
           sid = super
           break sid unless @pool.get(sid)
         end


### PR DESCRIPTION
[`loop` is slower than `while true`](https://github.com/JuanitoFatas/fast-ruby/blob/master/code/general/loop-vs-while-true.rb). 

This appears to be a decently hot area of the code - running your included benchmark gets about 3-5% faster for me with this change. It's a pretty minor speedup, but a free one! 