### PR TITLE
DalliStore: Fix default digest_class

### DIFF
--- a/lib/active_support/cache/dalli_store.rb
+++ b/lib/active_support/cache/dalli_store.rb
@@ -341,11 +341,12 @@ module ActiveSupport
       private
 
       def namespaced_key(key, options)
+        digest_class = @options[:digest_class] || ::Digest::MD5
         key = expanded_key(key)
         namespace = options[:namespace] if options
         prefix = namespace.is_a?(Proc) ? namespace.call : namespace
         key = "#{prefix}:#{key}" if prefix
-        key = "#{key[0, 213]}:md5:#{@options[:digest_class].hexdigest(key)}" if key && key.size > 250
+        key = "#{key[0, 213]}:md5:#{digest_class.hexdigest(key)}" if key && key.size > 250
         key
       end
       alias :normalize_key :namespaced_key

--- a/test/test_active_support.rb
+++ b/test/test_active_support.rb
@@ -59,7 +59,16 @@ describe 'ActiveSupport::Cache::DalliStore' do
 
     it 'uses valid digest_class option' do
       with_cache :expires_in => 5.minutes, :digest_class => OpenSSL::Digest::SHA1 do
-        dvalue = @dalli.fetch('a_key') { 123 }
+        key = "k" * 300
+        dvalue = @dalli.fetch(key) { 123 }
+        assert_equal 123, dvalue
+      end
+    end
+
+    it 'uses a fallback digest_class' do
+      with_cache :expires_in => 5.minutes do
+        key = "k" * 300
+        dvalue = @dalli.fetch(key) { 123 }
         assert_equal 123, dvalue
       end
     end


### PR DESCRIPTION
#724 introduced the ability to pass in a `digest_class` option. It also introduced a bug into `DalliStore` where passing a key with a length greater than 250 without passing a `digest_class` option will result in a `NoMethodError: undefined method 'hexdigest' for nil:NilClass` error. This is because there's no fallback specified for this option in DalliStore.

This PR introduces this fallback, and also makes this fallback consistent in the `Dalli::Client` class (rather than mutating the incoming options hash, it uses a fallback in the caller). It also adds a regression test for the bug.