### PR TITLE
Add ValueOverMaxSize to the whitelist of expected exceptions that get re-raised

### DIFF
--- a/lib/dalli/server.rb
+++ b/lib/dalli/server.rb
@@ -68,16 +68,12 @@ module Dalli
       raise Dalli::NetworkError, "#{name} is down: #{@error} #{@msg}. If you are sure it is running, ensure memcached version is > 1.4." unless alive?
       begin
         send(op, *args)
-      rescue Dalli::NetworkError
-        raise
       rescue Dalli::MarshalError => ex
         Dalli.logger.error "Marshalling error for key '#{args.first}': #{ex.message}"
         Dalli.logger.error "You are trying to cache a Ruby object which cannot be serialized to memcached."
         Dalli.logger.error ex.backtrace.join("\n\t")
         false
-      rescue Dalli::DalliError
-        raise
-      rescue Timeout::Error
+      rescue Dalli::DalliError, Dalli::NetworkError, Dalli::ValueOverMaxSize, Timeout::Error
         raise
       rescue => ex
         Dalli.logger.error "Unexpected exception during Dalli request: #{ex.class.name}: #{ex.message}"


### PR DESCRIPTION
This is a follow-up to #612, which doesn't currently behave as expected.

When actually using the `Server` instance as intended through the `request` interface, the `Dalli::ValueOverMaxSize` error was getting swallowed by the final `rescue => ex` branch since it wasn't added to the cases of whitelisted exceptions to re-raise.

Because of the way `test_server.rb` is written (using `send` to test private methods directly), there's unfortunately not really a good way to fix the tests to red/green this without serious refactoring.