### PR TITLE
Unify parsing of server string into connection attributes

### DIFF
--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -420,18 +420,17 @@ module Dalli
     end
 
     def ring
+      # TODO: This server initialization should probably be pushed down
+      # to the Ring
       @ring ||= Dalli::Ring.new(
-        @servers.map { |s|
-          server_options = {}
-          if s.start_with?("memcached://")
-            uri = URI.parse(s)
-            server_options[:username] = uri.user
-            server_options[:password] = uri.password
-            s = "#{uri.host}:#{uri.port}"
-          end
-          @options.fetch(:protocol_implementation, Dalli::Protocol::Binary).new(s, @options.merge(server_options))
-        }, @options
+        @servers.map do |s|
+          protocol_implementation.new(s, @options)
+        end, @options
       )
+    end
+
+    def protocol_implementation
+      @protocol_implementation ||= @options.fetch(:protocol_implementation, Dalli::Protocol::Binary)
     end
 
     # Chokepoint method for instrumentation

--- a/lib/dalli/protocol/binary.rb
+++ b/lib/dalli/protocol/binary.rb
@@ -35,7 +35,7 @@ module Dalli
       }
 
       def initialize(attribs, options = {})
-        @hostname, @port, @weight, @socket_type = ServerConfigParser.parse(attribs)
+        @hostname, @port, @weight, @socket_type, options = ServerConfigParser.parse(attribs, options)
         @fail_count = 0
         @down_at = nil
         @last_down_at = nil

--- a/test/protocol/test_server_config_parser.rb
+++ b/test/protocol/test_server_config_parser.rb
@@ -7,83 +7,137 @@ describe Dalli::Protocol::ServerConfigParser do
     let(:port) { rand(9999..99_999) }
     let(:weight) { rand(1..5) }
 
-    describe 'tcp' do
-      describe 'when the hostname is a domain name' do
-        let(:hostname) { "a#{SecureRandom.hex(5)}.b#{SecureRandom.hex(3)}.#{%w[net com edu].sample}" }
+    describe 'when the string is not an memcached URI' do
+      let(:options) { {} }
 
-        it 'parses a hostname by itself' do
-          assert_equal Dalli::Protocol::ServerConfigParser.parse(hostname), [hostname, 11_211, 1, :tcp]
+      describe 'tcp' do
+        describe 'when the hostname is a domain name' do
+          let(:hostname) { "a#{SecureRandom.hex(5)}.b#{SecureRandom.hex(3)}.#{%w[net com edu].sample}" }
+
+          it 'parses a hostname by itself' do
+            assert_equal Dalli::Protocol::ServerConfigParser.parse(hostname, options), [hostname, 11_211, 1, :tcp, {}]
+          end
+
+          it 'parses hostname with a port' do
+            assert_equal Dalli::Protocol::ServerConfigParser.parse("#{hostname}:#{port}", options),
+                         [hostname, port, 1, :tcp, {}]
+          end
+
+          it 'parses hostname with a port and weight' do
+            assert_equal Dalli::Protocol::ServerConfigParser.parse("#{hostname}:#{port}:#{weight}", options),
+                         [hostname, port, weight, :tcp, {}]
+          end
         end
 
-        it 'parses hostname with a port' do
-          assert_equal Dalli::Protocol::ServerConfigParser.parse("#{hostname}:#{port}"), [hostname, port, 1, :tcp]
+        describe 'when the hostname is an IPv4 address' do
+          let(:hostname) { '203.0.113.28' }
+
+          it 'parses a hostname by itself' do
+            assert_equal Dalli::Protocol::ServerConfigParser.parse(hostname, options), [hostname, 11_211, 1, :tcp, {}]
+          end
+
+          it 'parses hostname with a port' do
+            assert_equal Dalli::Protocol::ServerConfigParser.parse("#{hostname}:#{port}", options),
+                         [hostname, port, 1, :tcp, {}]
+          end
+
+          it 'parses hostname with a port and weight' do
+            assert_equal Dalli::Protocol::ServerConfigParser.parse("#{hostname}:#{port}:#{weight}", options),
+                         [hostname, port, weight, :tcp, {}]
+          end
         end
 
-        it 'parses hostname with a port and weight' do
-          assert_equal Dalli::Protocol::ServerConfigParser.parse("#{hostname}:#{port}:#{weight}"),
-                       [hostname, port, weight, :tcp]
+        describe 'when the hostname is an IPv6 address' do
+          let(:hostname) { ['2001:db8:ffff:ffff:ffff:ffff:ffff:ffff', '2001:db8::'].sample }
+
+          it 'parses a hostname by itself' do
+            assert_equal Dalli::Protocol::ServerConfigParser.parse("[#{hostname}]", options),
+                         [hostname, 11_211, 1, :tcp, {}]
+          end
+
+          it 'parses hostname with a port' do
+            assert_equal Dalli::Protocol::ServerConfigParser.parse("[#{hostname}]:#{port}", options),
+                         [hostname, port, 1, :tcp, {}]
+          end
+
+          it 'parses hostname with a port and weight' do
+            assert_equal Dalli::Protocol::ServerConfigParser.parse("[#{hostname}]:#{port}:#{weight}", options),
+                         [hostname, port, weight, :tcp, {}]
+          end
         end
       end
 
-      describe 'when the hostname is an IPv4 address' do
-        let(:hostname) { '203.0.113.28' }
+      describe 'unix' do
+        let(:hostname) { "/tmp/#{SecureRandom.hex(5)}" }
 
-        it 'parses a hostname by itself' do
-          assert_equal Dalli::Protocol::ServerConfigParser.parse(hostname), [hostname, 11_211, 1, :tcp]
+        it 'parses a socket by itself' do
+          assert_equal Dalli::Protocol::ServerConfigParser.parse(hostname, {}), [hostname, nil, 1, :unix, {}]
         end
 
-        it 'parses hostname with a port' do
-          assert_equal Dalli::Protocol::ServerConfigParser.parse("#{hostname}:#{port}"), [hostname, port, 1, :tcp]
+        it 'parses socket with a weight' do
+          assert_equal Dalli::Protocol::ServerConfigParser.parse("#{hostname}:#{weight}", {}),
+                       [hostname, nil, weight, :unix, {}]
         end
 
-        it 'parses hostname with a port and weight' do
-          assert_equal Dalli::Protocol::ServerConfigParser.parse("#{hostname}:#{port}:#{weight}"),
-                       [hostname, port, weight, :tcp]
-        end
-      end
-
-      describe 'when the hostname is an IPv6 address' do
-        let(:hostname) { ['2001:db8:ffff:ffff:ffff:ffff:ffff:ffff', '2001:db8::'].sample }
-
-        it 'parses a hostname by itself' do
-          assert_equal Dalli::Protocol::ServerConfigParser.parse("[#{hostname}]"), [hostname, 11_211, 1, :tcp]
-        end
-
-        it 'parses hostname with a port' do
-          assert_equal Dalli::Protocol::ServerConfigParser.parse("[#{hostname}]:#{port}"), [hostname, port, 1, :tcp]
-        end
-
-        it 'parses hostname with a port and weight' do
-          assert_equal Dalli::Protocol::ServerConfigParser.parse("[#{hostname}]:#{port}:#{weight}"),
-                       [hostname, port, weight, :tcp]
+        it 'produces an error with a port and weight' do
+          err = assert_raises Dalli::DalliError do
+            Dalli::Protocol::ServerConfigParser.parse("#{hostname}:#{port}:#{weight}", {})
+          end
+          assert_equal err.message, "Could not parse hostname #{hostname}:#{port}:#{weight}"
         end
       end
     end
 
-    describe 'unix' do
-      let(:hostname) { "/tmp/#{SecureRandom.hex(5)}" }
+    describe 'when the string is a memcached URI' do
+      let(:user) { SecureRandom.hex(5) }
+      let(:password) { SecureRandom.hex(5) }
+      let(:port) { rand(15_000..16_023) }
+      let(:hostname) { "a#{SecureRandom.hex(3)}.b#{SecureRandom.hex(3)}.com" }
 
-      it 'parses a socket by itself' do
-        assert_equal Dalli::Protocol::ServerConfigParser.parse(hostname), [hostname, nil, 1, :unix]
-      end
+      describe 'when the URI is properly formed and includes all values' do
+        let(:uri) { "memcached://#{user}:#{password}@#{hostname}:#{port}" }
 
-      it 'parses socket with a weight' do
-        assert_equal Dalli::Protocol::ServerConfigParser.parse("#{hostname}:#{weight}"), [hostname, nil, weight, :unix]
-      end
+        describe 'when the client options are empty' do
+          let(:client_options) { {} }
 
-      it 'produces an error with a port and weight' do
-        err = assert_raises Dalli::DalliError do
-          Dalli::Protocol::ServerConfigParser.parse("#{hostname}:#{port}:#{weight}")
+          it 'parses correctly' do
+            assert_equal Dalli::Protocol::ServerConfigParser.parse(uri, client_options),
+                         [hostname, port, 1, :tcp, { username: user, password: password }]
+          end
         end
-        assert_equal err.message, "Could not parse hostname #{hostname}:#{port}:#{weight}"
+
+        describe 'when the client options are not empty' do
+          let(:option_a) { SecureRandom.hex(3) }
+          let(:option_b) { SecureRandom.hex(3) }
+          let(:client_options) { { a: option_a, b: option_b } }
+
+          it 'parses correctly' do
+            assert_equal Dalli::Protocol::ServerConfigParser.parse(uri, client_options),
+                         [hostname, port, 1, :tcp, { username: user, password: password, a: option_a, b: option_b }]
+          end
+        end
       end
+
+      describe 'when the URI does not include a port' do
+        let(:uri) { "memcached://#{user}:#{password}@#{hostname}" }
+
+        describe 'when the client options are empty' do
+          let(:client_options) { {} }
+
+          it 'parses correctly' do
+            assert_equal Dalli::Protocol::ServerConfigParser.parse(uri, client_options),
+                         [hostname, 11_211, 1, :tcp, { username: user, password: password }]
+          end
+        end
+      end
+
     end
 
     describe 'errors' do
       describe 'when the string is empty' do
         it 'produces an error' do
           err = assert_raises Dalli::DalliError do
-            Dalli::Protocol::ServerConfigParser.parse('')
+            Dalli::Protocol::ServerConfigParser.parse('', {})
           end
           assert_equal err.message, 'Could not parse hostname '
         end
@@ -92,7 +146,7 @@ describe Dalli::Protocol::ServerConfigParser do
       describe 'when the string starts with a colon' do
         it 'produces an error' do
           err = assert_raises Dalli::DalliError do
-            Dalli::Protocol::ServerConfigParser.parse(':1:2')
+            Dalli::Protocol::ServerConfigParser.parse(':1:2', {})
           end
           assert_equal err.message, 'Could not parse hostname :1:2'
         end
@@ -101,7 +155,7 @@ describe Dalli::Protocol::ServerConfigParser do
       describe 'when the string ends with a colon' do
         it 'produces an error' do
           err = assert_raises Dalli::DalliError do
-            Dalli::Protocol::ServerConfigParser.parse('abc.com:')
+            Dalli::Protocol::ServerConfigParser.parse('abc.com:', {})
           end
           assert_equal err.message, 'Could not parse hostname abc.com:'
         end


### PR DESCRIPTION
Right now server config strings are parsed in two different stages, at two different places.  Memcached URIs are parsed at the point of Ring initialization, while the colon-separated strings are parsed inside the Dalli::Protocol::Binary initializer via a helper class.

One odd implication of this is that we do transformation of URIs into he colon-separated representation, rather than just parsing out the values directly.

It will be simpler to maintain if all of the server config string parsing occurs in one place, and there is no translation into another representation.  This PR unifies the server config string parsing into one class