### PR TITLE
Allow to initialize Client with just options and default server

### DIFF
--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -31,9 +31,14 @@ module Dalli
     # - :cache_nils - defaults to false, if true Dalli will not treat cached nil values as 'not found' for #fetch operations.
     # - :digest_class - defaults to Digest::MD5, allows you to pass in an object that responds to the hexdigest method, useful for injecting a FIPS compliant hash object.
     #
-    def initialize(servers = nil, options = {})
+    def initialize(servers = nil, options = nil)
+      if options.nil? && servers.is_a?(Hash)
+        options = servers
+        servers = nil
+      end
+
       @servers = normalize_servers(servers || ENV["MEMCACHE_SERVERS"] || "127.0.0.1:11211")
-      @options = normalize_options(options)
+      @options = normalize_options(options || {})
       @ring = nil
     end
 

--- a/test/test_dalli.rb
+++ b/test/test_dalli.rb
@@ -104,6 +104,16 @@ describe "Dalli" do
     assert_equal s2, s3
   end
 
+  it "can set options with default server" do
+    dc = Dalli::Client.new(compress: true)
+    assert dc.instance_variable_get(:@options)[:compress]
+
+    ring = dc.send(:ring)
+    assert_equal 1, ring.servers.size
+    s1 = ring.servers.first.hostname
+    assert_equal "127.0.0.1", s1
+  end
+
   it "accept comma separated string" do
     dc = Dalli::Client.new("server1.example.com:11211,server2.example.com:11211")
     ring = dc.send(:ring)


### PR DESCRIPTION
If you try to specify options without a server, you get confusing errors - until you notice that your options were interpreted as servers (with hash converted to an array). 

```
irb(main):011:0> m = Dalli::Client.new(namespace: "test")
=> #<Dalli::Client:0x000000009a9c5820 @servers=[:namespace, "test"], @options={}, @ring=nil>
irb(main):012:0> m.get("foo")
Dalli::Server#connect namespace:11211
namespace:11211 failed (count: 0) SocketError: getaddrinfo: hostname nor servname provided, or not known
Dalli::Server#connect namespace:11211
namespace:11211 failed (count: 1) SocketError: getaddrinfo: hostname nor servname provided, or not known
namespace:11211 is down
Dalli::Server#connect test:11211
test:11211 failed (count: 0) SocketError: getaddrinfo: hostname nor servname provided, or not known
Dalli::Server#connect test:11211
test:11211 failed (count: 1) SocketError: getaddrinfo: hostname nor servname provided, or not known
test:11211 is down
down_retry_delay not reached for test:11211 (60.000 seconds left)
down_retry_delay not reached for namespace:11211 (59.989 seconds left)
down_retry_delay not reached for namespace:11211 (59.989 seconds left)
down_retry_delay not reached for namespace:11211 (59.988 seconds left)
down_retry_delay not reached for test:11211 (60.000 seconds left)
down_retry_delay not reached for namespace:11211 (59.988 seconds left)
down_retry_delay not reached for test:11211 (59.999 seconds left)
down_retry_delay not reached for namespace:11211 (59.988 seconds left)
down_retry_delay not reached for namespace:11211 (59.988 seconds left)
down_retry_delay not reached for namespace:11211 (59.988 seconds left)
down_retry_delay not reached for test:11211 (59.999 seconds left)
down_retry_delay not reached for test:11211 (59.999 seconds left)
down_retry_delay not reached for namespace:11211 (59.987 seconds left)
down_retry_delay not reached for namespace:11211 (59.987 seconds left)
down_retry_delay not reached for test:11211 (59.998 seconds left)
down_retry_delay not reached for namespace:11211 (59.987 seconds left)
Traceback (most recent call last):
Dalli::RingError (No server available)
```

You can work around that by passing nil as the first argument:`Dalli::Client.new(nil, namespace: "test")`. But this small patch will solve the issue altogether and make Client more intuitive to use.