### PR TITLE
Explicitly include the Dalli cache adapter and ActiveSupport::Time

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -16,6 +16,9 @@ puts "Testing with Rails #{Rails.version}"
 require 'dalli'
 require 'logger'
 
+require 'active_support/time'
+require 'active_support/cache/dalli_store'
+
 Dalli.logger = Logger.new(STDOUT)
 Dalli.logger.level = Logger::ERROR
 


### PR DESCRIPTION
Explicitly include the Dalli cache adapter and ActiveSupport::Time to avoid intermittent failures in CI