### PR TITLE
Introduce new option, instrument_namespace, when running multiple dalli stores

### DIFF
--- a/lib/active_support/cache/dalli_store.rb
+++ b/lib/active_support/cache/dalli_store.rb
@@ -388,6 +388,8 @@ module ActiveSupport
       end
 
       def instrument(operation, payload)
+        payload[:instrument_namespace] = @options[:instrument_namespace] if @options[:instrument_namespace]
+
         ActiveSupport::Notifications.instrument("cache_#{operation}.active_support", payload) do
           yield(payload) if block_given?
         end

--- a/test/test_active_support.rb
+++ b/test/test_active_support.rb
@@ -463,6 +463,18 @@ describe 'ActiveSupport::Cache::DalliStore' do
           @dalli.unstub(:instrument)
         end
       end
+
+      it 'payload with instrument namespace' do
+        with_cache instrument_errors: true, instrument_namespace: "service_007" do
+          ActiveSupport::Notifications.expects(:instrument)
+            .with('cache_read.active_support', {
+              :key => 'burrito',
+              :instrument_namespace => 'service_007',
+            })
+          
+          @dalli.read('burrito')
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Proposal/Feature request PR :).

When we have more than one dalli store implementation in an app,
this option config would allow to subscribe to the same
`ActiveSupport::Notifications` operation(s), but also allow the ability to
segment these through an additional payload key `instrument_namespace`.
Otherwise, we could have the same instrumentation metrics
(`cache_read.active_support`) from different dalli store implementations
and no way to differentiate between  them.