### PR TITLE
Raise an error if an unsupported operation is used in a multi block

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -14,7 +14,7 @@ Metrics/AbcSize:
 # Offense count: 3
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 376
+  Max: 386
 
 # Offense count: 6
 # Configuration parameters: CountComments, CountAsOne, ExcludedMethods, IgnoredMethods.

--- a/History.md
+++ b/History.md
@@ -4,7 +4,8 @@ Dalli Changelog
 Unreleased
 ==========
 
-- Update Rack::Session::Dalli to inherit from Abstract::PersistedSecure (petergoldstein)
+- BREAKING CHANGE: Update Rack::Session::Dalli to inherit from Abstract::PersistedSecure.  This will invalidate existing sessions (petergoldstein)
+- BREAKING CHANGE: Use of unsupported operations in a multi block now raise an error. (petergoldstein)
 
 3.0.5
 ==========

--- a/lib/dalli.rb
+++ b/lib/dalli.rb
@@ -24,9 +24,14 @@ module Dalli
   # payload too big for memcached
   class ValueOverMaxSize < DalliError; end
 
+  # operation is not permitted in a multi block
+  class NotPermittedMultiOpError < DalliError; end
+
   # Implements the NullObject pattern to store an application-defined value for 'Key not found' responses.
   class NilObject; end # rubocop:disable Lint/EmptyClass
   NOT_FOUND = NilObject.new
+
+  MULTI_KEY = :dalli_multi
 
   def self.logger
     @logger ||= (rails_logger || default_logger)

--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -63,12 +63,12 @@ module Dalli
     # pipelined as Dalli will use 'quiet' operations where possible.
     # Currently supports the set, add, replace and delete operations.
     def multi
-      old = Thread.current[:dalli_multi]
-      Thread.current[:dalli_multi] = true
+      old = Thread.current[::Dalli::MULTI_KEY]
+      Thread.current[::Dalli::MULTI_KEY] = true
       yield
     ensure
       @ring&.flush_multi_responses
-      Thread.current[:dalli_multi] = old
+      Thread.current[::Dalli::MULTI_KEY] = old
     end
 
     ##


### PR DESCRIPTION
This addresses issue #831 .  This can be considered a breaking change, so I'm bundling it into 3.1.0.  

This PR also includes some simplification of the get multi code.