### PR TITLE
Remove appraisal for Rails 3

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,7 +1,3 @@
-appraise 'rails3' do
-  gem 'rails', '>= 3.2.0', '< 4'
-end
-
 appraise 'rails4' do
   gem 'rails', '>= 4.0.0', '< 5'
 end


### PR DESCRIPTION
A gemfile for Rails 3 doesn't exist in `gemfiles/` so I presume that Rails 3 appraisal isn't needed anymore.