### PR TITLE
Use Ruby 2.3 methods for consistent hash ring

### DIFF
--- a/lib/dalli/ring.rb
+++ b/lib/dalli/ring.rb
@@ -21,7 +21,7 @@ module Dalli
             continuum << Dalli::Ring::Entry.new(value, server)
           end
         end
-        @continuum = continuum.sort { |a, b| a.value <=> b.value }
+        @continuum = continuum.sort_by(&:value)
       end
 
       threadsafe! unless options[:threadsafe] == false
@@ -32,7 +32,13 @@ module Dalli
       if @continuum
         hkey = hash_for(key)
         20.times do |try|
-          entryidx = binary_search(@continuum, hkey)
+          # Find the closest index in the Ring with value <= the given value
+          entryidx = @continuum.bsearch_index { |entry| entry.value > hkey }
+          if entryidx.nil?
+            entryidx = @continuum.size - 1
+          else
+            entryidx -= 1
+          end
           server = @continuum[entryidx].server
           return server if server.alive?
           break unless @failover
@@ -69,64 +75,6 @@ module Dalli
 
     def entry_count_for(server, total_servers, total_weight)
       ((total_servers * POINTS_PER_SERVER * server.weight) / Float(total_weight)).floor
-    end
-
-    # Native extension to perform the binary search within the continuum
-    # space.  Fallback to a pure Ruby version if the compilation doesn't work.
-    # optional for performance and only necessary if you are using multiple
-    # memcached servers.
-    begin
-      require 'inline'
-      inline do |builder|
-        builder.c <<-EOM
-        int binary_search(VALUE ary, unsigned int r) {
-            long upper = RARRAY_LEN(ary) - 1;
-            long lower = 0;
-            long idx = 0;
-            ID value = rb_intern("value");
-            VALUE continuumValue;
-            unsigned int l;
-
-            while (lower <= upper) {
-                idx = (lower + upper) / 2;
-
-                continuumValue = rb_funcall(RARRAY_PTR(ary)[idx], value, 0);
-                l = NUM2UINT(continuumValue);
-                if (l == r) {
-                    return idx;
-                }
-                else if (l > r) {
-                    upper = idx - 1;
-                }
-                else {
-                    lower = idx + 1;
-                }
-            }
-            return upper;
-        }
-        EOM
-      end
-    rescue LoadError
-      # Find the closest index in the Ring with value <= the given value
-      def binary_search(ary, value)
-        upper = ary.size - 1
-        lower = 0
-        idx = 0
-
-        while (lower <= upper) do
-          idx = (lower + upper) / 2
-          comp = ary[idx].value <=> value
-
-          if comp == 0
-            return idx
-          elsif comp > 0
-            upper = idx - 1
-          else
-            lower = idx + 1
-          end
-        end
-        return upper
-      end
     end
 
     class Entry


### PR DESCRIPTION
Since #602 mentions dropping compatibility with old Ruby versions in Dalli 3.0 I thought it would be nice to use some of the new built-in tricks.

This changes replaces the current Dalli::Ring#binary_search method with Ruby's Array#bsearch_index method whilst maintaing compatible hashing. Performance improves 15% compared to the old Ruby implementation. I haven't benchmarked the inline C version, but I wonder how often that's even used considering the undocumented nature of that feature.
