### PR TITLE
rails 5.2 cache_versioning support

### DIFF
--- a/lib/active_support/cache/dalli_store.rb
+++ b/lib/active_support/cache/dalli_store.rb
@@ -346,10 +346,12 @@ module ActiveSupport
       end
       alias :normalize_key :namespaced_key
 
-      # Expand key to be a consistent string value. Invoke +cache_key+ if
-      # object responds to +cache_key+. Otherwise, to_param method will be
-      # called. If the key is a Hash, then keys will be sorted alphabetically.
+      # Expand key to be a consistent string value. Invokes +cache_key_with_version+
+      # first to support Rails 5.2 cache versioning.
+      # Invoke +cache_key+ if object responds to +cache_key+. Otherwise, to_param method
+      # will be called. If the key is a Hash, then keys will be sorted alphabetically.
       def expanded_key(key) # :nodoc:
+        return key.cache_key_with_version.to_s if key.respond_to?(:cache_key_with_version)
         return key.cache_key.to_s if key.respond_to?(:cache_key)
         original_object_id = key.object_id
 

--- a/test/test_active_support.rb
+++ b/test/test_active_support.rb
@@ -9,6 +9,12 @@ class MockUser
   end
 end
 
+class MockUserVersioning
+  def cache_key_with_version
+    "users/1/241012793847982434"
+  end
+end
+
 class ObjectRaisingEquality
   def ==(other)
     raise "Equality called on fetched object."
@@ -116,6 +122,13 @@ describe 'ActiveSupport::Cache::DalliStore' do
       it_with_and_without_local_cache 'support object with cache_key' do
         user = MockUser.new
         @dalli.write(user.cache_key, false)
+        dvalue = @dalli.fetch(user) { flunk }
+        assert_equal false, dvalue
+      end
+
+      it_with_and_without_local_cache 'support object with cache_key_with_version' do
+        user = MockUserVersioning.new
+        @dalli.write(user.cache_key_with_version, false)
         dvalue = @dalli.fetch(user) { flunk }
         assert_equal false, dvalue
       end


### PR DESCRIPTION
rails 5.2 introduced Recyclable cache keys https://github.com/rails/rails/pull/29092
which means that with Rails.application.config.active_record.cache_versioning = true dalli does not work (#cache_key now returns key without version. We need to use #cache_key_with_version)