### PR TITLE
Force binary encoding for all keys

### DIFF
--- a/lib/active_support/cache/dalli_store.rb
+++ b/lib/active_support/cache/dalli_store.rb
@@ -355,17 +355,17 @@ module ActiveSupport
       # Invoke +cache_key+ if object responds to +cache_key+. Otherwise, to_param method
       # will be called. If the key is a Hash, then keys will be sorted alphabetically.
       def expanded_key(key) # :nodoc:
-        return key.cache_key_with_version.to_s if key.respond_to?(:cache_key_with_version)
-        return key.cache_key.to_s if key.respond_to?(:cache_key)
-
-        case key
-        when Array
+        if key.respond_to?(:cache_key_with_version)
+          key = key.cache_key_with_version.to_s
+        elsif key.respond_to?(:cache_key)
+          key = key.cache_key.to_s
+        elsif key.is_a?(Array)
           if key.size > 1
             key = key.collect{|element| expanded_key(element)}
           else
             key = key.first
           end
-        when Hash
+        elsif key.is_a?(Hash)
           key = key.sort_by { |k,_| k.to_s }.collect{|k,v| "#{k}=#{v}"}
         end
 


### PR DESCRIPTION
**The problem:** when `key.cache_key` contains Unicode characters, `DalliStore#read_multi` fails.

If a key has a `cache_key` method, chances are it's an ActiveRecord object, and the string value of the key looks something like this:

```
Book.find(1).cache_key
=> "books/1-20180228150237000000000"
```
Currently, Dalli does not call `key.force_encoding('binary')` if `key.respond_to?(:cache_key)`. Usually that's fine because the only alphabetic component of `ar_object.cache_key` is the class name, and Ruby programmers worldwide tend — for whatever reason — to limit their class names to ASCII characters. But Unicode characters _are_ valid in Ruby class names. So if your AR class name contains Unicode, or if (as in our case) you use a custom class that also responds to `cache_key` and sometimes yields keys with Unicode characters, then `read_multi` can fail. What happens is that `DalliStore#expanded_key` does not force the key to binary, so there's a mismatch between the Unicode key in `mapping` vs. the binary key returned from `get_multi`, and the mapping lookup returns `nil` (which trickles down as a `nil` key in the hash returned by `read_multi`!).

In the PR here I propose that we always call `force_encoding`. I can see an argument that we should depend on key object to do that, but the reality is that Rails isn't written that way; in Rails, `cache_key` returns a Unicode string and it's `MemCacheStore`'s job to [force a binary encoding](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/cache/mem_cache_store.rb#L191).