### PR TITLE
Adding support for Rails5 CacheStore

### DIFF
--- a/dalli.gemspec
+++ b/dalli.gemspec
@@ -18,11 +18,10 @@ Gem::Specification.new do |s|
   s.rdoc_options = ["--charset=UTF-8"]
   s.add_development_dependency 'minitest', '>= 4.2.0'
   s.add_development_dependency 'mocha'
-  s.add_development_dependency 'rails', '~> 4'
+  s.add_development_dependency 'rails', '>= 4', '< 6'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'appraisal'
   s.add_development_dependency 'connection_pool'
   s.add_development_dependency 'rdoc'
   s.add_development_dependency 'simplecov'
 end
-

--- a/lib/action_dispatch/middleware/session/dalli_store.rb
+++ b/lib/action_dispatch/middleware/session/dalli_store.rb
@@ -1,12 +1,18 @@
 # frozen_string_literal: true
 require 'active_support/cache'
-require 'action_dispatch/middleware/session/abstract_store'
+if defined?(ActionDispatch::Sesssion::CacheStore)
+  # Rails 5 support
+  require 'action_dispatch/middleware/session/cache_store'
+else
+  # Rails 3-4 support
+  require 'action_dispatch/middleware/session/abstract_store'
+end
 require 'dalli'
 
-# Dalli-based session store for Rails 3.0.
+# Dalli-based session store for Rails 3.0, 4.0, and 5.0.
 module ActionDispatch
   module Session
-    class DalliStore < AbstractStore
+    class DalliStore < (defined?(CacheStore) CacheStore : AbstractStore)
       def initialize(app, options = {})
         # Support old :expires option
         options[:expire_after] ||= options[:expires]


### PR DESCRIPTION
Adding support for Rails 5 CacheStore but still sense for Rails3,4 AbstractStore.
