### PR TITLE
Fix memcached 1.5.4 compatibility.

### DIFF
--- a/test/memcached_mock.rb
+++ b/test/memcached_mock.rb
@@ -108,7 +108,7 @@ module MemcachedMock
 
 
     def memcached_low_mem_persistent(port = 19128)
-      dc = start_and_flush_with_retry(port, '-m 1 -M')
+      dc = start_and_flush_with_retry(port, '-m 1 -M -I 512k')
       yield dc, port if block_given?
     end
 


### PR DESCRIPTION
memcached 1.5.4 changed order of evaluation of command line parameters
[1]. As a result, the test suite failed with errors such as:

~~~
$ ruby -Ilib:test -e 'Dir.glob('\''./test/test_*.rb'\'').sort.each{ |x| require x }'
Testing with Rails 5.1.4
Using standard socket IO (ruby 2.5.0p0 (2017-12-25 revision 61468) [x86_64-linux])
Run options: --seed 35324
# Running:
Found memcached 1.5.4 in PATH
.........................................................Cannot set item size limit higher than 1/2 of memory max.
Cannot set item size limit higher than 1/2 of memory max.
F
Failure:
Dalli::using a live server::in low memory conditions#test_0001_handle error response correctly [/builddir/build/BUILD/dalli-2.7.6/usr/share/gems/gems/dalli-2.7.6/test/test_dalli.rb:740]:
unexpected failure on iteration 0
/usr/share/gems/gems/railties-5.1.4/lib/rails/test_unit/reporter.rb:70:in `method': undefined method `test_0001_handle error response correctly' for class `Minitest::Result' (NameError)
~~~

This commit adjust the memcached parameters to make the test suite pass.

[1] https://github.com/memcached/memcached/commit/95246f7947e9d95969d04db0898a93ef66235fb0