### PR TITLE
Show warning message if try to serialize non basic data type objects

### DIFF
--- a/test/test_serializer.rb
+++ b/test/test_serializer.rb
@@ -6,7 +6,7 @@ require 'json'
 describe 'Serializer' do
   it 'default to Marshal' do
     memcached(29198) do |dc|
-      dc.set 1,2
+      dc.set 1, 2
       assert_equal Marshal, dc.instance_variable_get('@ring').servers.first.serializer
     end
   end
@@ -14,7 +14,7 @@ describe 'Serializer' do
   it 'support a custom serializer' do
     memcached(29198) do |dc, port|
       memcache = Dalli::Client.new("127.0.0.1:#{port}", :serializer => JSON)
-      memcache.set 1,2
+      memcache.set 1, 2
       begin
         assert_equal JSON, memcache.instance_variable_get('@ring').servers.first.serializer
 
@@ -23,6 +23,18 @@ describe 'Serializer' do
           assert_equal({"foo" => "bar"}, newdc.get("json_test"))
         end
       end
+    end
+  end
+
+  it "raises warning if try to serialize Ruby Class object" do
+    memcached(29198) do |dc, port|
+      memcache = Dalli::Client.new("127.0.0.1:#{port}", :serializer => JSON)
+      mock = MiniTest::Mock.new
+      mock.expect(:call, nil, ["You're serializing a Ruby Class object which may not be serialized properly. Please convert to basic data type first."])
+      Dalli.logger.stub(:warn, mock) do
+        memcache.set(1, Struct.new(:name).new("name"))
+      end
+      mock.verify
     end
   end
 end


### PR DESCRIPTION
I happen to meet this issue while upgrading Rails from 3 to 4.

Before upgrade, we have:
```
Dalli::Client.new(host, namespace: "namespace", compress: false, serializer: JSON)
```

After upgrade, it stores "weird" data to Memcache, like `"\"#<User:0x007f83dc017248>\""`, instead of `"{\"id\":1,\"name\":\"al\"}"`.

Rails changes are:
+ https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#json-gem-compatibility
+ https://github.com/rails/rails/blob/3-2-stable/activesupport/lib/active_support/core_ext/object/to_json.rb#L15
+ https://github.com/rails/rails/blob/master/activesupport/lib/active_support/core_ext/object/json.rb#L36

I think it'd be better to show a warning message when try to cache non basic data type objects.
BTW, different kinds of JSON serializers have different behaviors. Some of them:

```
struct = Struct.new(:name).new("alex")
JSON.dump(struct) # "\"#<struct name=\\\"alex\\\">\""
Yajl.dump(struct) # "\"#<struct name=\\\"alex\\\">\""
Oj.dump(struct)   # "{\"^u\":[[\"name\"],\"alex\"]}"
```