### PR TITLE
Yield over block.call

### DIFF
--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -337,8 +337,8 @@ module Dalli
     end
 
     # Chokepoint method for instrumentation
-    def perform(*all_args, &blk)
-      return blk.call if blk
+    def perform(*all_args)
+      return yield if block_given?
       op, key, *args = *all_args
 
       key = key.to_s


### PR DESCRIPTION
Yielding is always faster than using #call, because [with #call we have to create a Proc object](https://www.omniref.com/ruby/2.2.0/symbols/Proc/yield?#annotation=4087638&line=711).

This doesn't appear to be a super-hot area of the code, the impact on your included macrobenchmark cannot be assessed.