### PR TITLE
Allow :username and :password as `Rack::Session::Dalli`'s option

### DIFF
--- a/lib/rack/session/dalli.rb
+++ b/lib/rack/session/dalli.rb
@@ -8,7 +8,9 @@ module Rack
 
       DEFAULT_OPTIONS = Abstract::ID::DEFAULT_OPTIONS.merge \
         :namespace => 'rack:session',
-        :memcache_server => 'localhost:11211'
+        :memcache_server => 'localhost:11211',
+        :username => nil,
+        :password => nil
 
       def initialize(app, options={})
         super


### PR DESCRIPTION
This commit makes authentication easier.

Before:
``` ruby
cache = Dalli::Client.new(
  ENV['MEMCACHE_SERVER'],
  {
    username: ENV['MEMCACHE_USERNAME'],
    password: ENV['MEMCACHE_PASSWORD']
  }
)
Rack::Session::Dalli.new(
  cache: cache
)
```

After:
``` ruby
Rack::Session::Dalli.new(
  memcache_server: ENV['MEMCACHE_SERVER'],
  username: ENV['MEMCACHE_USERNAME'],
  password: ENV['MEMCACHE_PASSWORD']
)
```

This is useful for Rails with intuitive API:
``` ruby
Rails.application.config.session_store :mem_cache_store,
  memcache_server: ENV['MEMCACHE_SERVER'],
  username: ENV['MEMCACHE_USERNAME'],
  password: ENV['MEMCACHE_PASSWORD']
```

However I'm not sure how the test should be...