### PR TITLE
ActiveSupport instrument DalliStore errors

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,8 @@
 Dalli Changelog
 =====================
 
+- Instrument DalliStore errors with instrument_errors configuration option. (btatnall)
+
 2.7.6
 ==========
 - Rails 5.0.0.beta2 compatibility (yui-knk, petergoldstein)

--- a/README.md
+++ b/README.md
@@ -194,6 +194,10 @@ If serving compressed data using nginx's HttpMemcachedModule, set `memcached_gzi
 
 **cache_nils**: Boolean. If true Dalli will not treat cached `nil` values as 'not found' for `#fetch` operations. Default is false.
 
+**raise_errors**: Boolean. When true DalliStore will reraise Dalli:DalliError instead swallowing the error. Default is false.
+
+**instrument_errors**: Boolean. When true DalliStore will send notification of Dalli::DalliError via a 'cache_error.active_support' event. Default is false.
+
 Features and Changes
 ------------------------
 

--- a/test/test_active_support.rb
+++ b/test/test_active_support.rb
@@ -394,6 +394,19 @@ describe 'ActiveSupport::Cache::DalliStore' do
     end
 
     describe 'instruments' do
+      it 'notifies errors' do
+        new_port = 29333
+        key = 'foo'
+        with_cache port: new_port, :instrument_errors => true do
+          memcached_kill(new_port)
+          payload_proc = Proc.new { |payload| payload }
+          @dalli.expects(:instrument).with(:read, { :key => key }).yields(&payload_proc).once
+          @dalli.expects(:instrument).with(:error, { :key => "DalliError",
+                                                     :message => "No server available" }).once
+          @dalli.read(key)
+        end
+      end
+
       it 'payload hits' do
         with_cache do
           payload = {}


### PR DESCRIPTION
Previously, one could use raise_errors to either handle execptions
in client code or have them handled by dalli. In the later case,
logging was the only way to be notified of an exception. This
commit adds the ability to be notified via active support
instrumentation via a cache_error.active_support event.

I've added this code because I want to know when errors are
occuring to trigger external monitoring and I still want
dalli to fail without raising errors so that cached values
are still generated.