### PR TITLE
Ruby-prof takes an IO object for print nowadays

### DIFF
--- a/test/benchmark_test.rb
+++ b/test/benchmark_test.rb
@@ -11,7 +11,9 @@ def profile(&block)
   prof = RubyProf::Profile.new
   result = prof.profile(&block)
   rep = RubyProf::GraphHtmlPrinter.new(result)
-  rep.print("profile.html")
+  file = File.new("profile.html", "w")
+  rep.print(file)
+  file.close
 end
 
 describe "performance" do


### PR DESCRIPTION
Code as written blows up on latest rubyprof, they changed print to take an IO instead