### PR TITLE
Increase log level of over max size to `error`

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,8 @@
 Dalli Changelog
 =====================
 
+- Increase log level of "over max size" to error (Takumasa Ochi, #715)
+
 2.7.9
 ==========
 - Fix behavior for Rails 5.2+ cache_versioning (GriwMF)

--- a/lib/dalli/server.rb
+++ b/lib/dalli/server.rb
@@ -477,7 +477,9 @@ module Dalli
         message = "Value for #{key} over max size: #{@options[:value_max_bytes]} <= #{value.bytesize}"
         raise Dalli::ValueOverMaxSize, message if @options[:error_when_over_max_size]
 
-        Dalli.logger.warn message
+        Dalli.logger.error message
+        Dalli.logger.error "You are trying to cache a Ruby object which might be truncated by memcached."
+        Dalli.logger.error caller.join("\n\t")
         false
       end
     end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -60,4 +60,14 @@ class MiniTest::Spec
     require 'connection_pool'
     yield
   end
+
+  def with_nil_logger
+    old = Dalli.logger
+    Dalli.logger = Logger.new(nil)
+    begin
+      yield
+    ensure
+      Dalli.logger = old
+    end
+  end
 end

--- a/test/test_dalli.rb
+++ b/test/test_dalli.rb
@@ -120,7 +120,9 @@ describe 'Dalli' do
         dc.flush
 
         val1 = "1234567890"*105000
-        assert_equal false, dc.set('a', val1)
+        with_nil_logger do
+          assert_equal false, dc.set('a', val1)
+        end
 
         val1 = "1234567890"*100000
         dc.set('a', val1)
@@ -698,12 +700,8 @@ describe 'Dalli' do
 
     it "handle application marshalling issues" do
       memcached_persistent do |dc|
-        old = Dalli.logger
-        Dalli.logger = Logger.new(nil)
-        begin
+        with_nil_logger do
           assert_equal false, dc.set('a', Proc.new { true })
-        ensure
-          Dalli.logger = old
         end
       end
     end
@@ -714,7 +712,9 @@ describe 'Dalli' do
           dalli = Dalli::Client.new(dc.instance_variable_get(:@servers), :compress => true)
 
           value = "0"*1024*1024
-          assert_equal false, dc.set('verylarge', value)
+          with_nil_logger do
+            assert_equal false, dc.set('verylarge', value)
+          end
           dalli.set('verylarge', value)
         end
       end

--- a/test/test_server.rb
+++ b/test/test_server.rb
@@ -128,11 +128,11 @@ describe Dalli::Server do
       assert_equal yielded, true
     end
 
-    it 'warns when size is over max' do
+    it 'errors when size is over max' do
       s = Dalli::Server.new('127.0.0.1')
       value = OpenStruct.new(:bytesize => 1_048_577)
 
-      Dalli.logger.expects(:warn).once.with("Value for foo over max size: 1048576 <= 1048577")
+      Dalli.logger.expects(:error).times(3)
 
       s.send(:guard_max_value, :foo, value)
     end


### PR DESCRIPTION
## Summary

This patch increases the log level of over max size from `warn` to `error`.

Temporary errors due to environmental factors should be logged as `warn` while reproducible errors due to program defects should be logged as `error`.

Since saving oversized object is the latter like saving an unserializable object, I have increased the log level.

Also, like an unserializable error, more developer friendly message has been added.


## Other Information

This issue relates to #612.

Although I agree that `raise` help visibility, I want to address the need for `logger.error`.

Most of the Ruby objects which we want to cache by Dalli is NOT fixed-sized string when serialized. This fact implies that whether the value exceeds the specified limit or not depends not only on the code but also on the data. Generally speaking, this data differs depending on (development/staging/production) environments and changes over time.

Now let's assume that we run a production service which uses `Dalli` as a cache. In this scenario, `raise` has a potential risk that in some day the application will blow up when the value is oversized. Since `Dalli` raises exceptions, it directly affects end-users, and we have to deploy the hotfix immediately. (Though we can write additional handling of `ValueOverMaxSize`.)

On the other hand, if we use `logger.error` instead of `raise` in this scenario, we can treat the error just as the other cache failures. When the cache is not mission-critical, cache failures can just be fallen back to the original code. This fallback seems natural and no additional handling is required. Since the amount of error log is proportional to that of cache failure and that of the invoked load thereby, it is not surprising from the viewpoint of system monitoring. We can take appropriate countermeasures within a realistic time without affecting end-users.