### PR TITLE
Add failing test for frozen string

### DIFF
--- a/test/test_active_support.rb
+++ b/test/test_active_support.rb
@@ -207,6 +207,12 @@ describe 'ActiveSupport::Cache::DalliStore' do
       end
     end
 
+    it 'supports frozen strings' do
+      with_cache do
+        @dalli.read(["foo".freeze])
+      end
+    end
+
     it 'support read_multi with special Regexp characters in namespace' do
       # /(?!)/ is a contradictory PCRE and should never be able to match
       with_cache :namespace => '(?!)' do

--- a/test/test_active_support.rb
+++ b/test/test_active_support.rb
@@ -21,6 +21,12 @@ class ObjectRaisingEquality
   end
 end
 
+class MyToParamIsFrozen
+  def to_param
+    "frozen".freeze
+  end
+end
+
 describe 'ActiveSupport::Cache::DalliStore' do
   # with and without local cache
   def self.it_with_and_without_local_cache(message, &block)
@@ -210,6 +216,12 @@ describe 'ActiveSupport::Cache::DalliStore' do
     it 'supports frozen strings' do
       with_cache do
         @dalli.read(["foo".freeze])
+      end
+    end
+
+    it 'supports frozen strings in more contrived scenarios' do
+      with_cache do
+        @dalli.read(MyToParamIsFrozen.new)
       end
     end
 


### PR DESCRIPTION
A way to reproduce #704 (not necessarily the only way).