### PR TITLE
Ensure against socket corruption by errors in a multi block.

### DIFF
--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -67,6 +67,7 @@ module Dalli
       Thread.current[:dalli_multi] = true
       yield
     ensure
+      @ring&.flush_multi_responses
       Thread.current[:dalli_multi] = old
     end
 

--- a/lib/dalli/ring.rb
+++ b/lib/dalli/ring.rb
@@ -65,6 +65,15 @@ module Dalli
       end
     end
 
+    def flush_multi_responses
+      @servers.each do |s|
+        s.request(:noop)
+      rescue DalliError::NetworkError
+        # Ignore this error, as it indicates the socket is unavailable
+        # and there's no need to flush
+      end
+    end
+
     private
 
     def threadsafe!

--- a/test/test_dalli.rb
+++ b/test/test_dalli.rb
@@ -306,7 +306,7 @@ describe 'Dalli' do
       end
     end
 
-    it 'support multi-get' do
+    it 'supports multi-get' do
       memcached_persistent do |dc|
         dc.close
         dc.flush
@@ -340,6 +340,23 @@ describe 'Dalli' do
         result = dc.get_multi(arr)
         assert_equal(1000, result.size)
         assert_equal(50, result['50'])
+      end
+    end
+
+    it 'does not corrupt multiget with errors' do
+      memcached_persistent do |dc|
+        dc.close
+        dc.flush
+        dc.set('a', 'av')
+        dc.set('b', 'bv')
+        assert_equal 'av', dc.get('a')
+        assert_equal 'bv', dc.get('b')
+
+        dc.multi do
+          dc.delete('non_existent_key')
+        end
+        assert_equal 'av', dc.get('a')
+        assert_equal 'bv', dc.get('b')
       end
     end
 


### PR DESCRIPTION
This change ensure that if an error occurs in an allowed operation in a multi block (e.g. setq, replaceq, deleteq) that error response is cleared from the socket at the end of the multi block.  This ensures that subsequent operations behave as expected.  Specifically it addresses issue #772 

While this is a reasonable start, there are a couple of issues with this implementation:

1. It executes a noop operation against each server in the ring at the end of the multi block, even if no multi operation was run against that server
2. The noop operations are run in sequence, not in parallel
3. The error responses are not returned to the caller and, even if they were returned, wouldn't be usable

That all said, it accomplishes the desired effect without introducing too much of a burden.  Resolving the above issues would require a much more dramatic set of changes, and would likely have compatibility implications.  So we'll stick with this more limited fix for now.