### PR TITLE
Change hash syntax to pre 2.0.0

### DIFF
--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -74,7 +74,7 @@ module Dalli
       end
     end
 
-    CACHE_NILS = {cache_nils: true}.freeze
+    CACHE_NILS = {:cache_nils => true}.freeze
 
     # Fetch the value associated with the key.
     # If a value is found, then it is returned.


### PR DESCRIPTION
Changing the hash syntax to pre 2.0.0 will allow this version of the lib to be used in older ruby versions.