### PR TITLE
Advertise support for "cache versioning"

### DIFF
--- a/lib/active_support/cache/dalli_store.rb
+++ b/lib/active_support/cache/dalli_store.rb
@@ -9,6 +9,10 @@ module ActiveSupport
       attr_reader :silence, :options
       alias_method :silence?, :silence
 
+      def self.supports_cache_versioning?
+        true
+      end
+
       # Silence the logger.
       def silence!
         @silence = true


### PR DESCRIPTION
Introduced in https://github.com/rails/rails/pull/33943 Rails will attempt to interpret if a cache store supports "cache versioning" by looking for the predicate method `supports_cache_versioning?` on the cache store class. This PR advertises support that was introduced in https://github.com/petergoldstein/dalli/pull/698.