### PR TITLE
Dalli error with RubyInline when GCC not present

### DIFF
--- a/lib/dalli/ring.rb
+++ b/lib/dalli/ring.rb
@@ -106,7 +106,7 @@ module Dalli
         }
         EOM
       end
-    rescue LoadError
+    rescue LoadError, ::CompilationError
       # Find the closest index in the Ring with value <= the given value
       def binary_search(ary, value)
         upper = ary.size - 1


### PR DESCRIPTION
When Dalli is used on a system that has RubyInline gem present, but does not have `gcc` then it will fail:


```
sh: 1: gcc: not found
Traceback (most recent call last):
	18: from /app/bin/rails:4:in `<main>'
	17: from /app/bin/rails:4:in `require'
	16: from /app/vendor/bundle/ruby/2.5.0/gems/railties-5.1.4/lib/rails/commands.rb:16:in `<top (required)>'
	15: from /app/vendor/bundle/ruby/2.5.0/gems/railties-5.1.4/lib/rails/command.rb:44:in `invoke'
	14: from /app/vendor/bundle/ruby/2.5.0/gems/railties-5.1.4/lib/rails/command/base.rb:63:in `perform'
	13: from /app/vendor/bundle/ruby/2.5.0/gems/thor-0.20.0/lib/thor.rb:387:in `dispatch'
	12: from /app/vendor/bundle/ruby/2.5.0/gems/thor-0.20.0/lib/thor/invocation.rb:126:in `invoke_command'
	11: from /app/vendor/bundle/ruby/2.5.0/gems/thor-0.20.0/lib/thor/command.rb:27:in `run'
	10: from /app/vendor/bundle/ruby/2.5.0/gems/railties-5.1.4/lib/rails/commands/console/console_command.rb:96:in `perform'
	 9: from /app/vendor/bundle/ruby/2.5.0/gems/railties-5.1.4/lib/rails/command/actions.rb:15:in `require_application_and_environment!'
	 8: from /app/vendor/bundle/ruby/2.5.0/gems/railties-5.1.4/lib/rails/command/actions.rb:15:in `require'
	 7: from /app/config/application.rb:17:in `<top (required)>'
	 6: from /app/vendor/bundle/ruby/2.5.0/gems/bundler-1.15.2/lib/bundler.rb:108:in `require'
	 5: from /app/vendor/bundle/ruby/2.5.0/gems/bundler-1.15.2/lib/bundler/runtime.rb:66:in `require'
	 4: from /app/vendor/bundle/ruby/2.5.0/gems/bundler-1.15.2/lib/bundler/runtime.rb:66:in `each'
	 3: from /app/vendor/bundle/ruby/2.5.0/gems/bundler-1.15.2/lib/bundler/runtime.rb:77:in `block in require'
	 2: from /app/vendor/bundle/ruby/2.5.0/gems/bundler-1.15.2/lib/bundler/runtime.rb:77:in `each'
	 1: from /app/vendor/bundle/ruby/2.5.0/gems/bundler-1.15.2/lib/bundler/runtime.rb:81:in `block (2 levels) in require'
/app/vendor/bundle/ruby/2.5.0/gems/bundler-1.15.2/lib/bundler/runtime.rb:85:in `rescue in block (2 levels) in require': There was an error while trying to load the gem 'dalli'. (Bundler::GemRequireError)
Gem Load Error is: error executing "gcc -shared  -Wl,--compress-debug-sections=zlib -fPIC -O3 -g -Wall -Wextra -Wno-unused-parameter -Wno-parentheses -Wno-long-long -Wno-missing-field-initializers -Wno-tautological-compare -Wno-parentheses-equality -Wno-constant-logical-operand -Wno-self-assign -Wunused-variable -Wimplicit-int -Wpointer-arith -Wwrite-strings -Wdeclaration-after-statement -Wimplicit-function-declaration -Wdeprecated-declarations -Wmisleading-indentation -Wno-packed-bitfield-compat -Wsuggest-attribute=noreturn -Wsuggest-attribute=format -Wimplicit-fallthrough=0 -Wduplicated-cond -Wrestrict -L. -fstack-protector -rdynamic -Wl,-export-dynamic -I /app/vendor/ruby-2.5.1/include/ruby-2.5.0 -I /app/vendor/ruby-2.5.1/include/ruby-2.5.0/x86_64-linux -I /app/vendor/ruby-2.5.1/include -L/app/vendor/ruby-2.5.1/lib -o \"/app/.ruby_inline/ruby-2.5.0/Inline_Dalli__Ring_ca4ff83feb7b263c9bd4987d8e541e30.so\" \"/app/.ruby_inline/ruby-2.5.0/Inline_Dalli__Ring_ca4ff83feb7b263c9bd4987d8e541e30.c\"  ": pid 9 exit 127
Renamed /app/.ruby_inline/ruby-2.5.0/Inline_Dalli__Ring_ca4ff83feb7b263c9bd4987d8e541e30.c to /app/.ruby_inline/ruby-2.5.0/Inline_Dalli__Ring_ca4ff83feb7b263c9bd4987d8e541e30.c.bad
Backtrace for gem load error is:
/app/vendor/bundle/ruby/2.5.0/gems/RubyInline-3.12.4/lib/inline.rb:618:in `build'
/app/vendor/bundle/ruby/2.5.0/gems/RubyInline-3.12.4/lib/inline.rb:856:in `inline'
/app/vendor/bundle/ruby/2.5.0/gems/dalli-2.7.9/lib/dalli/ring.rb:80:in `<class:Ring>'
/app/vendor/bundle/ruby/2.5.0/gems/dalli-2.7.9/lib/dalli/ring.rb:6:in `<module:Dalli>'
/app/vendor/bundle/ruby/2.5.0/gems/dalli-2.7.9/lib/dalli/ring.rb:5:in `<top (required)>'
/app/vendor/bundle/ruby/2.5.0/gems/activesupport-5.1.4/lib/active_support/dependencies.rb:292:in `require'
/app/vendor/bundle/ruby/2.5.0/gems/activesupport-5.1.4/lib/active_support/dependencies.rb:292:in `block in require'
/app/vendor/bundle/ruby/2.5.0/gems/activesupport-5.1.4/lib/active_support/dependencies.rb:258:in `load_dependency'
/app/vendor/bundle/ruby/2.5.0/gems/activesupport-5.1.4/lib/active_support/dependencies.rb:292:in `require'
/app/vendor/bundle/ruby/2.5.0/gems/dalli-2.7.9/lib/dalli.rb:4:in `<top (required)>'
/app/vendor/bundle/ruby/2.5.0/gems/bundler-1.15.2/lib/bundler/runtime.rb:82:in `require'
/app/vendor/bundle/ruby/2.5.0/gems/bundler-1.15.2/lib/bundler/runtime.rb:82:in `block (2 levels) in require'
/app/vendor/bundle/ruby/2.5.0/gems/bundler-1.15.2/lib/bundler/runtime.rb:77:in `each'
/app/vendor/bundle/ruby/2.5.0/gems/bundler-1.15.2/lib/bundler/runtime.rb:77:in `block in require'
/app/vendor/bundle/ruby/2.5.0/gems/bundler-1.15.2/lib/bundler/runtime.rb:66:in `each'
/app/vendor/bundle/ruby/2.5.0/gems/bundler-1.15.2/lib/bundler/runtime.rb:66:in `require'
/app/vendor/bundle/ruby/2.5.0/gems/bundler-1.15.2/lib/bundler.rb:108:in `require'
/app/config/application.rb:17:in `<top (required)>'
/app/vendor/bundle/ruby/2.5.0/gems/railties-5.1.4/lib/rails/command/actions.rb:15:in `require'
/app/vendor/bundle/ruby/2.5.0/gems/railties-5.1.4/lib/rails/command/actions.rb:15:in `require_application_and_environment!'
/app/vendor/bundle/ruby/2.5.0/gems/railties-5.1.4/lib/rails/commands/console/console_command.rb:96:in `perform'
/app/vendor/bundle/ruby/2.5.0/gems/thor-0.20.0/lib/thor/command.rb:27:in `run'
/app/vendor/bundle/ruby/2.5.0/gems/thor-0.20.0/lib/thor/invocation.rb:126:in `invoke_command'
/app/vendor/bundle/ruby/2.5.0/gems/thor-0.20.0/lib/thor.rb:387:in `dispatch'
/app/vendor/bundle/ruby/2.5.0/gems/railties-5.1.4/lib/rails/command/base.rb:63:in `perform'
/app/vendor/bundle/ruby/2.5.0/gems/railties-5.1.4/lib/rails/command.rb:44:in `invoke'
/app/vendor/bundle/ruby/2.5.0/gems/railties-5.1.4/lib/rails/commands.rb:16:in `<top (required)>'
/app/bin/rails:4:in `require'
/app/bin/rails:4:in `<main>'
Bundler Error Backtrace:
```

This can happen on build systems where different packages are available on runtime and build time. Heroku, for example, has gcc at build time but not at runtime. When this happens the user still likely wants to be able to load and utilize Dalli even if there's a compilation error.

This PR also makes the comment more true

> Fallback to a pure Ruby version if the compilation doesn't work.