### PR TITLE
Document `:mem_cache_store` `$MEMCACHE_SERVERS` incompatibility

### DIFF
--- a/3.0-Upgrade.md
+++ b/3.0-Upgrade.md
@@ -5,6 +5,8 @@ This major version update contains several backwards incompatible changes.
 * **:dalli_store** has been removed. Users should migrate to the
   official Rails **:mem_cache_store**, documented in the [caching
 guide](https://guides.rubyonrails.org/caching_with_rails.html#activesupport-cache-memcachestore).
+  Note that `:mem_cache_store` does _not_ check for `ENV['MEMCACHE_SERVERS']`
+  prior to Rails 6.1, so you may need to explicitly provide it.
 * Attempting to store a larger value than allowed by memcached used to
   print a warning and truncate the value. This now raises an error to
   prevent silent data corruption.

--- a/History.md
+++ b/History.md
@@ -6,6 +6,8 @@ Dalli Changelog
 - DEPRECATION: :dalli_store will be removed in Dalli 3.0.
   Use Rails' official :mem_cache_store instead.
   https://guides.rubyonrails.org/caching_with_rails.html
+  Note that `:mem_cache_store` does _not_ check for `ENV['MEMCACHE_SERVERS']`
+  prior to Rails 6.1, so you may need to explicitly provide it.
 - Add new `digest_class` option to Dalli::Client [#724]
 - Don't treat NameError as a network error [#728]
 - Handle nested comma separated server strings (sambostock)


### PR DESCRIPTION
This adds a warning to `History.md` and `3.0-Upgrade.md` to help prevent mistakes when migrating from `:dalli_store` to `:mem_cache_store`.

`:dalli_store` falls back to `$MEMCACHE_SERVERS` if no addresses are given, whereas `:mem_cache_store` goes straight to `localhost:11211`.

This is not immediately obvious, especially to users not providing any custom options, and makes it easy to accidentally effectively disable caching entirely (if `localhost:11211` is not a memcached server).

Note that rails/rails#40420 would add support for `$MEMCACHE_SERVERS`. Nonetheless, I think it would make sense to get this documentation out ASAP to prevent accidents. If the PR is accepted, it would make sense to follow up with a message mentioning specific Rails versions, once it has made it into a release.