### PR TITLE
Handle nested comma separated servers

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,10 @@
 Dalli Changelog
 =====================
 
+2.7.11
+==========
+- Handle nested comma separated server strings (sambostock)
+
 2.7.10
 ==========
 - Revert frozen string change (schneems)

--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -332,13 +332,15 @@ module Dalli
 
     ##
     # Normalizes the argument into an array of servers.
-    # If the argument is a string, it's expected that the URIs are comma separated e.g.
+    # If the argument is a string, or an array containing strings, it's expected that the URIs are comma separated e.g.
     # "memcache1.example.com:11211,memcache2.example.com:11211,memcache3.example.com:11211"
     def normalize_servers(servers)
-      if servers.is_a? String
-        return servers.split(",")
-      else
-        return servers
+      Array(servers).flat_map do |server|
+        if server.is_a? String
+          server.split(",")
+        else
+          server
+        end
       end
     end
 

--- a/test/test_active_support.rb
+++ b/test/test_active_support.rb
@@ -548,6 +548,16 @@ describe 'ActiveSupport::Cache::DalliStore' do
     assert_equal ["127.0.0.1:11211"], @dalli.instance_variable_get(:@data).instance_variable_get(:@servers)
   end
 
+  it 'normalizes servers passed in as comma separated' do
+    @dalli = ActiveSupport::Cache::DalliStore.new('server1:2,server3:4')
+    assert_equal ['server1:2', 'server3:4'], @dalli.instance_variable_get(:@data).instance_variable_get(:@servers)
+  end
+
+  it 'normalizes servers passed in as comma separated, nested in an array' do
+    @dalli = ActiveSupport::Cache::DalliStore.new(['server1:2,server3:4', 'server5:6'])
+    assert_equal ['server1:2', 'server3:4', 'server5:6'], @dalli.instance_variable_get(:@data).instance_variable_get(:@servers)
+  end
+
   it 'supports connection pooling' do
     with_cache :expires_in => 1, :namespace => 'foo', :compress => true, :pool_size => 3 do
       assert_nil @dalli.read('foo')


### PR DESCRIPTION
This ensures that not only are servers passed as strings split on commas, but also strings nested in an array.

Currently

```ruby
ENV["MEMCACHE_SERVERS"] = "foo:11211,bar:11211"

ActiveSupport::Cache::DalliStore.new(ENV["MEMCACHE_SERVERS"]) # doesn't work

Dalli::Client.new(ENV["MEMCACHE_SERVERS"]) # works
```

This makes the latter work.

