### PR TITLE
Add #cas! method that yields whether or not the key exists

### DIFF
--- a/test/test_dalli.rb
+++ b/test/test_dalli.rb
@@ -271,6 +271,22 @@ describe 'Dalli' do
       end
     end
 
+    it "support the cas! operation" do
+      memcached_persistent do |dc|
+        dc.flush
+
+        mutated = { 'blah' => 'foo!' }
+        resp = dc.cas!('cas_key') do |value|
+          assert_nil value
+          mutated
+        end
+        assert op_cas_succeeds(resp)
+
+        resp = dc.get('cas_key')
+        assert_equal mutated, resp
+      end
+    end
+
     it "support multi-get" do
       memcached_persistent do |dc|
         dc.close


### PR DESCRIPTION
Looking for a variant of the #cas method that yields to the block whether or not the key already exists. This is to avoid having to do things like:

```ruby
result = dc.cas(key) { |oldvalue| newvalue }
result = dc.add(key, newvalue) if result.nil?
```

Thanks in advance.