### PR TITLE
Travis: use latest JRuby 9.1.15.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ rvm:
   - 2.0.0
   - 1.9.3
   - rbx-2
-  - jruby
-  - jruby-9.0.4.0
+  - jruby-9.1.14.0
 gemfile:
   - gemfiles/rails3.gemfile
   - gemfiles/rails4.gemfile
@@ -25,17 +24,15 @@ matrix:
       gemfile: gemfiles/rails5.gemfile
     - rvm: rbx-2
       gemfile: gemfiles/rails5.gemfile
-    - rvm: jruby
-      gemfile: gemfiles/rails5.gemfile
     - rvm: 1.9.3
-      gemfile: gemfiles/rails4.gemfile
-    - rvm: jruby
       gemfile: gemfiles/rails4.gemfile
   allow_failures:
     - rvm: ruby-head
     - rvm: rbx-2
   fast_finish: true
-env: JRUBY_OPTS='--1.9'
+env:
+  global:
+    - JRUBY_OPTS='--debug'
 before_install:
   - gem install bundler
   - sudo apt-get -y remove memcached

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ rvm:
   - 2.0.0
   - 1.9.3
   - rbx-2
-  - jruby-9.1.14.0
+  - jruby-9.1.15.0
 gemfile:
   - gemfiles/rails3.gemfile
   - gemfiles/rails4.gemfile


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2017/12/07/jruby-9-1-15-0.html

  - drop old JRuby
  - enable JRUBY_OPTS=--debug to have code coverage stats counted