### PR TITLE
Prefix Digest::MD5 with :: operator

### DIFF
--- a/lib/active_support/cache/dalli_store.rb
+++ b/lib/active_support/cache/dalli_store.rb
@@ -341,7 +341,7 @@ module ActiveSupport
         namespace = options[:namespace] if options
         prefix = namespace.is_a?(Proc) ? namespace.call : namespace
         key = "#{prefix}:#{key}" if prefix
-        key = "#{key[0, 213]}:md5:#{Digest::MD5.hexdigest(key)}" if key && key.size > 250
+        key = "#{key[0, 213]}:md5:#{::Digest::MD5.hexdigest(key)}" if key && key.size > 250
         key
       end
       alias :normalize_key :namespaced_key


### PR DESCRIPTION
Rails 5.2.0 RC2 throws an "uninitialized constant ActiveSupport::Digest::MD5" error. This is happening because Rails 5.2 has a new class named ActiveSupport::Digest.