### PR TITLE
Not found checks no longer trigger the result's equality method

### DIFF
--- a/lib/active_support/cache/dalli_store.rb
+++ b/lib/active_support/cache/dalli_store.rb
@@ -103,13 +103,13 @@ module ActiveSupport
               read_entry(namespaced_name, options).tap do |result|
                 if payload
                   payload[:super_operation] = :fetch
-                  payload[:hit] = result != not_found
+                  payload[:hit] = not_found != result
                 end
               end
             end
           end
 
-          if entry == not_found
+          if not_found == entry
             result = instrument_with_log(:generate, namespaced_name, options) do |payload|
               yield
             end


### PR DESCRIPTION
Triggering the equality method on the result from the fetch can
cause the state of the result object to change, for example if it has
a custom `==` instance method. By reversing the operands we end up
achieving a hit/miss determination but will call `#==` on `nil` or
on `Dalli::Server::NOT_FOUND` if `cache_nils` is `true`. Either way
we won't modify the returned object from the cache before sending it
back to the caller.