### PR TITLE
Restore `with` method for compatibility with existing Rails code

### DIFF
--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -324,6 +324,11 @@ module Dalli
     end
     alias_method :reset, :close
 
+    # Stub method so a bare Dalli client can pretend to be a connection pool.
+    def with
+      yield self
+    end
+
     private
 
     def cas_core(key, always_set, ttl = nil, options = nil)

--- a/test/test_dalli.rb
+++ b/test/test_dalli.rb
@@ -742,5 +742,14 @@ describe "Dalli" do
       end
     end
 
+    it "supports the with method" do
+      memcached_persistent do |dc|
+        dc.with { |c| c.set("some_key", "some_value") }
+        assert_equal "some_value", dc.get("some_key")
+
+        dc.with { |c| c.delete("some_key") }
+        assert_nil dc.get("some_key")
+      end
+    end
   end
 end


### PR DESCRIPTION
This is intended to address #766 