### PR TITLE
Removes the server attribute from Dalli socket classes, and puts server handling in the PipelinedGetter

### DIFF
--- a/lib/dalli/protocol/binary.rb
+++ b/lib/dalli/protocol/binary.rb
@@ -547,9 +547,9 @@ module Dalli
 
       def memcached_socket
         if socket_type == :unix
-          Dalli::Socket::UNIX.open(hostname, self, options)
+          Dalli::Socket::UNIX.open(hostname, options)
         else
-          Dalli::Socket::TCP.open(hostname, port, self, options)
+          Dalli::Socket::TCP.open(hostname, port, options)
         end
       end
 

--- a/lib/dalli/socket.rb
+++ b/lib/dalli/socket.rb
@@ -67,10 +67,6 @@ module Dalli
         io.options
       end
 
-      def server
-        io.server
-      end
-
       unless method_defined?(:wait_readable)
         def wait_readable(timeout = nil)
           to_io.wait_readable(timeout)
@@ -90,14 +86,12 @@ module Dalli
     class TCP < TCPSocket
       include Dalli::Socket::InstanceMethods
       # options - supports enhanced logging in the case of a timeout
-      # server  - used to support IO.select in the pipelined getter
-      attr_accessor :options, :server
+      attr_accessor :options
 
-      def self.open(host, port, server, options = {})
+      def self.open(host, port, options = {})
         Timeout.timeout(options[:socket_timeout]) do
           sock = new(host, port)
           sock.options = { host: host, port: port }.merge(options)
-          sock.server = server
           init_socket_options(sock, options)
 
           options[:ssl_context] ? wrapping_ssl_socket(sock, host, options[:ssl_context]) : sock
@@ -141,13 +135,12 @@ module Dalli
 
         # options - supports enhanced logging in the case of a timeout
         # server  - used to support IO.select in the pipelined getter
-        attr_accessor :options, :server
+        attr_accessor :options
 
-        def self.open(path, server, options = {})
+        def self.open(path, options = {})
           Timeout.timeout(options[:socket_timeout]) do
             sock = new(path)
             sock.options = { path: path }.merge(options)
-            sock.server = server
             sock
           end
         end

--- a/test/test_dalli.rb
+++ b/test/test_dalli.rb
@@ -30,7 +30,7 @@ describe 'Dalli' do
     it 'opens a standard TCP connection' do
       memcached_persistent do |dc|
         server = dc.send(:ring).servers.first
-        sock = Dalli::Socket::TCP.open(server.hostname, server.port, server, server.options)
+        sock = Dalli::Socket::TCP.open(server.hostname, server.port, server.options)
         assert_equal Dalli::Socket::TCP, sock.class
 
         dc.set('abc', 123)
@@ -41,7 +41,7 @@ describe 'Dalli' do
     it 'opens a SSL TCP connection' do
       memcached_ssl_persistent do |dc|
         server = dc.send(:ring).servers.first
-        sock = Dalli::Socket::TCP.open(server.hostname, server.port, server, server.options)
+        sock = Dalli::Socket::TCP.open(server.hostname, server.port, server.options)
         assert_equal Dalli::Socket::SSLSocket, sock.class
 
         dc.set('abc', 123)


### PR DESCRIPTION
This moves the PipelinedGetter closer to being a Reactor.  It also decouples the socket layer from knowledge of higher level classes (Dalli::Protocol::Binary).  This will make it much easier to extract socket/connection level concerns for reuse.

We've almost got the PipelinedGetter response processing logic suitably cleaned up that we can push process_server down into the server itself, rather than keeping it in the PipelinedGetter.