### PR TITLE
Extracts key validation and namespace handling from the Dalli client.

### DIFF
--- a/lib/dalli.rb
+++ b/lib/dalli.rb
@@ -2,6 +2,7 @@
 
 require "dalli/compressor"
 require "dalli/client"
+require "dalli/key_manager"
 require "dalli/ring"
 require "dalli/protocol"
 require "dalli/protocol/binary"

--- a/lib/dalli/key_manager.rb
+++ b/lib/dalli/key_manager.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require 'digest/md5'
+
+module Dalli
+  ##
+  # This class manages and validates keys send to Memcached, ensuring
+  # that they meet Memcached key length requirements, and supporting
+  # the implementation of optional namespaces on a per-Dalli client
+  # basis.
+  ##
+  class KeyManager
+    MAX_KEY_LENGTH = 250
+
+    NAMESPACE_SEPARATOR = ':'
+
+    # This is a hard coded md5 for historical reasons
+    TRUNCATED_KEY_SEPARATOR = ':md5:'
+
+    # This is 249 for historical reasons
+    TRUNCATED_KEY_TARGET_SIZE = 249
+
+    DEFAULTS = {
+      digest_class: ::Digest::MD5
+    }.freeze
+
+    OPTIONS = %i[digest_class namespace].freeze
+
+    attr_reader :namespace
+
+    def initialize(client_options)
+      @key_options =
+        DEFAULTS.merge(client_options.select { |k, _| OPTIONS.include?(k) })
+      validate_digest_class_option(@key_options)
+
+      @namespace = namespace_from_options
+    end
+
+    ##
+    # Validates the key, and transforms as needed.
+    #
+    # If the key is nil or empty, raises ArgumentError.  Whitespace
+    # characters are allowed for historical reasons, but likely shouldn't
+    # be used.
+    # If the key (with namespace) is shorter than the memcached maximum
+    # allowed key length, just returns the argument key
+    # Otherwise computes a "truncated" key that uses a truncated prefix
+    # combined with a 32-byte hex digest of the whole key.
+    ##
+    def validate_key(key)
+      raise ArgumentError, 'key cannot be blank' unless key&.length&.positive?
+
+      key = key_with_namespace(key)
+      key.length > MAX_KEY_LENGTH ? truncated_key(key) : key
+    end
+
+    ##
+    # Returns the key with the namespace prefixed, if a namespace is
+    # defined.  Otherwise just returns the key
+    ##
+    def key_with_namespace(key)
+      return key if namespace.nil?
+
+      "#{namespace}#{NAMESPACE_SEPARATOR}#{key}"
+    end
+
+    def key_without_namespace(key)
+      return key if namespace.nil?
+
+      key.sub(namespace_regexp, '')
+    end
+
+    def digest_class
+      @digest_class ||= @key_options[:digest_class]
+    end
+
+    def namespace_regexp
+      @namespace_regexp ||= /\A#{Regexp.escape(namespace)}:/.freeze unless namespace.nil?
+    end
+
+    def validate_digest_class_option(opts)
+      return if opts[:digest_class].respond_to?(:hexdigest)
+
+      raise ArgumentError, 'The digest_class object must respond to the hexdigest method'
+    end
+
+    def namespace_from_options
+      raw_namespace = @key_options[:namespace]
+      return nil unless raw_namespace
+      return raw_namespace.call.to_s if raw_namespace.is_a?(Proc)
+
+      raw_namespace.to_s
+    end
+
+    ##
+    # Produces a truncated key, if the raw key is longer than the maximum allowed
+    # length.  The truncated key is produced by generating a hex digest
+    # of the key, and appending that to a truncated section of the key.
+    ##
+    def truncated_key(key)
+      digest = digest_class.hexdigest(key)
+      "#{key[0, prefix_length(digest)]}#{TRUNCATED_KEY_SEPARATOR}#{digest}"
+    end
+
+    def prefix_length(digest)
+      return TRUNCATED_KEY_TARGET_SIZE - (TRUNCATED_KEY_SEPARATOR.length + digest.length) if namespace.nil?
+
+      # For historical reasons, truncated keys with namespaces had a length of 250 rather
+      # than 249
+      TRUNCATED_KEY_TARGET_SIZE + 1 - (TRUNCATED_KEY_SEPARATOR.length + digest.length)
+    end
+  end
+end

--- a/test/test_dalli.rb
+++ b/test/test_dalli.rb
@@ -6,12 +6,6 @@ require "securerandom"
 
 describe "Dalli" do
   describe "options parsing" do
-    it "handle deprecated options" do
-      dc = Dalli::Client.new("foo", compression: true)
-      assert dc.instance_variable_get(:@options)[:compress]
-      refute dc.instance_variable_get(:@options)[:compression]
-    end
-
     it "not warn about valid options" do
       dc = Dalli::Client.new("foo", compress: true)
       # Rails.logger.expects :warn
@@ -67,7 +61,7 @@ describe "Dalli" do
   end
 
   describe "key validation" do
-    it "not allow blanks" do
+    it "not allow blanks, but allows whitespace characters" do
       memcached_persistent do |dc|
         dc.set "   ", 1
         assert_equal 1, dc.get("   ")

--- a/test/test_key_manager.rb
+++ b/test/test_key_manager.rb
@@ -1,0 +1,312 @@
+# frozen_string_literal: true
+
+require_relative 'helper'
+
+describe 'options' do
+  let(:key_manager) { Dalli::KeyManager.new(options) }
+
+  describe 'digest_class' do
+    describe 'when there is no explicit digest_class parameter provided' do
+      let(:options) { {} }
+
+      it 'uses Digest::MD5 as a default' do
+        assert_equal ::Digest::MD5, key_manager.digest_class
+      end
+    end
+
+    describe 'when there is an explicit digest_class parameter provided' do
+      describe 'and the class implements hexdigest' do
+        let(:options) { { digest_class: ::Digest::SHA2 } }
+
+        it 'uses the specified argument' do
+          assert_equal ::Digest::SHA2, key_manager.digest_class
+        end
+      end
+
+      describe 'and the class does not implement hexdigest' do
+        let(:options) { { digest_class: Object.new } }
+
+        it 'raises an argument error' do
+          err = assert_raises ArgumentError do
+            key_manager
+          end
+          assert_equal 'The digest_class object must respond to the hexdigest method', err.message
+        end
+      end
+    end
+  end
+
+  describe 'namespace' do
+    describe 'when there is no explicit namespace parameter provided' do
+      let(:options) { {} }
+
+      it 'the namespace is nil' do
+        assert_nil key_manager.namespace
+      end
+    end
+
+    describe 'when there is an explicit String provided as a namespace parameter' do
+      let(:options) { { namespace: namespace_as_s } }
+      let(:namespace_as_s) { SecureRandom.hex(5) }
+
+      it 'the namespace is the string' do
+        assert_equal namespace_as_s, key_manager.namespace
+      end
+    end
+
+    describe 'when there is an explicit symbol provided as a namespace parameter' do
+      let(:options) { { namespace: namespace_as_symbol } }
+      let(:namespace_as_symbol) { namespace_as_s.to_sym }
+      let(:namespace_as_s) { SecureRandom.hex(5) }
+
+      it 'the namespace is the stringified symbol' do
+        assert_equal namespace_as_s, key_manager.namespace
+      end
+    end
+
+    describe 'when there is a Proc provided as a namespace parameter' do
+      let(:options) { { namespace: namespace_as_symbol } }
+      let(:namespace_as_proc) { proc { namespace_as_symbol } }
+      let(:namespace_as_symbol) { namespace_as_s.to_sym }
+      let(:namespace_as_s) { SecureRandom.hex(5) }
+
+      it 'the namespace is the stringified symbol' do
+        assert_equal namespace_as_s, key_manager.namespace
+      end
+    end
+  end
+end
+
+describe 'validate_key' do
+  subject { key_manager.validate_key(key) }
+
+  describe 'when there is no namespace' do
+    let(:key_manager) { ::Dalli::KeyManager.new(options) }
+    let(:options) { {} }
+
+    describe 'when the key is nil' do
+      let(:key) { nil }
+
+      it 'raises an error' do
+        err = assert_raises ArgumentError do
+          subject
+        end
+        assert_equal 'key cannot be blank', err.message
+      end
+    end
+
+    describe 'when the key is empty' do
+      let(:key) { '' }
+
+      it 'raises an error' do
+        err = assert_raises ArgumentError do
+          subject
+        end
+        assert_equal 'key cannot be blank', err.message
+      end
+    end
+
+    describe 'when the key is blank, but not empty' do
+      let(:keylen) { rand(1..5) }
+      let(:key) { Array.new(keylen) { [' ', '\t', '\n'].sample }.join }
+
+      it 'returns the key' do
+        assert_equal key, subject
+      end
+    end
+
+    describe 'when the key is shorter than 250 characters' do
+      let(:keylen) { rand(1..250) }
+      let(:alphanum) { [('a'..'z').to_a, ('A'..'Z').to_a, ('0'..'9').to_a].flatten }
+      let(:key) { Array.new(keylen) { alphanum.sample }.join }
+
+      it 'returns the key' do
+        assert_equal keylen, key.length
+        assert_equal key, subject
+      end
+    end
+
+    describe 'when the key is longer than 250 characters' do
+      let(:keylen) { rand(251..500) }
+      let(:alphanum) { [('a'..'z').to_a, ('A'..'Z').to_a, ('0'..'9').to_a].flatten }
+      let(:key) { Array.new(keylen) { alphanum.sample }.join }
+
+      describe 'when there is no digest_class parameter' do
+        let(:truncated_key) { "#{key[0, 212]}:md5:#{::Digest::MD5.hexdigest(key)}" }
+
+        it 'returns the truncated key' do
+          assert_equal 249, subject.length
+          assert_equal truncated_key, subject
+        end
+      end
+
+      describe 'when there is a custom digest_class parameter' do
+        let(:options) { { digest_class: ::Digest::SHA2 } }
+        let(:truncated_key) { "#{key[0, 180]}:md5:#{::Digest::SHA2.hexdigest(key)}" }
+
+        it 'returns the truncated key' do
+          assert_equal 249, subject.length
+          assert_equal truncated_key, subject
+        end
+      end
+    end
+  end
+
+  describe 'when there is a namespace' do
+    let(:key_manager) { ::Dalli::KeyManager.new(options) }
+    let(:half_namespace_len) { rand(1..5) }
+    let(:namespace_as_s) { SecureRandom.hex(half_namespace_len) }
+    let(:options) { { namespace: namespace_as_s } }
+
+    describe 'when the key is nil' do
+      let(:key) { nil }
+
+      it 'raises an error' do
+        err = assert_raises ArgumentError do
+          subject
+        end
+        assert_equal 'key cannot be blank', err.message
+      end
+    end
+
+    describe 'when the key is empty' do
+      let(:key) { '' }
+
+      it 'raises an error' do
+        err = assert_raises ArgumentError do
+          subject
+        end
+        assert_equal 'key cannot be blank', err.message
+      end
+    end
+
+    describe 'when the key is blank, but not empty' do
+      let(:keylen) { rand(1..5) }
+      let(:key) { Array.new(keylen) { [' ', '\t', '\n'].sample }.join }
+
+      it 'returns the key' do
+        assert_equal "#{namespace_as_s}:#{key}", subject
+      end
+    end
+
+    describe 'when the key with namespace is shorter than 250 characters' do
+      let(:keylen) { rand(250 - (2 * half_namespace_len)) + 1 }
+      let(:alphanum) { [('a'..'z').to_a, ('A'..'Z').to_a, ('0'..'9').to_a].flatten }
+      let(:key) { Array.new(keylen) { alphanum.sample }.join }
+
+      it 'returns the key' do
+        assert_equal keylen, key.length
+        assert_equal "#{namespace_as_s}:#{key}", subject
+      end
+    end
+
+    describe 'when the key with namespace is longer than 250 characters' do
+      let(:keylen) { rand(251..500) - (2 * half_namespace_len) }
+      let(:alphanum) { [('a'..'z').to_a, ('A'..'Z').to_a, ('0'..'9').to_a].flatten }
+      let(:key) { Array.new(keylen) { alphanum.sample }.join }
+
+      describe 'when there is no digest_class parameter' do
+        let(:key_prefix) { key[0, 212 - (2 * half_namespace_len)] }
+        let(:truncated_key) do
+          "#{namespace_as_s}:#{key_prefix}:md5:#{::Digest::MD5.hexdigest("#{namespace_as_s}:#{key}")}"
+        end
+
+        it 'returns the truncated key' do
+          assert_equal 250, subject.length
+          assert_equal truncated_key, subject
+        end
+      end
+
+      describe 'when there is a custom digest_class parameter' do
+        let(:options) { { digest_class: ::Digest::SHA2, namespace: namespace_as_s } }
+        let(:key_prefix) { key[0, 180 - (2 * half_namespace_len)] }
+        let(:truncated_key) do
+          "#{namespace_as_s}:#{key_prefix}:md5:#{::Digest::SHA2.hexdigest("#{namespace_as_s}:#{key}")}"
+        end
+
+        it 'returns the truncated key' do
+          assert_equal 250, subject.length
+          assert_equal truncated_key, subject
+        end
+      end
+    end
+  end
+end
+
+describe 'key_with_namespace' do
+  let(:raw_key) { SecureRandom.hex(10) }
+  let(:key_manager) { ::Dalli::KeyManager.new(options) }
+  subject { key_manager.key_with_namespace(raw_key) }
+
+  describe 'without namespace' do
+    let(:options) { {} }
+
+    it 'returns the argument' do
+      assert_equal raw_key, subject
+    end
+  end
+
+  describe 'with namespace' do
+    let(:namespace_as_s) { SecureRandom.hex(5) }
+    let(:options) { { namespace: namespace_as_s } }
+
+    it 'returns the argument with the namespace prepended' do
+      assert_equal "#{namespace_as_s}:#{raw_key}", subject
+    end
+  end
+end
+
+describe 'key_without_namespace' do
+  let(:key_manager) { ::Dalli::KeyManager.new(options) }
+  subject { key_manager.key_without_namespace(raw_key) }
+
+  describe 'without namespace' do
+    let(:options) { {} }
+
+    describe 'when the key has no colon' do
+      let(:raw_key) { SecureRandom.hex(10) }
+
+      it 'returns the argument' do
+        assert_equal raw_key, subject
+      end
+    end
+
+    describe 'when the key has a colon' do
+      let(:raw_key) { "#{SecureRandom.hex(5)}:#{SecureRandom.hex(10)}" }
+
+      it 'returns the argument' do
+        assert_equal raw_key, subject
+      end
+    end
+  end
+
+  describe 'with namespace' do
+    let(:namespace_as_s) { SecureRandom.hex(5) }
+    let(:options) { { namespace: namespace_as_s } }
+
+    describe 'when the argument starts with the namespace' do
+      let(:key_wout_namespace) { SecureRandom.hex(5) }
+      let(:raw_key) { "#{namespace_as_s}:#{key_wout_namespace}" }
+
+      it 'strips the namespace' do
+        assert_equal key_wout_namespace, subject
+      end
+    end
+
+    describe 'when the argument includes the namespace in a position other than the start' do
+      let(:raw_key) { "#{SecureRandom.hex(5)}#{namespace_as_s}:#{SecureRandom.hex(5)}" }
+
+      it 'returns the argument' do
+        assert_equal raw_key, subject
+      end
+    end
+
+    describe 'when the argument does not include the namespace' do
+      let(:raw_key) { SecureRandom.hex(10) }
+
+      it 'returns the argument' do
+        assert_equal raw_key, subject
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Simplifies the Dalli client code a bit
* Makes it easier to do an extraction of the multi-yielder, by decoupling the multi-yielder code from the client
* Exposed and allowed resolution of issue #819 , which was a bug in the use of alternate digest classes
* Makes it simpler to support base64 encoded keys as described in the meta protocol document for a future meta implemenation

To maintain backwards compatibility the key truncation code is more complex than it could be.  Specifically, there is a difference in how clients using namespaces and clients without namespaces truncate keys.  This is essentially due to an off by one error introduced in the historical logic that didn't take into account the namespace separator character.  So without a namespace truncated keys are one character shorter than they need to be (249 characters).  Had the logic been unified and all truncated keys forced to 250 characters in length, that might break some key lookup for some deployed systems, so this complexity was left in place.  This may be revisited in a future major version.