### PR TITLE
Add an option to raise an exception when trying to save too much data

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ If serving compressed data using nginx's HttpMemcachedModule, set `memcached_gzi
 
 **value_max_bytes**: The maximum size of a value in memcached.  Defaults to 1MB, this can be increased with memcached's -I parameter.  You must also configure Dalli to allow the larger size here.
 
+**error_when_over_max_size**: Boolean. If true, Dalli will throw a Dalli::ValueOverMaxSize exception when trying to store data larger than **value_max_bytes**. Defaults to false, meaning only a warning is logged.
+
 **username**: The username to use for authenticating this client instance against a SASL-enabled memcached server.  Heroku users should not need to use this normally.
 
 **password**: The password to use for authenticating this client instance against a SASL-enabled memcached server.  Heroku users should not need to use this normally.

--- a/lib/dalli.rb
+++ b/lib/dalli.rb
@@ -19,6 +19,8 @@ module Dalli
   class MarshalError < DalliError; end
   # application error in marshalling deserialization or decompression
   class UnmarshalError < DalliError; end
+  # payload too big for memcached
+  class ValueOverMaxSize < RuntimeError; end
 
   def self.logger
     @logger ||= (rails_logger || default_logger)

--- a/lib/dalli/server.rb
+++ b/lib/dalli/server.rb
@@ -24,6 +24,8 @@ module Dalli
       :socket_failure_delay => 0.01,
       # max size of value in bytes (default is 1 MB, can be overriden with "memcached -I <size>")
       :value_max_bytes => 1024 * 1024,
+      # surpassing value_max_bytes either warns (false) or throws (true)
+      :error_when_over_max_size => false,
       :compressor => Compressor,
       # min byte size to attempt compression
       :compression_min_size => 1024,
@@ -476,7 +478,10 @@ module Dalli
       if value.bytesize <= @options[:value_max_bytes]
         yield
       else
-        Dalli.logger.warn "Value for #{key} over max size: #{@options[:value_max_bytes]} <= #{value.bytesize}"
+        message = "Value for #{key} over max size: #{@options[:value_max_bytes]} <= #{value.bytesize}"
+        raise Dalli::ValueOverMaxSize, message if @options[:error_when_over_max_size]
+
+        Dalli.logger.warn message
         false
       end
     end


### PR DESCRIPTION
When the payload to `set` is larger than `value_max_bytes`, it's currently almost quietly ignored (logs a warning), appearing to have succeeded.

This adds an `fatal_over_max` option (defaulting to false - the previous behaviour), that causes `guard_max_value` to raise a `Dalli::TooBig` exception in such cases, making the failure more explicit and noticeable.

(test failures seem unrelated)

Thoughts, anyone? :)