### PR TITLE
Keep @ring object of Dalli::Client after #close to reuse it on next operation

### DIFF
--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -250,10 +250,20 @@ module Dalli
     ##
     # Close our connection to each server.
     # If you perform another operation after this, the connections will be re-established.
-    def close
+    def close!
       if @ring
         @ring.servers.each { |s| s.close }
         @ring = nil
+      end
+    end
+    alias_method :reset!, :close!
+
+    ##
+    # Close our connection to each server like +#close!+ but do not clear ring
+    # so that one can reuse it for next operation.
+    def close
+      if @ring
+        @ring.servers.each { |s| s.close }
       end
     end
     alias_method :reset, :close


### PR DESCRIPTION
Hello,

In my environment, `Dalli::Ring.new` was a bottleneck for performance.
So I want to reuse `@ring` objects even after `Dalli::Client#close` (or `#reset`) is called.
I already made a monkey-patch in my environment and it works well.

But this change can be a breaking change and will affect so many people.
Second choice is here: https://github.com/petergoldstein/dalli/compare/master...key-amb:topic/reuse-ring
This just makes `Dalli::Client#ring` public so that we can access `@ring` from application codes.