### PR TITLE
Allow Dalli::Client#incr and #decr to take negative numbers

### DIFF
--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -161,7 +161,6 @@ module Dalli
 
     ##
     # Incr adds the given amount to the counter on the memcached server.
-    # Amt must be a positive integer value.
     #
     # If default is nil, the counter must already exist or the operation
     # will fail and will return nil.  Otherwise this method will return
@@ -171,13 +170,17 @@ module Dalli
     # exist.  To increase an existing counter and update its TTL, use
     # #cas.
     def incr(key, amt=1, ttl=nil, default=nil)
-      raise ArgumentError, "Positive values only: #{amt}" if amt < 0
-      perform(:incr, key, amt.to_i, ttl_or_default(ttl), default)
+      meth = :incr
+      if amt < 0
+        meth = :decr
+        amt *= -1
+      end
+
+      perform(meth, key, amt.to_i, ttl_or_default(ttl), default)
     end
 
     ##
     # Decr subtracts the given amount from the counter on the memcached server.
-    # Amt must be a positive integer value.
     #
     # memcached counters are unsigned and cannot hold negative values.  Calling
     # decr on a counter which is 0 will just return 0.
@@ -190,8 +193,13 @@ module Dalli
     # exist.  To decrease an existing counter and update its TTL, use
     # #cas.
     def decr(key, amt=1, ttl=nil, default=nil)
-      raise ArgumentError, "Positive values only: #{amt}" if amt < 0
-      perform(:decr, key, amt.to_i, ttl_or_default(ttl), default)
+      meth = :decr
+      if amt < 0
+        meth = :incr
+        amt *= -1
+      end
+
+      perform(meth, key, amt.to_i, ttl_or_default(ttl), default)
     end
 
     ##


### PR DESCRIPTION
A simple patch to reroute `incr` to `decr` and `decr` to `incr` when negative increments are encountered.