### PR TITLE
Close kgio socket after IO.select timeouts

### DIFF
--- a/lib/dalli/socket.rb
+++ b/lib/dalli/socket.rb
@@ -64,6 +64,9 @@ begin
       sock.server = server
       sock.kgio_wait_writable
       sock
+    rescue Timeout::Error
+      sock.close if sock
+      raise
     end
   end
 
@@ -75,6 +78,9 @@ begin
       sock.server = server
       sock.kgio_wait_writable
       sock
+    rescue Timeout::Error
+      sock.close if sock
+      raise
     end
   end
 


### PR DESCRIPTION
Hello,

I had a trouble that my web application processes stil holds established TCP connections with remote Memcached servers after one `Dalli::Server` downs and `RingError` occurs.

I tried some times and found that when `Dalli::Server::KSocket#kgio_wait_writable` fails with `Timeout::Error`, the created sockets are left and survives after the error.

This patch worked well in my environment.
Though I tried only for TCP socket, I think this patch is applicable for UNIX socket, too.

Thanks,