### PR TITLE
add 'expire_after' in the session, so it is configurable in the app

### DIFF
--- a/lib/rack/session/dalli.rb
+++ b/lib/rack/session/dalli.rb
@@ -55,7 +55,7 @@ module Rack
 
       def set_session(env, session_id, new_session, options)
         return false unless session_id
-        expiry = options[:expire_after]
+        expiry = new_session['expire_after'] || options[:expire_after]
         expiry = expiry.nil? ? 0 : expiry + 1
 
         with_lock(env, false) do


### PR DESCRIPTION
if 'rack.session.options' is set in the app, it can be overriden by the defaults if a middleware returns between the session and the app