### PR TITLE
Extract servers arg normalization

### DIFF
--- a/lib/dalli.rb
+++ b/lib/dalli.rb
@@ -9,6 +9,7 @@ require "dalli/protocol/binary"
 require "dalli/protocol/server_config_parser"
 require "dalli/protocol/ttl_sanitizer"
 require 'dalli/protocol/value_compressor'
+require 'dalli/servers_arg_normalizer'
 require "dalli/socket"
 require "dalli/version"
 require "dalli/options"

--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -34,8 +34,7 @@ module Dalli
     # - :protocol_implementation - defaults to Dalli::Protocol::Binary which uses the binary protocol. Allows you to pass an alternative implementation using another protocol.
     #
     def initialize(servers = nil, options = {})
-      validate_servers_arg(servers)
-      @servers = normalize_servers(servers || ENV["MEMCACHE_SERVERS"] || "127.0.0.1:11211")
+      @servers = ::Dalli::ServersArgNormalizer.normalize_servers(servers)
       @options = normalize_options(options)
       @key_manager = ::Dalli::KeyManager.new(options)
       @ring = nil
@@ -393,30 +392,6 @@ module Dalli
       end
   
       servers.delete_if { |server| deleted.include?(server) }
-    end
-
-    ##
-    # Ensures that the servers arg is either an array or a string.
-    def validate_servers_arg(servers)
-      return if servers.nil?
-      return if servers.is_a?(Array)
-      return if servers.is_a?(String)
-
-      raise ArgumentError, "An explicit servers argument must be a comma separated string or an array containing strings."
-    end
-
-    ##
-    # Normalizes the argument into an array of servers.
-    # If the argument is a string, or an array containing strings, it's expected that the URIs are comma separated e.g.
-    # "memcache1.example.com:11211,memcache2.example.com:11211,memcache3.example.com:11211"
-    def normalize_servers(servers)
-      Array(servers).flat_map do |server|
-        if server.is_a? String
-          server.split(",")
-        else
-          server
-        end
-      end
     end
 
     def ring

--- a/lib/dalli/servers_arg_normalizer.rb
+++ b/lib/dalli/servers_arg_normalizer.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Dalli
+  ##
+  # This module contains methods for validating and normalizing the servers
+  # argument passed to the client.  This argument can be nil, a string, or
+  # an array of strings.  Each string value in the argument can represent
+  # a single server or a comma separated list of servers.
+  #
+  # If nil, it falls back to the values of ENV['MEMCACHE_SERVERS'] if the latter is
+  # defined.  If that environment value is not defined, a default of '127.0.0.1:11211'
+  # is used.
+  #
+  # A server config string can take one of three forms:
+  #   * A colon separated string of (host, port, weight) where both port and
+  #     weight are optional (e.g. 'localhost', 'abc.com:12345', 'example.org:22222:3')
+  #   * A colon separated string of (UNIX socket, weight) where the weight is optional
+  #     (e.g. '/var/run/memcached/socket', '/tmp/xyz:3') (not supported on Windows)
+  #   * A URI with a 'memcached' protocol, which will typically include a username/password
+  #
+  # The methods in this module do not validate the format of individual server strings, but
+  # rather normalize the argument into a compact array, wherein each array entry corresponds
+  # to a single server config string.  If that normalization is not possible, then an
+  # ArgumentError is thrown.
+  ##
+  module ServersArgNormalizer
+    ENV_VAR_NAME = 'MEMCACHE_SERVERS'
+    DEFAULT_SERVERS = ['127.0.0.1:11211'].freeze
+
+    ##
+    # Normalizes the argument into an array of servers.
+    # If the argument is a string, or an array containing strings, it's expected that the URIs are comma separated e.g.
+    # "memcache1.example.com:11211,memcache2.example.com:11211,memcache3.example.com:11211"
+    def self.normalize_servers(arg)
+      arg = apply_defaults(arg)
+      validate_type(arg)
+      Array(arg).flat_map { |s| s.split(',') }.reject(&:empty?)
+    end
+
+    def self.apply_defaults(arg)
+      return arg unless arg.nil?
+
+      ENV[ENV_VAR_NAME] || DEFAULT_SERVERS
+    end
+
+    def self.validate_type(arg)
+      return if arg.is_a?(String)
+      return if arg.is_a?(Array) && arg.all? { |s| s.is_a?(String) }
+
+      raise ArgumentError,
+            'An explicit servers argument must be a comma separated string or an array containing strings.'
+    end
+  end
+end

--- a/test/test_key_manager.rb
+++ b/test/test_key_manager.rb
@@ -2,310 +2,312 @@
 
 require_relative 'helper'
 
-describe 'options' do
-  let(:key_manager) { Dalli::KeyManager.new(options) }
+describe 'KeyManager' do
+  describe 'options' do
+    let(:key_manager) { Dalli::KeyManager.new(options) }
 
-  describe 'digest_class' do
-    describe 'when there is no explicit digest_class parameter provided' do
-      let(:options) { {} }
+    describe 'digest_class' do
+      describe 'when there is no explicit digest_class parameter provided' do
+        let(:options) { {} }
 
-      it 'uses Digest::MD5 as a default' do
-        assert_equal ::Digest::MD5, key_manager.digest_class
-      end
-    end
-
-    describe 'when there is an explicit digest_class parameter provided' do
-      describe 'and the class implements hexdigest' do
-        let(:options) { { digest_class: ::Digest::SHA2 } }
-
-        it 'uses the specified argument' do
-          assert_equal ::Digest::SHA2, key_manager.digest_class
+        it 'uses Digest::MD5 as a default' do
+          assert_equal ::Digest::MD5, key_manager.digest_class
         end
       end
 
-      describe 'and the class does not implement hexdigest' do
-        let(:options) { { digest_class: Object.new } }
+      describe 'when there is an explicit digest_class parameter provided' do
+        describe 'and the class implements hexdigest' do
+          let(:options) { { digest_class: ::Digest::SHA2 } }
 
-        it 'raises an argument error' do
-          err = assert_raises ArgumentError do
-            key_manager
+          it 'uses the specified argument' do
+            assert_equal ::Digest::SHA2, key_manager.digest_class
           end
-          assert_equal 'The digest_class object must respond to the hexdigest method', err.message
+        end
+
+        describe 'and the class does not implement hexdigest' do
+          let(:options) { { digest_class: Object.new } }
+
+          it 'raises an argument error' do
+            err = assert_raises ArgumentError do
+              key_manager
+            end
+            assert_equal 'The digest_class object must respond to the hexdigest method', err.message
+          end
+        end
+      end
+    end
+
+    describe 'namespace' do
+      describe 'when there is no explicit namespace parameter provided' do
+        let(:options) { {} }
+
+        it 'the namespace is nil' do
+          assert_nil key_manager.namespace
+        end
+      end
+
+      describe 'when there is an explicit String provided as a namespace parameter' do
+        let(:options) { { namespace: namespace_as_s } }
+        let(:namespace_as_s) { SecureRandom.hex(5) }
+
+        it 'the namespace is the string' do
+          assert_equal namespace_as_s, key_manager.namespace
+        end
+      end
+
+      describe 'when there is an explicit symbol provided as a namespace parameter' do
+        let(:options) { { namespace: namespace_as_symbol } }
+        let(:namespace_as_symbol) { namespace_as_s.to_sym }
+        let(:namespace_as_s) { SecureRandom.hex(5) }
+
+        it 'the namespace is the stringified symbol' do
+          assert_equal namespace_as_s, key_manager.namespace
+        end
+      end
+
+      describe 'when there is a Proc provided as a namespace parameter' do
+        let(:options) { { namespace: namespace_as_symbol } }
+        let(:namespace_as_proc) { proc { namespace_as_symbol } }
+        let(:namespace_as_symbol) { namespace_as_s.to_sym }
+        let(:namespace_as_s) { SecureRandom.hex(5) }
+
+        it 'the namespace is the stringified symbol' do
+          assert_equal namespace_as_s, key_manager.namespace
         end
       end
     end
   end
 
-  describe 'namespace' do
-    describe 'when there is no explicit namespace parameter provided' do
+  describe 'validate_key' do
+    subject { key_manager.validate_key(key) }
+
+    describe 'when there is no namespace' do
+      let(:key_manager) { ::Dalli::KeyManager.new(options) }
       let(:options) { {} }
 
-      it 'the namespace is nil' do
-        assert_nil key_manager.namespace
+      describe 'when the key is nil' do
+        let(:key) { nil }
+
+        it 'raises an error' do
+          err = assert_raises ArgumentError do
+            subject
+          end
+          assert_equal 'key cannot be blank', err.message
+        end
+      end
+
+      describe 'when the key is empty' do
+        let(:key) { '' }
+
+        it 'raises an error' do
+          err = assert_raises ArgumentError do
+            subject
+          end
+          assert_equal 'key cannot be blank', err.message
+        end
+      end
+
+      describe 'when the key is blank, but not empty' do
+        let(:keylen) { rand(1..5) }
+        let(:key) { Array.new(keylen) { [' ', '\t', '\n'].sample }.join }
+
+        it 'returns the key' do
+          assert_equal key, subject
+        end
+      end
+
+      describe 'when the key is shorter than 250 characters' do
+        let(:keylen) { rand(1..250) }
+        let(:alphanum) { [('a'..'z').to_a, ('A'..'Z').to_a, ('0'..'9').to_a].flatten }
+        let(:key) { Array.new(keylen) { alphanum.sample }.join }
+
+        it 'returns the key' do
+          assert_equal keylen, key.length
+          assert_equal key, subject
+        end
+      end
+
+      describe 'when the key is longer than 250 characters' do
+        let(:keylen) { rand(251..500) }
+        let(:alphanum) { [('a'..'z').to_a, ('A'..'Z').to_a, ('0'..'9').to_a].flatten }
+        let(:key) { Array.new(keylen) { alphanum.sample }.join }
+
+        describe 'when there is no digest_class parameter' do
+          let(:truncated_key) { "#{key[0, 212]}:md5:#{::Digest::MD5.hexdigest(key)}" }
+
+          it 'returns the truncated key' do
+            assert_equal 249, subject.length
+            assert_equal truncated_key, subject
+          end
+        end
+
+        describe 'when there is a custom digest_class parameter' do
+          let(:options) { { digest_class: ::Digest::SHA2 } }
+          let(:truncated_key) { "#{key[0, 180]}:md5:#{::Digest::SHA2.hexdigest(key)}" }
+
+          it 'returns the truncated key' do
+            assert_equal 249, subject.length
+            assert_equal truncated_key, subject
+          end
+        end
       end
     end
 
-    describe 'when there is an explicit String provided as a namespace parameter' do
+    describe 'when there is a namespace' do
+      let(:key_manager) { ::Dalli::KeyManager.new(options) }
+      let(:half_namespace_len) { rand(1..5) }
+      let(:namespace_as_s) { SecureRandom.hex(half_namespace_len) }
       let(:options) { { namespace: namespace_as_s } }
-      let(:namespace_as_s) { SecureRandom.hex(5) }
 
-      it 'the namespace is the string' do
-        assert_equal namespace_as_s, key_manager.namespace
+      describe 'when the key is nil' do
+        let(:key) { nil }
+
+        it 'raises an error' do
+          err = assert_raises ArgumentError do
+            subject
+          end
+          assert_equal 'key cannot be blank', err.message
+        end
       end
-    end
 
-    describe 'when there is an explicit symbol provided as a namespace parameter' do
-      let(:options) { { namespace: namespace_as_symbol } }
-      let(:namespace_as_symbol) { namespace_as_s.to_sym }
-      let(:namespace_as_s) { SecureRandom.hex(5) }
+      describe 'when the key is empty' do
+        let(:key) { '' }
 
-      it 'the namespace is the stringified symbol' do
-        assert_equal namespace_as_s, key_manager.namespace
+        it 'raises an error' do
+          err = assert_raises ArgumentError do
+            subject
+          end
+          assert_equal 'key cannot be blank', err.message
+        end
       end
-    end
 
-    describe 'when there is a Proc provided as a namespace parameter' do
-      let(:options) { { namespace: namespace_as_symbol } }
-      let(:namespace_as_proc) { proc { namespace_as_symbol } }
-      let(:namespace_as_symbol) { namespace_as_s.to_sym }
-      let(:namespace_as_s) { SecureRandom.hex(5) }
+      describe 'when the key is blank, but not empty' do
+        let(:keylen) { rand(1..5) }
+        let(:key) { Array.new(keylen) { [' ', '\t', '\n'].sample }.join }
 
-      it 'the namespace is the stringified symbol' do
-        assert_equal namespace_as_s, key_manager.namespace
+        it 'returns the key' do
+          assert_equal "#{namespace_as_s}:#{key}", subject
+        end
+      end
+
+      describe 'when the key with namespace is shorter than 250 characters' do
+        let(:keylen) { rand(250 - (2 * half_namespace_len)) + 1 }
+        let(:alphanum) { [('a'..'z').to_a, ('A'..'Z').to_a, ('0'..'9').to_a].flatten }
+        let(:key) { Array.new(keylen) { alphanum.sample }.join }
+
+        it 'returns the key' do
+          assert_equal keylen, key.length
+          assert_equal "#{namespace_as_s}:#{key}", subject
+        end
+      end
+
+      describe 'when the key with namespace is longer than 250 characters' do
+        let(:keylen) { rand(251..500) - (2 * half_namespace_len) }
+        let(:alphanum) { [('a'..'z').to_a, ('A'..'Z').to_a, ('0'..'9').to_a].flatten }
+        let(:key) { Array.new(keylen) { alphanum.sample }.join }
+
+        describe 'when there is no digest_class parameter' do
+          let(:key_prefix) { key[0, 212 - (2 * half_namespace_len)] }
+          let(:truncated_key) do
+            "#{namespace_as_s}:#{key_prefix}:md5:#{::Digest::MD5.hexdigest("#{namespace_as_s}:#{key}")}"
+          end
+
+          it 'returns the truncated key' do
+            assert_equal 250, subject.length
+            assert_equal truncated_key, subject
+          end
+        end
+
+        describe 'when there is a custom digest_class parameter' do
+          let(:options) { { digest_class: ::Digest::SHA2, namespace: namespace_as_s } }
+          let(:key_prefix) { key[0, 180 - (2 * half_namespace_len)] }
+          let(:truncated_key) do
+            "#{namespace_as_s}:#{key_prefix}:md5:#{::Digest::SHA2.hexdigest("#{namespace_as_s}:#{key}")}"
+          end
+
+          it 'returns the truncated key' do
+            assert_equal 250, subject.length
+            assert_equal truncated_key, subject
+          end
+        end
       end
     end
   end
-end
 
-describe 'validate_key' do
-  subject { key_manager.validate_key(key) }
-
-  describe 'when there is no namespace' do
+  describe 'key_with_namespace' do
+    let(:raw_key) { SecureRandom.hex(10) }
     let(:key_manager) { ::Dalli::KeyManager.new(options) }
-    let(:options) { {} }
+    subject { key_manager.key_with_namespace(raw_key) }
 
-    describe 'when the key is nil' do
-      let(:key) { nil }
+    describe 'without namespace' do
+      let(:options) { {} }
 
-      it 'raises an error' do
-        err = assert_raises ArgumentError do
-          subject
-        end
-        assert_equal 'key cannot be blank', err.message
+      it 'returns the argument' do
+        assert_equal raw_key, subject
       end
     end
 
-    describe 'when the key is empty' do
-      let(:key) { '' }
+    describe 'with namespace' do
+      let(:namespace_as_s) { SecureRandom.hex(5) }
+      let(:options) { { namespace: namespace_as_s } }
 
-      it 'raises an error' do
-        err = assert_raises ArgumentError do
-          subject
-        end
-        assert_equal 'key cannot be blank', err.message
-      end
-    end
-
-    describe 'when the key is blank, but not empty' do
-      let(:keylen) { rand(1..5) }
-      let(:key) { Array.new(keylen) { [' ', '\t', '\n'].sample }.join }
-
-      it 'returns the key' do
-        assert_equal key, subject
-      end
-    end
-
-    describe 'when the key is shorter than 250 characters' do
-      let(:keylen) { rand(1..250) }
-      let(:alphanum) { [('a'..'z').to_a, ('A'..'Z').to_a, ('0'..'9').to_a].flatten }
-      let(:key) { Array.new(keylen) { alphanum.sample }.join }
-
-      it 'returns the key' do
-        assert_equal keylen, key.length
-        assert_equal key, subject
-      end
-    end
-
-    describe 'when the key is longer than 250 characters' do
-      let(:keylen) { rand(251..500) }
-      let(:alphanum) { [('a'..'z').to_a, ('A'..'Z').to_a, ('0'..'9').to_a].flatten }
-      let(:key) { Array.new(keylen) { alphanum.sample }.join }
-
-      describe 'when there is no digest_class parameter' do
-        let(:truncated_key) { "#{key[0, 212]}:md5:#{::Digest::MD5.hexdigest(key)}" }
-
-        it 'returns the truncated key' do
-          assert_equal 249, subject.length
-          assert_equal truncated_key, subject
-        end
-      end
-
-      describe 'when there is a custom digest_class parameter' do
-        let(:options) { { digest_class: ::Digest::SHA2 } }
-        let(:truncated_key) { "#{key[0, 180]}:md5:#{::Digest::SHA2.hexdigest(key)}" }
-
-        it 'returns the truncated key' do
-          assert_equal 249, subject.length
-          assert_equal truncated_key, subject
-        end
+      it 'returns the argument with the namespace prepended' do
+        assert_equal "#{namespace_as_s}:#{raw_key}", subject
       end
     end
   end
 
-  describe 'when there is a namespace' do
+  describe 'key_without_namespace' do
     let(:key_manager) { ::Dalli::KeyManager.new(options) }
-    let(:half_namespace_len) { rand(1..5) }
-    let(:namespace_as_s) { SecureRandom.hex(half_namespace_len) }
-    let(:options) { { namespace: namespace_as_s } }
+    subject { key_manager.key_without_namespace(raw_key) }
 
-    describe 'when the key is nil' do
-      let(:key) { nil }
+    describe 'without namespace' do
+      let(:options) { {} }
 
-      it 'raises an error' do
-        err = assert_raises ArgumentError do
-          subject
-        end
-        assert_equal 'key cannot be blank', err.message
-      end
-    end
+      describe 'when the key has no colon' do
+        let(:raw_key) { SecureRandom.hex(10) }
 
-    describe 'when the key is empty' do
-      let(:key) { '' }
-
-      it 'raises an error' do
-        err = assert_raises ArgumentError do
-          subject
-        end
-        assert_equal 'key cannot be blank', err.message
-      end
-    end
-
-    describe 'when the key is blank, but not empty' do
-      let(:keylen) { rand(1..5) }
-      let(:key) { Array.new(keylen) { [' ', '\t', '\n'].sample }.join }
-
-      it 'returns the key' do
-        assert_equal "#{namespace_as_s}:#{key}", subject
-      end
-    end
-
-    describe 'when the key with namespace is shorter than 250 characters' do
-      let(:keylen) { rand(250 - (2 * half_namespace_len)) + 1 }
-      let(:alphanum) { [('a'..'z').to_a, ('A'..'Z').to_a, ('0'..'9').to_a].flatten }
-      let(:key) { Array.new(keylen) { alphanum.sample }.join }
-
-      it 'returns the key' do
-        assert_equal keylen, key.length
-        assert_equal "#{namespace_as_s}:#{key}", subject
-      end
-    end
-
-    describe 'when the key with namespace is longer than 250 characters' do
-      let(:keylen) { rand(251..500) - (2 * half_namespace_len) }
-      let(:alphanum) { [('a'..'z').to_a, ('A'..'Z').to_a, ('0'..'9').to_a].flatten }
-      let(:key) { Array.new(keylen) { alphanum.sample }.join }
-
-      describe 'when there is no digest_class parameter' do
-        let(:key_prefix) { key[0, 212 - (2 * half_namespace_len)] }
-        let(:truncated_key) do
-          "#{namespace_as_s}:#{key_prefix}:md5:#{::Digest::MD5.hexdigest("#{namespace_as_s}:#{key}")}"
-        end
-
-        it 'returns the truncated key' do
-          assert_equal 250, subject.length
-          assert_equal truncated_key, subject
+        it 'returns the argument' do
+          assert_equal raw_key, subject
         end
       end
 
-      describe 'when there is a custom digest_class parameter' do
-        let(:options) { { digest_class: ::Digest::SHA2, namespace: namespace_as_s } }
-        let(:key_prefix) { key[0, 180 - (2 * half_namespace_len)] }
-        let(:truncated_key) do
-          "#{namespace_as_s}:#{key_prefix}:md5:#{::Digest::SHA2.hexdigest("#{namespace_as_s}:#{key}")}"
-        end
+      describe 'when the key has a colon' do
+        let(:raw_key) { "#{SecureRandom.hex(5)}:#{SecureRandom.hex(10)}" }
 
-        it 'returns the truncated key' do
-          assert_equal 250, subject.length
-          assert_equal truncated_key, subject
+        it 'returns the argument' do
+          assert_equal raw_key, subject
         end
       end
     end
-  end
-end
 
-describe 'key_with_namespace' do
-  let(:raw_key) { SecureRandom.hex(10) }
-  let(:key_manager) { ::Dalli::KeyManager.new(options) }
-  subject { key_manager.key_with_namespace(raw_key) }
+    describe 'with namespace' do
+      let(:namespace_as_s) { SecureRandom.hex(5) }
+      let(:options) { { namespace: namespace_as_s } }
 
-  describe 'without namespace' do
-    let(:options) { {} }
+      describe 'when the argument starts with the namespace' do
+        let(:key_wout_namespace) { SecureRandom.hex(5) }
+        let(:raw_key) { "#{namespace_as_s}:#{key_wout_namespace}" }
 
-    it 'returns the argument' do
-      assert_equal raw_key, subject
-    end
-  end
-
-  describe 'with namespace' do
-    let(:namespace_as_s) { SecureRandom.hex(5) }
-    let(:options) { { namespace: namespace_as_s } }
-
-    it 'returns the argument with the namespace prepended' do
-      assert_equal "#{namespace_as_s}:#{raw_key}", subject
-    end
-  end
-end
-
-describe 'key_without_namespace' do
-  let(:key_manager) { ::Dalli::KeyManager.new(options) }
-  subject { key_manager.key_without_namespace(raw_key) }
-
-  describe 'without namespace' do
-    let(:options) { {} }
-
-    describe 'when the key has no colon' do
-      let(:raw_key) { SecureRandom.hex(10) }
-
-      it 'returns the argument' do
-        assert_equal raw_key, subject
+        it 'strips the namespace' do
+          assert_equal key_wout_namespace, subject
+        end
       end
-    end
 
-    describe 'when the key has a colon' do
-      let(:raw_key) { "#{SecureRandom.hex(5)}:#{SecureRandom.hex(10)}" }
+      describe 'when the argument includes the namespace in a position other than the start' do
+        let(:raw_key) { "#{SecureRandom.hex(5)}#{namespace_as_s}:#{SecureRandom.hex(5)}" }
 
-      it 'returns the argument' do
-        assert_equal raw_key, subject
+        it 'returns the argument' do
+          assert_equal raw_key, subject
+        end
       end
-    end
-  end
 
-  describe 'with namespace' do
-    let(:namespace_as_s) { SecureRandom.hex(5) }
-    let(:options) { { namespace: namespace_as_s } }
+      describe 'when the argument does not include the namespace' do
+        let(:raw_key) { SecureRandom.hex(10) }
 
-    describe 'when the argument starts with the namespace' do
-      let(:key_wout_namespace) { SecureRandom.hex(5) }
-      let(:raw_key) { "#{namespace_as_s}:#{key_wout_namespace}" }
-
-      it 'strips the namespace' do
-        assert_equal key_wout_namespace, subject
-      end
-    end
-
-    describe 'when the argument includes the namespace in a position other than the start' do
-      let(:raw_key) { "#{SecureRandom.hex(5)}#{namespace_as_s}:#{SecureRandom.hex(5)}" }
-
-      it 'returns the argument' do
-        assert_equal raw_key, subject
-      end
-    end
-
-    describe 'when the argument does not include the namespace' do
-      let(:raw_key) { SecureRandom.hex(10) }
-
-      it 'returns the argument' do
-        assert_equal raw_key, subject
+        it 'returns the argument' do
+          assert_equal raw_key, subject
+        end
       end
     end
   end

--- a/test/test_servers_arg_normalizer.rb
+++ b/test/test_servers_arg_normalizer.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require_relative 'helper'
+
+describe Dalli::ServersArgNormalizer do
+  describe 'normalize_servers' do
+    subject { Dalli::ServersArgNormalizer.normalize_servers(arg) }
+
+    describe 'when the argument is nil' do
+      let(:arg) { nil }
+
+      describe 'when the MEMCACHE_SERVERS environment is set' do
+        let(:server_string) { 'example.com:1234' }
+
+        before do
+          ENV['MEMCACHE_SERVERS'] = server_string
+        end
+
+        after do
+          ENV['MEMCACHE_SERVERS'] = nil
+        end
+
+        it 'returns the value from the environment' do
+          assert_equal [server_string], subject
+        end
+      end
+
+      describe 'when the MEMCACHE_SERVERS environment is not set' do
+        it 'returns the expected default' do
+          assert_equal ['127.0.0.1:11211'], subject
+        end
+      end
+    end
+
+    describe 'when the argument is a single string' do
+      describe 'when the string is a single entry' do
+        let(:arg) { 'example.com:1234' }
+
+        it 'returns the single entry as an array' do
+          assert_equal [arg], subject
+        end
+      end
+
+      describe 'when the string is multiple comma separated entries' do
+        let(:server1) { 'example.com:1234' }
+        let(:server2) { '127.0.0.1:11111' }
+        let(:server3) { 'abc.def.com:7890' }
+        let(:arg) { [server1, server2, server3].join(',') }
+
+        it 'splits the string and returns an array' do
+          assert_equal [server1, server2, server3], subject
+        end
+      end
+
+      describe 'when the string is multiple comma separated entries with empty entries' do
+        let(:server1) { 'example.com:1234' }
+        let(:server2) { '127.0.0.1:11111' }
+        let(:server3) { 'abc.def.com:7890' }
+        let(:arg) { [server1, server2, '', server3, ''].join(',') }
+
+        it 'splits the string and returns an array, discarding the empty elements' do
+          assert_equal [server1, server2, server3], subject
+        end
+      end
+    end
+
+    describe 'when the argument is an array of strings' do
+      describe 'when there is a single entry, with no commas' do
+        let(:server1) { 'example.com:1234' }
+        let(:arg) { [server1] }
+
+        it 'returns the single entry as an array' do
+          assert_equal arg, subject
+        end
+      end
+
+      describe 'when there is a single entry, with commas' do
+        let(:server1) { 'example.com:1234' }
+        let(:server2) { '127.0.0.1:11111' }
+        let(:server3) { 'abc.def.com:7890' }
+        let(:arg) { [[server1, server2, server3].join(',')] }
+
+        it 'returns the servers as an array' do
+          assert_equal [server1, server2, server3], subject
+        end
+      end
+
+      describe 'when there are multiple entries' do
+        let(:server1) { 'example.com:1234' }
+        let(:server2) { '127.0.0.1:11111' }
+        let(:server3) { 'abc.def.com:7890' }
+        let(:server4) { 'localhost' }
+        let(:server5) { '192.168.0.6:11211:3' }
+        let(:server6) { '192.168.0.6:11211:3' }
+        let(:arg) do
+          entry1 = [server1, server2, server3].join(',')
+          entry2 = server4
+          entry3 = [server5, '', server6].join(',')
+          [entry1, entry2, entry3]
+        end
+
+        it 'returns the individual servers as an array' do
+          assert_equal [server1, server2, server3, server4, server5, server6], subject
+        end
+      end
+    end
+
+    describe 'when the argument is an array with non-strings' do
+      let(:arg) { [1, 2, 3, 4] }
+
+      it 'raises an error' do
+        err = assert_raises ArgumentError do
+          subject
+        end
+        assert_equal 'An explicit servers argument must be a comma separated string or an array containing strings.',
+                     err.message
+      end
+    end
+
+    describe 'when the argument is neither a string nor an array of strings' do
+      let(:arg) { Object.new }
+
+      it 'raises an error' do
+        err = assert_raises ArgumentError do
+          subject
+        end
+        assert_equal 'An explicit servers argument must be a comma separated string or an array containing strings.',
+                     err.message
+      end
+    end
+  end
+end


### PR DESCRIPTION
The supported values for the servers arg for Dalli::Client are actually fairly complex.  For the nil case it has two fallbacks (one ENV variable, and the other a hardcoded localhost).  It supports strings which represent a single server or a comma separated set of servers.  And it supports receiving any set of those strings as an array.

On initialization the Dalli::Client immediately applies defaults as needed and normalizes this to an array of strings, wherein each string represents a single server.  This just pulls that logic out into a separate module.