### PR TITLE
Refactor Ring

### DIFF
--- a/lib/dalli/ring.rb
+++ b/lib/dalli/ring.rb
@@ -12,15 +12,15 @@ module Dalli
       @continuum = nil
       if servers.size > 1
         total_weight = servers.inject(0) { |memo, srv| memo + srv.weight }
-        continuum = []
+        @continuum = []
         servers.each do |server|
           entry_count_for(server, servers.size, total_weight).times do |idx|
             hash = Digest::SHA1.hexdigest("#{server.name}:#{idx}")
             value = Integer("0x#{hash[0..7]}")
-            continuum << Dalli::Ring::Entry.new(value, server)
+            @continuum << { value: value, server: server }
           end
         end
-        @continuum = continuum.sort { |a, b| a.value <=> b.value }
+        @continuum.sort_by! { |a| a[:value] }.reverse!
       end
 
       threadsafe! unless options[:threadsafe] == false
@@ -31,8 +31,8 @@ module Dalli
       if @continuum
         hkey = hash_for(key)
         20.times do |try|
-          entryidx = binary_search(@continuum, hkey)
-          server = @continuum[entryidx].server
+          entry = @continuum.bsearch { |h| h[:value] <= hkey } || @continuum.last
+          server = entry[:server]
           return server if server.alive?
           break unless @failover
           hkey = hash_for("#{try}#{key}")
@@ -69,74 +69,5 @@ module Dalli
     def entry_count_for(server, total_servers, total_weight)
       ((total_servers * POINTS_PER_SERVER * server.weight) / Float(total_weight)).floor
     end
-
-    # Native extension to perform the binary search within the continuum
-    # space.  Fallback to a pure Ruby version if the compilation doesn't work.
-    # optional for performance and only necessary if you are using multiple
-    # memcached servers.
-    begin
-      require 'inline'
-      inline do |builder|
-        builder.c <<-EOM
-        int binary_search(VALUE ary, unsigned int r) {
-            long upper = RARRAY_LEN(ary) - 1;
-            long lower = 0;
-            long idx = 0;
-            ID value = rb_intern("value");
-            VALUE continuumValue;
-            unsigned int l;
-
-            while (lower <= upper) {
-                idx = (lower + upper) / 2;
-
-                continuumValue = rb_funcall(RARRAY_PTR(ary)[idx], value, 0);
-                l = NUM2UINT(continuumValue);
-                if (l == r) {
-                    return idx;
-                }
-                else if (l > r) {
-                    upper = idx - 1;
-                }
-                else {
-                    lower = idx + 1;
-                }
-            }
-            return upper;
-        }
-        EOM
-      end
-    rescue LoadError
-      # Find the closest index in the Ring with value <= the given value
-      def binary_search(ary, value)
-        upper = ary.size - 1
-        lower = 0
-        idx = 0
-
-        while (lower <= upper) do
-          idx = (lower + upper) / 2
-          comp = ary[idx].value <=> value
-
-          if comp == 0
-            return idx
-          elsif comp > 0
-            upper = idx - 1
-          else
-            lower = idx + 1
-          end
-        end
-        return upper
-      end
-    end
-
-    class Entry
-      attr_reader :value
-      attr_reader :server
-
-      def initialize(val, srv)
-        @value = val
-        @server = srv
-      end
-    end
-
   end
 end

--- a/test/test_ring.rb
+++ b/test/test_ring.rb
@@ -8,11 +8,7 @@ describe 'Ring' do
       servers = [stub(:name => "localhost:11211", :weight => 1),
                  stub(:name => "localhost:9500", :weight => 1)]
       ring = Dalli::Ring.new(servers, {})
-      previous_value = 0
-      ring.continuum.each do |entry|
-        assert entry.value > previous_value
-        previous_value = entry.value
-      end
+      assert_equal ring.continuum.sort_by { |h| h[:value] }.reverse, ring.continuum
     end
 
     it 'raise when no servers are available/defined' do


### PR DESCRIPTION
Unless there is some plugin or other infrastructure that somehow extends Dalli::Server::Ring, we can greatly simplify the included code.

In any case, I don't see why re-implementing `bsearch` is necessary, maybe I missed something or am missing context. This version performs equally to the previous.

The continuum is now sorted in *descending* rather than *ascending* value order - not sure if anyone is depending on that.