### PR TITLE
Handle timestamp TTLs

### DIFF
--- a/lib/dalli/server.rb
+++ b/lib/dalli/server.rb
@@ -481,14 +481,16 @@ module Dalli
       end
     end
 
-    # https://code.google.com/p/memcached/wiki/NewCommands#Standard_Protocol
+    # https://github.com/memcached/memcached/blob/master/doc/protocol.txt#L79
     # > An expiration time, in seconds. Can be up to 30 days. After 30 days, is treated as a unix timestamp of an exact date.
     MAX_ACCEPTABLE_EXPIRATION_INTERVAL = 30*24*60*60 # 30 days
     def sanitize_ttl(ttl)
       ttl_as_i = ttl.to_i
       return ttl_as_i if ttl_as_i <= MAX_ACCEPTABLE_EXPIRATION_INTERVAL
+      now = Time.now.to_i
+      return ttl_as_i if ttl_as_i > now # already a timestamp
       Dalli.logger.debug "Expiration interval (#{ttl_as_i}) too long for Memcached, converting to an expiration timestamp"
-      Time.now.to_i + ttl_as_i
+      now + ttl_as_i
     end
 
     # Implements the NullObject pattern to store an application-defined value for 'Key not found' responses.

--- a/test/test_server.rb
+++ b/test/test_server.rb
@@ -107,5 +107,11 @@ describe Dalli::Server do
       s = Dalli::Server.new('localhost')
       assert_equal s.send(:sanitize_ttl, 30*24*60*60 + 1), Time.now.to_i + 30*24*60*60+1
     end
+
+    it 'does not translate ttls which are already timestamps' do
+      s = Dalli::Server.new('localhost')
+      timestamp_ttl = Time.now.to_i + 60
+      assert_equal s.send(:sanitize_ttl, timestamp_ttl), timestamp_ttl
+    end
   end
 end


### PR DESCRIPTION
Memcached allows expiration times to be specified as either relative to now or as a timestamp.
But since relative times only allows values less than 30 days, the code tried to handle larger valued by converting them to timestamps. This caused actual timestamps to be offset incorrectly.

Now it checks if the values looks like a timestamp (i.e. has a value like a future timestamp) before doing the conversion.