### PR TITLE
Add Ruby 2.4 to Travis and add ruby-head to Travis as allow_failures.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
 cache: bundler
 rvm:
+  - ruby-head
+  - 2.4.1
   - 2.3.0
   - 2.2.4
   - 2.1.8
@@ -30,7 +32,9 @@ matrix:
     - rvm: jruby
       gemfile: gemfiles/rails4.gemfile
   allow_failures:
+    - rvm: ruby-head
     - rvm: rbx-2
+  fast_finish: true
 env: JRUBY_OPTS='--1.9'
 before_install:
   - gem install bundler


### PR DESCRIPTION
* allow_failures is because it's good to know new version Ruby's issue
  as faster before the release.
* fast_finish is to get the Travis result as faster
  without waiting the result of the "allow_failures" items.
  See https://blog.travis-ci.com/2013-11-27-fast-finishing-builds/

I want to add `ruby-head` as allow_failures in `.travis.yml`.
I think this is useful.
Because we can prepare before next version Ruby 2.5 release.
Though it might not be useful until the actual preview release.
We can support the next version as faster.

We can see this kind of logic in `rails`, `rspec` and `cucumber` and etc.
I think that is the reason why `rails` and `rspec` can support new version Ruby as faster.

https://github.com/rails/rails/blob/master/.travis.yml
https://github.com/rspec/rspec-core/blob/master/.travis.yml
https://github.com/cucumber/cucumber-ruby/blob/master/.travis.yml

Is it possible to add it?

Thanks.
