### PR TITLE
Update down_retry_delay default

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ If serving compressed data using nginx's HttpMemcachedModule, set `memcached_gzi
 
 **socket_failure_delay**: Before retrying a socket operation, the process sleeps for this amount of time. Default is 0.01.  Set to nil for no delay.
 
-**down_retry_delay**: When a server has been marked down due to many failures, the server will be checked again for being alive only after this amount of time. Don't set this value too low, otherwise each request which tries the failed server might hang for the maximum **socket_timeout**. Default is 1 second.
+**down_retry_delay**: When a server has been marked down due to many failures, the server will be checked again for being alive only after this amount of time. Don't set this value too low, otherwise each request which tries the failed server might hang for the maximum **socket_timeout**. Default is 60 seconds.
 
 **value_max_bytes**: The maximum size of a value in memcached.  Defaults to 1MB, this can be increased with memcached's -I parameter.  You must also configure Dalli to allow the larger size here.
 

--- a/lib/dalli/server.rb
+++ b/lib/dalli/server.rb
@@ -15,7 +15,7 @@ module Dalli
     DEFAULT_WEIGHT = 1
     DEFAULTS = {
       # seconds between trying to contact a remote server
-      :down_retry_delay => 1,
+      :down_retry_delay => 60,
       # connect/read/write timeout for socket operations
       :socket_timeout => 0.5,
       # times a socket operation may fail before considering the server dead


### PR DESCRIPTION
Update `down_retry_delay` for #621

I ran into this myself recently. I saw the existing issue and figured I’d throw together a quick pull request since nobody had done anything with this since it was raised back in May of last year.