### PR TITLE
Split out the server string configuration parsing logic from Dalli::Protocol::Binary

### DIFF
--- a/lib/dalli.rb
+++ b/lib/dalli.rb
@@ -5,6 +5,7 @@ require "dalli/client"
 require "dalli/ring"
 require "dalli/protocol"
 require "dalli/protocol/binary"
+require "dalli/protocol/server_config_parser"
 require 'dalli/protocol/value_compressor'
 require "dalli/socket"
 require "dalli/version"

--- a/lib/dalli/protocol/server_config_parser.rb
+++ b/lib/dalli/protocol/server_config_parser.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Dalli
+  module Protocol
+    ##
+    # Dalli::Protocol::ServerConfigParser parses a server string passed to
+    # a Dalli::Protocol::Binary instance into the hostname, port, weight, and
+    # socket_type.
+    ##
+    class ServerConfigParser
+      # TODO: Revisit this, especially the IP/domain part.  Likely
+      # can limit character set to LDH + '.'.  Hex digit section
+      # appears to have been added to support IPv6, but as far as
+      # I can tell it doesn't work
+      SERVER_CONFIG_REGEXP = /\A(\[([\h:]+)\]|[^:]+)(?::(\d+))?(?::(\d+))?\z/.freeze
+
+      DEFAULT_PORT = 11_211
+      DEFAULT_WEIGHT = 1
+
+      def self.parse(str)
+        res = deconstruct_string(str)
+
+        hostname = normalize_hostname(str, res)
+        if hostname.start_with?('/')
+          socket_type = :unix
+          port, weight = attributes_for_unix_socket(res)
+        else
+          socket_type = :tcp
+          port, weight = attributes_for_tcp_socket(res)
+        end
+        [hostname, port, weight, socket_type]
+      end
+
+      def self.deconstruct_string(str)
+        mtch = str.match(SERVER_CONFIG_REGEXP)
+        raise Dalli::DalliError, "Could not parse hostname #{str}" if mtch.nil? || mtch[1] == '[]'
+
+        mtch
+      end
+
+      def self.attributes_for_unix_socket(res)
+        # in case of unix socket, allow only setting of weight, not port
+        raise Dalli::DalliError, "Could not parse hostname #{res[0]}" if res[4]
+
+        [nil, normalize_weight(res[3])]
+      end
+
+      def self.attributes_for_tcp_socket(res)
+        [normalize_port(res[3]), normalize_weight(res[4])]
+      end
+
+      def self.normalize_hostname(str, res)
+        raise Dalli::DalliError, "Could not parse hostname #{str}" if res.nil? || res[1] == '[]'
+
+        res[2] || res[1]
+      end
+
+      def self.normalize_port(port)
+        Integer(port || DEFAULT_PORT)
+      end
+
+      def self.normalize_weight(weight)
+        Integer(weight || DEFAULT_WEIGHT)
+      end
+    end
+  end
+end

--- a/test/protocol/test_server_config_parser.rb
+++ b/test/protocol/test_server_config_parser.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require_relative '../helper'
+
+describe Dalli::Protocol::ServerConfigParser do
+  describe 'parse' do
+    let(:port) { rand(9999..99_999) }
+    let(:weight) { rand(1..5) }
+
+    describe 'tcp' do
+      describe 'when the hostname is a domain name' do
+        let(:hostname) { "a#{SecureRandom.hex(5)}.b#{SecureRandom.hex(3)}.#{%w[net com edu].sample}" }
+
+        it 'parses a hostname by itself' do
+          assert_equal Dalli::Protocol::ServerConfigParser.parse(hostname), [hostname, 11_211, 1, :tcp]
+        end
+
+        it 'parses hostname with a port' do
+          assert_equal Dalli::Protocol::ServerConfigParser.parse("#{hostname}:#{port}"), [hostname, port, 1, :tcp]
+        end
+
+        it 'parses hostname with a port and weight' do
+          assert_equal Dalli::Protocol::ServerConfigParser.parse("#{hostname}:#{port}:#{weight}"),
+                       [hostname, port, weight, :tcp]
+        end
+      end
+
+      describe 'when the hostname is an IPv4 address' do
+        let(:hostname) { '203.0.113.28' }
+
+        it 'parses a hostname by itself' do
+          assert_equal Dalli::Protocol::ServerConfigParser.parse(hostname), [hostname, 11_211, 1, :tcp]
+        end
+
+        it 'parses hostname with a port' do
+          assert_equal Dalli::Protocol::ServerConfigParser.parse("#{hostname}:#{port}"), [hostname, port, 1, :tcp]
+        end
+
+        it 'parses hostname with a port and weight' do
+          assert_equal Dalli::Protocol::ServerConfigParser.parse("#{hostname}:#{port}:#{weight}"),
+                       [hostname, port, weight, :tcp]
+        end
+      end
+    end
+
+    describe 'unix' do
+      let(:hostname) { "/tmp/#{SecureRandom.hex(5)}" }
+
+      it 'parses a socket by itself' do
+        assert_equal Dalli::Protocol::ServerConfigParser.parse(hostname), [hostname, nil, 1, :unix]
+      end
+
+      it 'parses socket with a weight' do
+        assert_equal Dalli::Protocol::ServerConfigParser.parse("#{hostname}:#{weight}"), [hostname, nil, weight, :unix]
+      end
+
+      it 'produces an error with a port and weight' do
+        err = assert_raises Dalli::DalliError do
+          Dalli::Protocol::ServerConfigParser.parse("#{hostname}:#{port}:#{weight}")
+        end
+        assert_equal err.message, "Could not parse hostname #{hostname}:#{port}:#{weight}"
+      end
+    end
+
+    describe 'errors' do
+      describe 'when the string is empty' do
+        it 'produces an error' do
+          err = assert_raises Dalli::DalliError do
+            Dalli::Protocol::ServerConfigParser.parse('')
+          end
+          assert_equal err.message, 'Could not parse hostname '
+        end
+      end
+
+      describe 'when the string starts with a colon' do
+        it 'produces an error' do
+          err = assert_raises Dalli::DalliError do
+            Dalli::Protocol::ServerConfigParser.parse(':1:2')
+          end
+          assert_equal err.message, 'Could not parse hostname :1:2'
+        end
+      end
+
+      describe 'when the string ends with a colon' do
+        it 'produces an error' do
+          err = assert_raises Dalli::DalliError do
+            Dalli::Protocol::ServerConfigParser.parse('abc.com:')
+          end
+          assert_equal err.message, 'Could not parse hostname abc.com:'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This change serves two purposes:

1. Reducing the scope of an individual class, bringing it closer to SRP.
2. Enabling reuse of the logic in a future meta protocol implementation