### PR TITLE
Normalize comma separated server string in arrays

### DIFF
--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -338,6 +338,8 @@ module Dalli
     def normalize_servers(servers)
       if servers.is_a? String
         return servers.split(",")
+      elsif servers.is_a? Array
+        return servers.map { |server| normalize_servers(server) }.flatten!
       else
         return servers
       end

--- a/test/test_dalli.rb
+++ b/test/test_dalli.rb
@@ -111,6 +111,15 @@ describe 'Dalli' do
     assert_equal "server2.example.com", s2
   end
 
+  it 'accepts comma separated server within array' do
+    servers = ["foo:11211,bar:11211", "localhost:11211"]
+    expectedServers = ["foo", "bar", "localhost"]
+    dc = Dalli::Client.new(servers)
+    ring = dc.send(:ring)
+    assert_equal 3, ring.servers.size
+    assert_equal expectedServers, ring.servers.map(&:hostname)
+  end
+
   it "accept array of servers" do
     dc = Dalli::Client.new(["server1.example.com:11211","server2.example.com:11211"])
     ring = dc.send(:ring)


### PR DESCRIPTION
Currently, explicit configuration using `dalli_store` like:
`config.cache_store = :dalli_store, ENV["MEMCACHE_SERVERS"]` doesn't work with a comma delimited server string.

### Example
```
ENV["MEMCACHE_SERVERS"] = "foo:11211,bar:11211"

ActiveSupport::Cache::DalliStore.new(ENV["MEMCACHE_SERVERS"]) # doesn't work

Dalli::Client.new(ENV["MEMCACHE_SERVERS"]) # works
```
This is because the server string normalization is only performed when the [input argument is a string](https://github.com/petergoldstein/dalli/blob/b895ae1f99eafd542d34662c61ac627b344eed71/lib/dalli/client.rb#L339) but `dalli_store` [passes in an array](https://github.com/petergoldstein/dalli/blob/b895ae1f99eafd542d34662c61ac627b344eed71/lib/active_support/cache/dalli_store.rb#L72) at all times.

This PR adds server normalization for array types as well.

Another way to fix this would be to change `dalli_store` to pass a comma delimited string at all times but it seemed more appropriate to abstract the normalization logic in dalli `client`