### PR TITLE
[BUG?] #fetch does not provide a key attribute to the fallback block (but should provide)

### DIFF
--- a/lib/active_support/cache/dalli_store.rb
+++ b/lib/active_support/cache/dalli_store.rb
@@ -111,7 +111,7 @@ module ActiveSupport
 
           if not_found == entry
             result = instrument_with_log(:generate, namespaced_name, options) do |payload|
-              yield
+              yield(name)
             end
             write(name, result, options)
             result

--- a/test/test_active_support.rb
+++ b/test/test_active_support.rb
@@ -77,6 +77,14 @@ describe 'ActiveSupport::Cache::DalliStore' do
         @dalli.fetch('obj') { obj }
       end
 
+      it_with_and_without_local_cache 'fallback block gets a key as a parameter' do
+        key = rand_key
+        o = Object.new
+        o.instance_variable_set :@foo, 'bar'
+        dvalue = @dalli.fetch(key) { |k| "#{k}-#{o}" }
+        assert_equal "#{key}-#{o}", dvalue
+      end
+
       it_with_and_without_local_cache 'support object' do
         o = Object.new
         o.instance_variable_set :@foo, 'bar'


### PR DESCRIPTION
`ActiveSupport::Cache::Storage` abstraction requires that `#fetch`/`#fetch_multi` methods provides a key to the block used for generating entries that does not exist in cache storage (with a given key).

I found that `ActiveSupport::Cache::DalliStore#fetch` missed this logic (in my own project).

This pull request resolves this.

now it works correctly:

```ruby
# INCORRECT:
cache.fetch("a") { |key| "#{key}-calculated" } # in current implementation the key is nil
# => { "a" => "-calculated" }

# CORRECT (pull request)
cache.fetch("a") { |key| "#{key}-calculated" } # in current pull request the key has a corresponding value
# => { "a" => "a-calculated" }

