### PR TITLE
Execute tests for Rails 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ rvm:
 gemfile:
   - gemfiles/rails3.gemfile
   - gemfiles/rails4.gemfile
+  - gemfiles/rails5.gemfile
 matrix:
   exclude:
     - rvm: 2.1.7


### PR DESCRIPTION
Current .travis.yml does not include 'gemfiles/rails5.gemfile' to
gemfile, so tests for Rails 5 are not executed.