### PR TITLE
Ring symbol#to_proc

### DIFF
--- a/lib/dalli/ring.rb
+++ b/lib/dalli/ring.rb
@@ -46,11 +46,11 @@ module Dalli
     end
 
     def lock
-      @servers.each { |s| s.lock! }
+      @servers.each(&:lock!)
       begin
         return yield
       ensure
-        @servers.each { |s| s.unlock! }
+        @servers.each(&:unlock!)
       end
     end
 


### PR DESCRIPTION
This will perform better on a micro benchmark, but I don't this code gets called often enough for it to matter. Plus, I think Symbol#to_proc generally just sort of reads better :)