### PR TITLE
Handle ActiveSupport::Cache:Entry when getting session

### DIFF
--- a/lib/rack/session/dalli.rb
+++ b/lib/rack/session/dalli.rb
@@ -88,7 +88,7 @@ module Rack
 
       def get_session(_env, sid)
         with_block([nil, {}]) do |dc|
-          unless sid && !sid.empty? && (session = dc.get(sid))
+          unless sid && !sid.empty? && (session = entry_value(dc.get(sid)))
             old_sid = sid
             sid = generate_sid_with(dc)
             session = {}
@@ -99,6 +99,10 @@ module Rack
           end
           [sid, session]
         end
+      end
+
+      def entry_value(s)
+        s.is_a?(ActiveSupport::Cache::Entry) ? s.value : s
       end
 
       def set_session(_env, session_id, new_session, options)


### PR DESCRIPTION
When switching from `:dalli_store` to `:mem_cache_store` for the [Dalli v3](https://github.com/petergoldstein/dalli/blob/master/History.md#300) update, this error began raising in my rails app:
```
<NoMethodError: undefined method `stringify_keys' for #<ActiveSupport::Cache::Entry:0x00007fd04602da...021 23:00:16.939192000 UTC +00:00}}, @version=nil, @created_at=1637704817.3283908, @expires_in=nil>> 
with backtrace: .rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/actionpack-6.1.4.1/lib/action_dispatch/request/session.rb:236:in `load!'
```

It appears to be related to the way `ActiveSupport::Cache::MemCacheStore` writes session data as an `Entry` class:
https://github.com/rails/rails/blob/v6.1.4.1/activesupport/lib/active_support/cache/mem_cache_store.rb#L149

For example:
```
> mc = ActiveSupport::Cache::MemCacheStore.new
=> #<ActiveSupport::Cache::MemCacheStore:0x00007f8b04976e68>

> mc.write('k', 'v')
=> 12107646123208867840

> mc.read('k')
=> "v"

> dc = Dalli::Client.new
=> #<Dalli::Client:0x00007f8af6fb4978 @options={}, @ring=nil, @servers=["localhost:11211"]>

> dc.get('k')
=> #<ActiveSupport::Cache::Entry:0x00007f8b04165648 @created_at=1637705128.0518441, @expires_in=nil, @value="v", @version=nil>

> dc.get('k').value
=> "v"
```

In `Rack::Session::Dalli#get_session` the session is found via `Dalli::Client#get` which doesn't check or handle the Entry value after lookup in the same way that [ActiveSupport::Cache#read](https://github.com/rails/rails/blob/v6.1.4.1/activesupport/lib/active_support/cache.rb#L379) does.

I think that is ultimately is leading to the error in rails when attempting to load the session here:
https://github.com/rails/rails/blob/v6.1.4.1/actionpack/lib/action_dispatch/request/session.rb#L236
