### PR TITLE
Pass options hash to Client, Ring, and Server

### DIFF
--- a/lib/dalli/ring.rb
+++ b/lib/dalli/ring.rb
@@ -29,8 +29,10 @@ module Dalli
       @failover = options[:failover] != false
     end
 
-    def server_for_key(key)
+    def server_for_key(key, options = nil)
+      options ||= {}
       if @continuum
+        failover = options.key?(:failover) ? options[:failover] : @failover
         hkey = hash_for(key)
         20.times do |try|
           # Find the closest index in the Ring with value <= the given value
@@ -42,7 +44,7 @@ module Dalli
           end
           server = @continuum[entryidx].server
           return server if server.alive?
-          break unless @failover
+          break unless failover
           hkey = hash_for("#{try}#{key}")
         end
       else

--- a/lib/dalli/server.rb
+++ b/lib/dalli/server.rb
@@ -315,7 +315,7 @@ module Dalli
       cas_response unless multi?
     end
 
-    def delete(key, cas)
+    def delete(key, cas, options = nil)
       req = [REQUEST, OPCODES[multi? ? :deleteq : :delete], key.bytesize, 0, 0, 0, key.bytesize, 0, cas, key].pack(FORMAT[:delete])
       write(req)
       generic_response unless multi?
@@ -327,7 +327,7 @@ module Dalli
       generic_response
     end
 
-    def decr_incr(opcode, key, count, ttl, default)
+    def decr_incr(opcode, key, count, ttl, default, options = nil)
       expiry = default ? sanitize_ttl(ttl) : 0xFFFFFFFF
       default ||= 0
       (h, l) = split(count)
@@ -338,12 +338,12 @@ module Dalli
       body ? body.unpack1("Q>") : body
     end
 
-    def decr(key, count, ttl, default)
-      decr_incr :decr, key, count, ttl, default
+    def decr(key, count, ttl, default, options = nil)
+      decr_incr :decr, key, count, ttl, default, options
     end
 
-    def incr(key, count, ttl, default)
-      decr_incr :incr, key, count, ttl, default
+    def incr(key, count, ttl, default, options = nil)
+      decr_incr :incr, key, count, ttl, default, options
     end
 
     def write_append_prepend(opcode, key, value)
@@ -367,11 +367,11 @@ module Dalli
       multi_response
     end
 
-    def append(key, value)
+    def append(key, value, options = nil)
       write_append_prepend :append, key, value
     end
 
-    def prepend(key, value)
+    def prepend(key, value, options = nil)
       write_append_prepend :prepend, key, value
     end
 
@@ -385,7 +385,7 @@ module Dalli
       write_generic [REQUEST, OPCODES[:stat], "reset".bytesize, 0, 0, 0, "reset".bytesize, 0, 0, "reset"].pack(FORMAT[:stat])
     end
 
-    def cas(key)
+    def cas(key, options = nil)
       req = [REQUEST, OPCODES[:get], key.bytesize, 0, 0, 0, key.bytesize, 0, 0, key].pack(FORMAT[:get])
       write(req)
       data_cas_response
@@ -395,7 +395,7 @@ module Dalli
       write_generic [REQUEST, OPCODES[:version], 0, 0, 0, 0, 0, 0, 0].pack(FORMAT[:noop])
     end
 
-    def touch(key, ttl)
+    def touch(key, ttl, options = nil)
       ttl = sanitize_ttl(ttl)
       write_generic [REQUEST, OPCODES[:touch], key.bytesize, 4, 0, 0, key.bytesize + 4, 0, 0, ttl, key].pack(FORMAT[:touch])
     end


### PR DESCRIPTION
Adds support for passing an `options` Hash from any `Dalli::Client` calls into the downstream `Dalli::Client`, `Dalli::Ring` and `Dalli::Server` methods. This allows callers to pass options like `failover: false` in the cache call itself, rather than having to create a separate Client or Store to enable these options.

Normally this can be achieved by creating a separate Store to get different configuration, but right now there's no way to share connections between Stores. This means if you want a particular call to `failover` and another one to not, the only current option is to double the open connections (one pool for each configured Store).

Currently the `set`, `replace`, `get`, and `add` operations support passing `options`, but the `delete`, `incr`, `decr`, `append`, `prepend`, `cas`, and `touch` operations don't. This PR adds `options` support for these latter operations.

It also adds support for passing `:failover` option per operation, rather than as configuration.

An alternative direction would be to allow creation of new clients that share the same underlying pool of connections, but this is a deeper change as currently the connection pool is at the Store level, as a pool of Clients.