### PR TITLE
Don't override generate_sid

### DIFF
--- a/lib/rack/session/dalli.rb
+++ b/lib/rack/session/dalli.rb
@@ -157,18 +157,9 @@ module Rack
         [nil, mserv, mopts, popts]
       end
 
-      # Capture generate_sid's super so we can call it from generate_sid_with
-      alias_method :generate_sid_super, :generate_sid
-
-      def generate_sid
-        # no way to check env['rack.multithread'] here so fall back on
-        # Dalli::Client or ConnectionPool's internal mutex cf. our own
-        @pool.with {|dc| generate_sid_with(dc) }
-      end
-
       def generate_sid_with(dc)
         while true
-          sid = generate_sid_super
+          sid = generate_sid
           break sid unless dc.get(sid)
         end
       end


### PR DESCRIPTION
There's no need to override the generate_sid method and call the super method via an alias because the get_session and destroy_session methods call generate_sid_with directly. This fixes the issue with the Rails subclass of Rack::Session::Dalli which overrides the generate_sid method for compatibility reasons.