### PR TITLE
Split out TTL sanitization from the binary protocol.

### DIFF
--- a/lib/dalli.rb
+++ b/lib/dalli.rb
@@ -6,6 +6,7 @@ require "dalli/ring"
 require "dalli/protocol"
 require "dalli/protocol/binary"
 require "dalli/protocol/server_config_parser"
+require "dalli/protocol/ttl_sanitizer"
 require 'dalli/protocol/value_compressor'
 require "dalli/socket"
 require "dalli/version"

--- a/lib/dalli/protocol/ttl_sanitizer.rb
+++ b/lib/dalli/protocol/ttl_sanitizer.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Dalli
+  module Protocol
+    ##
+    # Utility class for sanitizing TTL arguments based on Memcached rules.
+    # TTLs are either expirations times in seconds (with a maximum value of
+    # 30 days) or expiration timestamps.  This class sanitizes TTLs to ensure
+    # they meet those restrictions.
+    ##
+    class TtlSanitizer
+      # https://github.com/memcached/memcached/blob/master/doc/protocol.txt#L79
+      # > An expiration time, in seconds. Can be up to 30 days. After 30 days, is
+      #   treated as a unix timestamp of an exact date.
+      MAX_ACCEPTABLE_EXPIRATION_INTERVAL = 30 * 24 * 60 * 60 # 30 days
+
+      # Ensures the TTL passed to Memcached is a valid TTL in the expected format.
+      def self.sanitize(ttl)
+        ttl_as_i = ttl.to_i
+        return ttl_as_i if less_than_max_expiration_interval?(ttl_as_i)
+
+        as_timestamp(ttl_as_i)
+      end
+
+      def self.less_than_max_expiration_interval?(ttl_as_i)
+        ttl_as_i <= MAX_ACCEPTABLE_EXPIRATION_INTERVAL
+      end
+
+      def self.as_timestamp(ttl_as_i)
+        now = current_timestamp
+        return ttl_as_i if ttl_as_i > now # Already a timestamp
+
+        Dalli.logger.debug "Expiration interval (#{ttl_as_i}) too long for Memcached " \
+                           'and too short to be a future timestamp,' \
+                           'converting to an expiration timestamp'
+        now + ttl_as_i
+      end
+
+      # Pulled out into a method so it's easy to stub time
+      def self.current_timestamp
+        Time.now.to_i
+      end
+    end
+  end
+end

--- a/test/protocol/test_ttl_sanitizer.rb
+++ b/test/protocol/test_ttl_sanitizer.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require_relative '../helper'
+
+describe Dalli::Protocol::TtlSanitizer do
+  describe 'sanitize' do
+    subject { Dalli::Protocol::TtlSanitizer.sanitize(arg_value) }
+
+    describe 'when the argument is an integer' do
+      let(:arg_value) { arg_value_as_i }
+
+      describe 'when the value is less than 30 days in seconds' do
+        let(:arg_value_as_i) { rand(30 * 24 * 60 * 60 + 1) }
+
+        it 'just returns the value' do
+          assert_equal subject, arg_value_as_i
+        end
+      end
+
+      describe 'when the value is more than 30 days in seconds, but less than the current timestamp' do
+        let(:arg_value_as_i) { (30 * 24 * 60 * 60) + 1 + rand(100 * 24 * 60 * 60) }
+        let(:now) { 1_634_706_177 }
+
+        it 'converts to a future timestamp' do
+          Dalli::Protocol::TtlSanitizer.stub :current_timestamp, now do
+            assert_equal subject, arg_value_as_i + now
+          end
+        end
+      end
+
+      describe 'when the value is more than the current timestamp' do
+        let(:now) { 1_634_706_177 }
+        let(:arg_value_as_i) { now + 1 + rand(100 * 24 * 60 * 60) }
+
+        it 'just returns the value' do
+          Dalli::Protocol::TtlSanitizer.stub :current_timestamp, now do
+            assert_equal subject, arg_value_as_i
+          end
+        end
+      end
+    end
+
+    describe 'when the argument is a string' do
+      let(:arg_value) { arg_value_as_i.to_s }
+
+      describe 'when the value is less than 30 days in seconds' do
+        let(:arg_value_as_i) { rand(30 * 24 * 60 * 60 + 1) }
+
+        it 'just returns the value' do
+          assert_equal subject, arg_value_as_i
+        end
+      end
+
+      describe 'when the value is more than 30 days in seconds, but less than the current timestamp' do
+        let(:arg_value_as_i) { (30 * 24 * 60 * 60) + 1 + rand(100 * 24 * 60 * 60) }
+        let(:now) { 1_634_706_177 }
+
+        it 'converts to a future timestamp' do
+          Dalli::Protocol::TtlSanitizer.stub :current_timestamp, now do
+            assert_equal subject, arg_value_as_i + now
+          end
+        end
+      end
+
+      describe 'when the value is more than the current timestamp' do
+        let(:now) { 1_634_706_177 }
+        let(:arg_value_as_i) { now + 1 + rand(100 * 24 * 60 * 60) }
+
+        it 'just returns the value' do
+          Dalli::Protocol::TtlSanitizer.stub :current_timestamp, now do
+            assert_equal subject, arg_value_as_i
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/test_binary_protocol.rb
+++ b/test/test_binary_protocol.rb
@@ -98,24 +98,6 @@ describe Dalli::Protocol::Binary do
     end
   end
 
-  describe "ttl translation" do
-    it "does not translate ttls under 30 days" do
-      s = Dalli::Protocol::Binary.new("localhost")
-      assert_equal s.send(:sanitize_ttl, 30 * 24 * 60 * 60), 30 * 24 * 60 * 60
-    end
-
-    it "translates ttls over 30 days into timestamps" do
-      s = Dalli::Protocol::Binary.new("localhost")
-      assert_equal s.send(:sanitize_ttl, 30 * 24 * 60 * 60 + 1), Time.now.to_i + 30 * 24 * 60 * 60 + 1
-    end
-
-    it "does not translate ttls which are already timestamps" do
-      s = Dalli::Protocol::Binary.new("localhost")
-      timestamp_ttl = Time.now.to_i + 60
-      assert_equal s.send(:sanitize_ttl, timestamp_ttl), timestamp_ttl
-    end
-  end
-
   describe "guard_max_value" do
     it "throws when size is over max" do
       s = Dalli::Protocol::Binary.new("127.0.0.1")


### PR DESCRIPTION
This changes serves two purposes:

1. Reduce the scope of the Dalli::Protocol::Binary class, driving closer to SRP
2. Enable reuse of this logic by a meta implemenation