### PR TITLE
Fix SyntaxError: unterminated string meets end of file

### DIFF
--- a/lib/dalli/cas/client.rb
+++ b/lib/dalli/cas/client.rb
@@ -1,1 +1,1 @@
-puts "You can remove `require 'dalli/cas/client'` as this code has been rolled into the standard 'dalli/client'.
+puts "You can remove `require 'dalli/cas/client'` as this code has been rolled into the standard 'dalli/client'."


### PR DESCRIPTION
This is meant to be a deprecation warning, but currently any code that loads this file will raise a SyntaxError.