### PR TITLE
Added digest_class configuration option

### DIFF
--- a/lib/active_support/cache/dalli_store.rb
+++ b/lib/active_support/cache/dalli_store.rb
@@ -345,7 +345,7 @@ module ActiveSupport
         namespace = options[:namespace] if options
         prefix = namespace.is_a?(Proc) ? namespace.call : namespace
         key = "#{prefix}:#{key}" if prefix
-        key = "#{key[0, 213]}:md5:#{::Digest::MD5.hexdigest(key)}" if key && key.size > 250
+        key = "#{key[0, 213]}:md5:#{@options[:digest_class].hexdigest(key)}" if key && key.size > 250
         key
       end
       alias :normalize_key :namespaced_key

--- a/test/test_active_support.rb
+++ b/test/test_active_support.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 require_relative 'helper'
 require 'connection_pool'
+require 'openssl'
 
 class MockUser
   def cache_key
@@ -49,6 +50,17 @@ describe 'ActiveSupport::Cache::DalliStore' do
     it 'has accessible options' do
       with_cache :expires_in => 5.minutes, :frob => 'baz' do
         assert_equal 'baz', @dalli.options[:frob]
+      end
+
+      with_cache :expires_in => 5.minutes, :digest_class => OpenSSL::Digest::SHA1 do
+        assert_equal OpenSSL::Digest::SHA1, @dalli.options[:digest_class]
+      end
+    end
+
+    it 'uses valid digest_class option' do
+      with_cache :expires_in => 5.minutes, :digest_class => OpenSSL::Digest::SHA1 do
+        dvalue = @dalli.fetch('a_key') { 123 }
+        assert_equal 123, dvalue
       end
     end
 

--- a/test/test_dalli.rb
+++ b/test/test_dalli.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require_relative 'helper'
+require 'openssl'
 
 describe 'Dalli' do
   describe 'options parsing' do
@@ -32,6 +33,12 @@ describe 'Dalli' do
       dc = Dalli::Client.new('foo', :namespace => Proc.new{:wunderschoen})
       assert_equal "wunderschoen", dc.send(:namespace)
       dc.close
+    end
+
+    it 'raises error with invalid digest_class' do
+      assert_raises ArgumentError do
+        Dalli::Client.new('foo', {:expires_in => 10, :digest_class => Object })
+      end
     end
   end
 
@@ -529,7 +536,7 @@ describe 'Dalli' do
         dc.close
         dc = nil
 
-        dc = Dalli::Client.new("localhost:#{port}")
+        dc = Dalli::Client.new("localhost:#{port}", :digest_class => ::OpenSSL::Digest::SHA1)
 
         assert op_addset_succeeds(dc.set('456', 'xyz', 0, :raw => true))
 


### PR DESCRIPTION
- MD5 is not permitted in FIPS mode, nor is the Digest class. When operating with FIPS mode, only OpenSSL::Digest::SHAxxx is permitted.
-Closes #723