### PR TITLE
Allow instrumentation of ValueOverMaxSize

### DIFF
--- a/lib/dalli.rb
+++ b/lib/dalli.rb
@@ -20,7 +20,7 @@ module Dalli
   # application error in marshalling deserialization or decompression
   class UnmarshalError < DalliError; end
   # payload too big for memcached
-  class ValueOverMaxSize < RuntimeError; end
+  class ValueOverMaxSize < DalliError; end
 
   def self.logger
     @logger ||= (rails_logger || default_logger)


### PR DESCRIPTION
*Problem*:
It is not possible to properly instrument `ValueOverMaxSize` errors

*Reason*: 
In according to https://github.com/petergoldstein/dalli/blob/96da6efdfc3ec634583976351909e9a63bb456c2/lib/active_support/cache/dalli_store.rb#L241 Only subclasses of `DalliError` are instrumented, but `ValueOverMaxSize` is a subclass of [RuntimeError](https://github.com/petergoldstein/dalli/blob/17344b625676bd1aa45f87757e0b718a3e1ae282/lib/dalli.rb#L23)

*Solution*:
Change parent of `ValueOverMaxSize` from `RuntimeError` to `DalliError`