### PR TITLE
Raise NetworkError and reconnect when multi_response_nonblock is unexpectedly called

### DIFF
--- a/lib/dalli/server.rb
+++ b/lib/dalli/server.rb
@@ -145,7 +145,7 @@ module Dalli
     #
     # Returns a Hash of kv pairs received.
     def multi_response_nonblock
-      raise "multi_response has completed" if @multi_buffer.nil?
+      reconnect! "multi_response has completed" if @multi_buffer.nil?
 
       @multi_buffer << @sock.read_available
       buf = @multi_buffer

--- a/test/test_server.rb
+++ b/test/test_server.rb
@@ -191,4 +191,24 @@ describe Dalli::Server do
       end
     end
   end
+
+  describe "multi_response_nonblock" do
+    subject { Dalli::Server.new("127.0.0.1") }
+
+    it "raises NetworkError when called before multi_response_start" do
+      assert_raises Dalli::NetworkError do
+        subject.request(:send_multiget, ["a", "b"])
+        subject.multi_response_nonblock
+      end
+    end
+
+    it "raises NetworkError when called after multi_response_abort" do
+      assert_raises Dalli::NetworkError do
+        subject.request(:send_multiget, ["a", "b"])
+        subject.multi_response_start
+        subject.multi_response_abort
+        subject.multi_response_nonblock
+      end
+    end
+  end
 end


### PR DESCRIPTION
When an elasticache node is rebooted, it seems to send invalid response headers that cause dalli to think that the multiget response has completed, when there is actually still data queued up in the socket.

This causes dalli to raise `RuntimeError, "multi_response has completed"`, which is acceptable behavior. However, the problem is that the data queued up in the socket then **leaks into subsequent responses**.

It is unclear if this is an elasticache-specific bug. This may be related to the issue reported in #390.

To work around this issue, raise NetworkError and reconnect whenever we run into this state. The multiget response will be incomplete but it seems like this is being addressed in #754.

Other possible solutions:

- Call `down!` - this also works, but may cause the server to be marked as down for a longer time than necessary.
- Attempt to drain the socket when this happens - seems like a rather more complicated fix.