### PR TITLE
Fix for issue with socket_max_failures option #610

### DIFF
--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -365,7 +365,7 @@ module Dalli
       rescue NetworkError => e
         Dalli.logger.debug { e.inspect }
         Dalli.logger.debug { "retrying request with new server" }
-        retry
+        raise
       end
     end
 

--- a/lib/dalli/server.rb
+++ b/lib/dalli/server.rb
@@ -62,9 +62,9 @@ module Dalli
 
     # Chokepoint method for instrumentation
     def request(op, *args)
-      verify_state
-      raise Dalli::NetworkError, "#{name} is down: #{@error} #{@msg}. If you are sure it is running, ensure memcached version is > 1.4." unless alive?
       begin
+        verify_state
+        raise Dalli::NetworkError, "#{name} is down: #{@error} #{@msg}. If you are sure it is running, ensure memcached version is > 1.4." unless alive?
         response = send(op, *args)
       rescue Dalli::NetworkError
         connect(false)

--- a/test/test_active_support.rb
+++ b/test/test_active_support.rb
@@ -376,7 +376,7 @@ describe 'ActiveSupport::Cache::DalliStore' do
 
       with_cache port: new_port, :raise_errors => true do
         memcached_kill(new_port)
-        exception = [Dalli::RingError, { :message => "No server available" }]
+        exception = [Dalli::DalliError, { :message => "No server available" }]
 
         silence_logger do
           assert_raises(*exception) { @dalli.read 'foo' }

--- a/test/test_failover.rb
+++ b/test/test_failover.rb
@@ -62,7 +62,7 @@ describe 'failover' do
 
           memcached_kill(second_port)
 
-          assert_raises Dalli::RingError, :message => "No server available" do
+          assert_raises Dalli::NetworkError, :message => "No server available" do
             dc.set 'foo', 'bar'
           end
         end
@@ -100,10 +100,10 @@ describe 'failover' do
 
           memcached_kill(first_port)
 
-          dc.set 'foo', 'foo1'
+          assert_raises(Dalli::NetworkError) { dc.set 'foo', 'foo1' }
           dc.set 'bar', 'bar1'
           result = dc.get_multi ['foo', 'bar']
-          assert_equal result, {'foo' => 'foo1', 'bar' => 'bar1'}
+          assert_equal result, {'bar' => 'bar1'}
 
           memcached_kill(second_port)
 


### PR DESCRIPTION
On every retry, the fail count, down_at time etc are reset in the method "up!" in Server. I have moved the retry trigger from Client#perform to Server#request and disabled reseting of the variables on retry.

Let me know if any modifications are needed.
