### PR TITLE
Add gat command support

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,8 @@
 Dalli Changelog
 =====================
 
+- Add gat operation (tbeauvais, #769)
+
 2.7.11
 ==========
 - DEPRECATION: :dalli_store will be removed in Dalli 3.0.

--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -215,6 +215,14 @@ module Dalli
     end
 
     ##
+    # Gat (get and touch) fetch an item and simultaneously update its expiration time.
+    #
+    # If a value is not found, then +nil+ is returned.
+    def gat(key, ttl = nil)
+      perform(:gat, key, ttl_or_default(ttl))
+    end
+
+    ##
     # Collect the stats for each server.
     # You can optionally pass a type including :items, :slabs or :settings to get specific stats
     # Returns a hash like { 'hostname:port' => { 'stat1' => 'value1', ... }, 'hostname2:port' => { ... } }

--- a/lib/dalli/server.rb
+++ b/lib/dalli/server.rb
@@ -400,6 +400,13 @@ module Dalli
       write_generic [REQUEST, OPCODES[:touch], key.bytesize, 4, 0, 0, key.bytesize + 4, 0, 0, ttl, key].pack(FORMAT[:touch])
     end
 
+    def gat(key, ttl, options = nil)
+      ttl = sanitize_ttl(ttl)
+      req = [REQUEST, OPCODES[:gat], key.bytesize, 4, 0, 0, key.bytesize + 4, 0, 0, ttl, key].pack(FORMAT[:gat])
+      write(req)
+      generic_response(true, !!(options && options.is_a?(Hash) && options[:cache_nils]))
+    end
+
     # http://www.hjp.at/zettel/m/memcached_flags.rxml
     # Looks like most clients use bit 0 to indicate native language serialization
     # and bit 1 to indicate gzip compression.
@@ -647,7 +654,8 @@ module Dalli
       auth_negotiation: 0x20,
       auth_request: 0x21,
       auth_continue: 0x22,
-      touch: 0x1C
+      touch: 0x1C,
+      gat: 0x1D
     }
 
     HEADER = "CCnCCnNNQ"
@@ -668,7 +676,8 @@ module Dalli
       prepend: "a*a*",
       auth_request: "a*a*",
       auth_continue: "a*a*",
-      touch: "Na*"
+      touch: "Na*",
+      gat: "Na*"
     }
     FORMAT = OP_FORMAT.each_with_object({}) { |(k, v), memo| memo[k] = HEADER + v; }
 

--- a/test/test_dalli.rb
+++ b/test/test_dalli.rb
@@ -449,6 +449,19 @@ describe "Dalli" do
       end
     end
 
+    it "support gat operation" do
+      memcached_persistent do |dc|
+        dc.flush
+        dc.set "key", "value"
+        assert_equal "value", dc.gat("key", 10)
+        assert_equal "value", dc.gat("key")
+        assert_nil dc.gat("notexist", 10)
+      rescue Dalli::DalliError => e
+        # This will happen when memcached is in lesser version than 1.4.8
+        assert_equal "Response error 129: Unknown command", e.message
+      end
+    end
+
     it "support version operation" do
       memcached_persistent do |dc|
         v = dc.version


### PR DESCRIPTION
Add support for "gat" (get and touch) fetch an item and simultaneously update its expiration time.
See #769