### PR TITLE
Enable SSL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,20 @@ dc.set('abc', 123)
 value = dc.get('abc')
 ```
 
+With SSL enabled:
+```ruby
+require 'dalli'
+ssl_context = OpenSSL::SSL::SSLContext.new
+ssl_context.ca_file = "./myCA.pem"
+ssl_context.ssl_version = :SSLv23
+ssl_context.verify_hostname = true
+ssl_context.verify_mode = OpenSSL::SSL::VERIFY_PEER
+
+dc = Dalli::Client.new("memcached:11212", :ssl_context => ssl_context)
+dc.set("abc", 123)
+value = dc.get("abc")
+```
+
 The test suite requires memcached 1.4.3+ with SASL enabled (`brew install memcached --enable-sasl ; mv /usr/bin/memcached /usr/bin/memcached.old`).  Currently only supports the PLAIN mechanism.
 
 Dalli has no runtime dependencies.

--- a/dalli.gemspec
+++ b/dalli.gemspec
@@ -17,4 +17,5 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/petergoldstein/dalli"
   s.add_development_dependency "rack"
   s.add_development_dependency "connection_pool"
+  s.add_development_dependency "openssl-extensions"
 end

--- a/scripts/install_memcached.sh
+++ b/scripts/install_memcached.sh
@@ -6,6 +6,6 @@ sudo apt-get install libsasl2-dev
 wget https://memcached.org/files/memcached-1.5.22.tar.gz
 tar -zxvf memcached-1.5.22.tar.gz
 cd memcached-1.5.22
-./configure --enable-sasl
+./configure --enable-sasl --enable-tls
 make
 sudo mv memcached /usr/local/bin/

--- a/test/test_dalli.rb
+++ b/test/test_dalli.rb
@@ -42,6 +42,28 @@ describe "Dalli" do
         Dalli::Client.new("foo", {expires_in: 10, digest_class: Object})
       end
     end
+
+    it "opens a standard TCP connection" do
+      memcached_persistent do |dc|
+        server = dc.send(:ring).servers.first
+        sock = Dalli::Socket::TCP.open(server.hostname, server.port, server, server.options)
+        assert_equal Dalli::Socket::TCP, sock.class
+
+        dc.set("abc", 123)
+        assert_equal(123, dc.get("abc"))
+      end
+    end
+
+    it "opens a SSL TCP connection" do
+      memcached_ssl_persistent do |dc|
+        server = dc.send(:ring).servers.first
+        sock = Dalli::Socket::TCP.open(server.hostname, server.port, server, server.options)
+        assert_equal Dalli::Socket::SSLSocket, sock.class
+
+        dc.set("abc", 123)
+        assert_equal(123, dc.get("abc"))
+      end
+    end
   end
 
   describe "key validation" do


### PR DESCRIPTION
Running a server with:
`memcached -Z -p 11212 -o ssl_chain_cert=./memcached.crt -o ssl_key=./memcached.key`

The client configuration is as follows:
```ruby
require 'dalli'
ssl_context = OpenSSL::SSL::SSLContext.new
ssl_context.ca_file = "./myCA.pem"
ssl_context.ssl_version = :SSLv23
ssl_context.verify_hostname = true
ssl_context.verify_mode = OpenSSL::SSL::VERIFY_PEER

d = Dalli::Client.new("memcached:11212", :ssl_context => ssl_context)
d.get("abc")
```