### PR TITLE
Don’t dup string if it’s not the argument

### DIFF
--- a/lib/active_support/cache/dalli_store.rb
+++ b/lib/active_support/cache/dalli_store.rb
@@ -351,6 +351,7 @@ module ActiveSupport
       # called. If the key is a Hash, then keys will be sorted alphabetically.
       def expanded_key(key) # :nodoc:
         return key.cache_key.to_s if key.respond_to?(:cache_key)
+        original_object_id = key.object_id
 
         case key
         when Array
@@ -365,7 +366,7 @@ module ActiveSupport
 
         key = key.to_param
         if key.respond_to? :force_encoding
-          key = key.dup
+          key = key.dup if key.object_id == original_object_id
           key.force_encoding('binary')
         end
         key


### PR DESCRIPTION
The only time to dup a key is if it’s the original value passed in (to prevent mutation). By adding this check I reduced object allocation by about 100 strings per page load in the app https://www.codetriage.com.

Measured using derailed benchmarks:

```
$ RAILS_SERVE_STATIC_FILES=1 RAILS_LOG_TO_STDOUT=1 DEVISE_SECRET_KEY=foo bundle exec derailed exec perf:objects
```

Before:

```
Total allocated: 1003030 bytes (8686 objects)
Total retained:  1608 bytes (13 objects)

allocated memory by gem
-----------------------------------
    250490  activesupport-5.2.1
    164550  dalli/lib
```

After:

```
Total allocated: 1073993 bytes (8586 objects)
Total retained:  1608 bytes (13 objects)

allocated memory by gem
-----------------------------------
    250826  activesupport-5.2.1
    236160  dalli/lib
```

