### PR TITLE
Corrected default values in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,13 +80,13 @@ If serving compressed data using nginx's HttpMemcachedModule, set `memcached_gzi
 
 **keepalive**: Boolean. If true, Dalli will enable keep-alive for socket connections.  Default is true.
 
-**socket_timeout**: Timeout for all socket operations (connect, read, write). Default is 0.5.
+**socket_timeout**: Timeout for all socket operations (connect, read, write). Default is 1.
 
 **socket_max_failures**: When a socket operation fails after socket_timeout, the same operation is retried. This is to not immediately mark a server down when there's a very slight network problem. Default is 2.
 
-**socket_failure_delay**: Before retrying a socket operation, the process sleeps for this amount of time. Default is 0.01.  Set to nil for no delay.
+**socket_failure_delay**: Before retrying a socket operation, the process sleeps for this amount of time. Default is 0.1.  Set to nil for no delay.
 
-**down_retry_delay**: When a server has been marked down due to many failures, the server will be checked again for being alive only after this amount of time. Don't set this value too low, otherwise each request which tries the failed server might hang for the maximum **socket_timeout**. Default is 60 seconds.
+**down_retry_delay**: When a server has been marked down due to many failures, the server will be checked again for being alive only after this amount of time. Don't set this value too low, otherwise each request which tries the failed server might hang for the maximum **socket_timeout**. Default is 30 seconds.
 
 **value_max_bytes**: The maximum size of a value in memcached.  Defaults to 1MB, this can be increased with memcached's -I parameter.  You must also configure Dalli to allow the larger size here.
 


### PR DESCRIPTION
This is a follow up for commit ccf55f4bf618d310072667f7049ed39fd1ceed7f