### PR TITLE
Log over max size as an error, rather than a warning

### DIFF
--- a/lib/dalli/server.rb
+++ b/lib/dalli/server.rb
@@ -477,7 +477,7 @@ module Dalli
         message = "Value for #{key} over max size: #{@options[:value_max_bytes]} <= #{value.bytesize}"
         raise Dalli::ValueOverMaxSize, message if @options[:error_when_over_max_size]
 
-        Dalli.logger.warn message
+        Dalli.logger.error "#{message} - this value may be truncated by memcached"
         false
       end
     end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -60,4 +60,14 @@ class MiniTest::Spec
     require 'connection_pool'
     yield
   end
+
+  def with_nil_logger
+    old = Dalli.logger
+    Dalli.logger = Logger.new(nil)
+    begin
+      yield
+    ensure
+      Dalli.logger = old
+    end
+  end
 end

--- a/test/test_dalli.rb
+++ b/test/test_dalli.rb
@@ -120,7 +120,9 @@ describe 'Dalli' do
         dc.flush
 
         val1 = "1234567890"*105000
-        assert_equal false, dc.set('a', val1)
+        with_nil_logger do
+          assert_equal false, dc.set('a', val1)
+        end
 
         val1 = "1234567890"*100000
         dc.set('a', val1)
@@ -698,12 +700,8 @@ describe 'Dalli' do
 
     it "handle application marshalling issues" do
       memcached_persistent do |dc|
-        old = Dalli.logger
-        Dalli.logger = Logger.new(nil)
-        begin
+        with_nil_logger do
           assert_equal false, dc.set('a', Proc.new { true })
-        ensure
-          Dalli.logger = old
         end
       end
     end
@@ -714,7 +712,9 @@ describe 'Dalli' do
           dalli = Dalli::Client.new(dc.instance_variable_get(:@servers), :compress => true)
 
           value = "0"*1024*1024
-          assert_equal false, dc.set('verylarge', value)
+          with_nil_logger do
+            assert_equal false, dc.set('verylarge', value)
+          end
           dalli.set('verylarge', value)
         end
       end

--- a/test/test_server.rb
+++ b/test/test_server.rb
@@ -132,7 +132,7 @@ describe Dalli::Server do
       s = Dalli::Server.new('127.0.0.1')
       value = OpenStruct.new(:bytesize => 1_048_577)
 
-      Dalli.logger.expects(:warn).once.with("Value for foo over max size: 1048576 <= 1048577")
+      Dalli.logger.expects(:error).once.with("Value for foo over max size: 1048576 <= 1048577 - this value may be truncated by memcached")
 
       s.send(:guard_max_value, :foo, value)
     end


### PR DESCRIPTION
Rebuilt existing PR #715  on a stable master.  Also retained the error as a single line.

Thanks to @aeroastro for the original PR.