### PR TITLE
Fix Ruby 2.7 keyword arguments deprecation warning

### DIFF
--- a/lib/active_support/cache/dalli_store.rb
+++ b/lib/active_support/cache/dalli_store.rb
@@ -418,7 +418,7 @@ module ActiveSupport
       module LocalCacheEntryUnwrapAndRaw # :nodoc:
         protected
           def read_entry(key, options)
-            retval = super
+            retval = super(key, **options)
             if retval.is_a? ActiveSupport::Cache::Entry
               # Must have come from LocalStore, unwrap it
               if options[:raw]


### PR DESCRIPTION
This fixes the following warnings that are printed when using dalli with Ruby 2.7.1 (on Rails 6.0.3.1):

```
/root/project/vendor/bundle/ruby/2.7.0/gems/dalli-2.7.10/lib/active_support/cache/dalli_store.rb:420: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/root/project/vendor/bundle/ruby/2.7.0/gems/activesupport-6.0.3.1/lib/active_support/cache/strategy/local_cache.rb:122: warning: The called method `read_entry' is defined here
```