### PR TITLE
Spike on extracting connection logic from Dalli::Protocol::Binary

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -14,7 +14,7 @@ Metrics/AbcSize:
 # Offense count: 5
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 241
+  Max: 237
 
 # Offense count: 5
 # Configuration parameters: CountComments, CountAsOne, ExcludedMethods, IgnoredMethods.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -11,12 +11,12 @@
 Metrics/AbcSize:
   Max: 19
 
-# Offense count: 4
+# Offense count: 5
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 387
+  Max: 241
 
-# Offense count: 6
+# Offense count: 5
 # Configuration parameters: CountComments, CountAsOne, ExcludedMethods, IgnoredMethods.
 Metrics/MethodLength:
   Exclude:

--- a/History.md
+++ b/History.md
@@ -4,6 +4,8 @@ Dalli Changelog
 Unreleased
 ==========
 
+- Add quiet support for incr, decr, append, depend, and flush (petergoldstein)
+- Additional refactoring to allow reuse of connection behavior (petergoldstein)
 - Fix issue in flush such that it wasn't passing the delay argument to memcached (petergoldstein)
 
 3.1.0

--- a/lib/dalli.rb
+++ b/lib/dalli.rb
@@ -31,7 +31,7 @@ module Dalli
   class NilObject; end # rubocop:disable Lint/EmptyClass
   NOT_FOUND = NilObject.new
 
-  MULTI_KEY = :dalli_multi
+  QUIET = :dalli_multi
 
   def self.logger
     @logger ||= (rails_logger || default_logger)
@@ -63,6 +63,7 @@ require_relative 'dalli/pipelined_getter'
 require_relative 'dalli/ring'
 require_relative 'dalli/protocol'
 require_relative 'dalli/protocol/binary'
+require_relative 'dalli/protocol/connection_manager'
 require_relative 'dalli/protocol/response_buffer'
 require_relative 'dalli/protocol/server_config_parser'
 require_relative 'dalli/protocol/ttl_sanitizer'

--- a/lib/dalli/options.rb
+++ b/lib/dalli/options.rb
@@ -31,19 +31,19 @@ module Dalli
       end
     end
 
-    def pipeline_response_start
+    def pipeline_response_setup
       @lock.synchronize do
         super
       end
     end
 
-    def process_outstanding_pipeline_requests
+    def pipeline_next_responses
       @lock.synchronize do
         super
       end
     end
 
-    def pipeline_response_abort
+    def pipeline_abort
       @lock.synchronize do
         super
       end

--- a/lib/dalli/protocol/binary.rb
+++ b/lib/dalli/protocol/binary.rb
@@ -59,6 +59,9 @@ module Dalli
       # The socket connection to the underlying server is initialized as a side
       # effect of this call.  In fact, this is the ONLY place where that
       # socket connection is initialized.
+      #
+      # Both this method and connect need to be in this class so we can do auth
+      # as required
       def alive?
         return true if connected?
         return false unless reconnect_down_server?
@@ -165,7 +168,7 @@ module Dalli
         verify_allowed_quiet!(opkey) if quiet?
       end
 
-      ALLOWED_QUIET_OPS = %i[add delete replace set incr decr append prepend noop flush].freeze
+      ALLOWED_QUIET_OPS = %i[add replace set delete incr decr append prepend flush noop].freeze
       def verify_allowed_quiet!(opkey)
         return if ALLOWED_QUIET_OPS.include?(opkey)
 

--- a/lib/dalli/protocol/binary.rb
+++ b/lib/dalli/protocol/binary.rb
@@ -20,45 +20,18 @@ module Dalli
     class Binary
       extend Forwardable
 
-      attr_accessor :hostname, :port, :weight, :options
-      attr_reader :sock, :socket_type
+      attr_accessor :weight, :options
 
       def_delegators :@value_marshaller, :serializer, :compressor, :compression_min_size, :compress_by_default?
+      def_delegators :@connection_manager, :name, :sock, :hostname, :port, :close, :connected?, :socket_timeout,
+                     :socket_type, :up!, :down!, :write, :reconnect_down_server?
 
-      DEFAULTS = {
-        # seconds between trying to contact a remote server
-        down_retry_delay: 30,
-        # connect/read/write timeout for socket operations
-        socket_timeout: 1,
-        # times a socket operation may fail before considering the server dead
-        socket_max_failures: 2,
-        # amount of time to sleep between retries when a failure occurs
-        socket_failure_delay: 0.1
-      }.freeze
-
-      def initialize(attribs, options = {})
-        @hostname, @port, @weight, @socket_type, options = ServerConfigParser.parse(attribs, options)
-        @options = DEFAULTS.merge(options)
+      def initialize(attribs, client_options = {})
+        hostname, port, socket_type, @weight, user_creds = ServerConfigParser.parse(attribs)
+        @options = client_options.merge(user_creds)
         @value_marshaller = ValueMarshaller.new(@options)
-        @response_processor = ResponseProcessor.new(self, @value_marshaller)
-        @response_buffer = ResponseBuffer.new(self, @response_processor)
-
-        reset_down_info
-        @sock = nil
-        @pid = nil
-        @request_in_progress = false
-      end
-
-      def response_buffer
-        @response_buffer ||= ResponseBuffer.new(self, @response_processor)
-      end
-
-      def name
-        if socket_type == :unix
-          hostname
-        else
-          "#{hostname}:#{port}"
-        end
+        @connection_manager = ConnectionManager.new(hostname, port, socket_type, @options)
+        @response_processor = ResponseProcessor.new(@connection_manager, @value_marshaller)
       end
 
       # Chokepoint method for error handling and ensuring liveness
@@ -73,7 +46,7 @@ module Dalli
         begin
           send(opkey, *args)
         rescue Dalli::MarshalError => e
-          log_marshall_err(args.first, e)
+          log_marshal_err(args.first, e)
           raise
         rescue Dalli::DalliError, Dalli::NetworkError, Dalli::ValueOverMaxSize, Timeout::Error
           raise
@@ -83,61 +56,17 @@ module Dalli
         end
       end
 
-      def raise_memcached_down_err
-        raise Dalli::NetworkError,
-              "#{name} is down: #{@error} #{@msg}. If you are sure it is running, "\
-              "ensure memcached version is > #{::Dalli::MIN_SUPPORTED_MEMCACHED_VERSION}."
-      end
-
-      def log_marshall_err(key, err)
-        Dalli.logger.error "Marshalling error for key '#{key}': #{err.message}"
-        Dalli.logger.error 'You are trying to cache a Ruby object which cannot be serialized to memcached.'
-      end
-
-      def log_unexpected_err(err)
-        Dalli.logger.error "Unexpected exception during Dalli request: #{err.class.name}: #{err.message}"
-        Dalli.logger.error err.backtrace.join("\n\t")
-      end
-
       # The socket connection to the underlying server is initialized as a side
       # effect of this call.  In fact, this is the ONLY place where that
       # socket connection is initialized.
       def alive?
-        return true if @sock
+        return true if connected?
         return false unless reconnect_down_server?
 
-        connect
-        !!@sock
+        connect # This call needs to be in this class so we can do auth
+        connected?
       rescue Dalli::NetworkError
         false
-      end
-
-      def reconnect_down_server?
-        return true unless @last_down_at
-
-        time_to_next_reconnect = @last_down_at + options[:down_retry_delay] - Time.now
-        return true unless time_to_next_reconnect.positive?
-
-        Dalli.logger.debug do
-          format('down_retry_delay not reached for %<name>s (%<time>.3f seconds left)', name: name,
-                                                                                        time: time_to_next_reconnect)
-        end
-        false
-      end
-
-      # Closes the underlying socket and cleans up
-      # socket state.
-      def close
-        return unless @sock
-
-        begin
-          @sock.close
-        rescue StandardError
-          nil
-        end
-        @sock = nil
-        @pid = nil
-        abort_request!
       end
 
       def lock!; end
@@ -149,224 +78,102 @@ module Dalli
       # flushing responses for kv pairs that were found.
       #
       # Returns nothing.
-      def pipeline_response_start
+      def pipeline_response_setup
         verify_state(:getkq)
         write_noop
         response_buffer.reset
-        start_request!
-      end
-
-      # Did the last call to #pipeline_response_start complete successfully?
-      def pipeline_response_completed?
-        response_buffer.completed?
-      end
-
-      def pipeline_response(bytes_to_advance = 0)
-        response_buffer.process_single_response(bytes_to_advance)
-      end
-
-      def reconnect_on_pipeline_complete!
-        reconnect! 'multi_response has completed' if pipeline_response_completed?
+        @connection_manager.start_request!
       end
 
       # Attempt to receive and parse as many key/value pairs as possible
-      # from this server. After #pipeline_response_start, this should be invoked
+      # from this server. After #pipeline_response_setup, this should be invoked
       # repeatedly whenever this server's socket is readable until
-      # #pipeline_response_completed?.
+      # #pipeline_complete?.
       #
       # Returns a Hash of kv pairs received.
-      def process_outstanding_pipeline_requests
+      def pipeline_next_responses
         reconnect_on_pipeline_complete!
         values = {}
 
         response_buffer.read
 
-        bytes_to_advance, status, key, value, cas = pipeline_response
-        # Loop while we have at least a complete header in the buffer
-        while bytes_to_advance.positive?
-          # If the status and key length are both zero, then this is the response
+        resp_header, key, value = pipeline_response
+        # resp_header is not nil only if we have a full response to parse
+        # in the buffer
+        while resp_header
+          # If the status is ok and key is nil, then this is the response
           # to the noop at the end of the pipeline
-          if status.zero? && key.nil?
-            finish_pipeline
-            break
-          end
+          finish_pipeline && break if resp_header.ok? && key.nil?
 
-          # If the status is zero and the key len is positive, then this is a
+          # If the status is ok and the key is not nil, then this is a
           # getkq response with a value that we want to set in the response hash
-          values[key] = [value, cas] unless key.nil?
+          values[key] = [value, resp_header.cas] unless key.nil?
 
-          # Get the next set of bytes from the buffer
-          bytes_to_advance, status, key, value, cas = pipeline_response(bytes_to_advance)
+          # Get the next response from the buffer
+          resp_header, key, value = pipeline_response
         end
 
         values
       rescue SystemCallError, Timeout::Error, EOFError => e
-        failure!(e)
+        @connection_manager.error_on_request!(e)
       end
 
-      def read_nonblock
-        @sock.read_available
-      end
-
-      # Called after the noop response is received at the end of a set
-      # of pipelined gets
-      def finish_pipeline
-        response_buffer.clear
-        finish_request!
-      end
-
-      # Abort an earlier #pipeline_response_start. Used to signal an external
-      # timeout. The underlying socket is disconnected, and the exception is
-      # swallowed.
+      # Abort current pipelined get. Generally used to signal an external
+      # timeout during pipelined get.  The underlying socket is
+      # disconnected, and the exception is swallowed.
       #
       # Returns nothing.
-      def pipeline_response_abort
+      def pipeline_abort
         response_buffer.clear
-        abort_request!
-        return true unless @sock
+        @connection_manager.abort_request!
+        return true unless connected?
 
-        failure!(RuntimeError.new('External timeout'))
+        # Closes the connection, which ensures that our connection
+        # is in a clean state for future requests
+        @connection_manager.error_on_request!('External timeout')
       rescue NetworkError
         true
       end
 
-      def read(count)
-        start_request!
-        data = @sock.readfull(count)
-        finish_request!
-        data
-      rescue SystemCallError, Timeout::Error, EOFError => e
-        failure!(e)
+      # Did the last call to #pipeline_response_setup complete successfully?
+      def pipeline_complete?
+        !response_buffer.in_progress?
       end
 
-      def write(bytes)
-        start_request!
-        result = @sock.write(bytes)
-        finish_request!
-        result
-      rescue SystemCallError, Timeout::Error => e
-        failure!(e)
+      def username
+        @options[:username] || ENV['MEMCACHE_USERNAME']
       end
 
-      def connected?
-        !@sock.nil?
+      def password
+        @options[:password] || ENV['MEMCACHE_PASSWORD']
       end
 
-      def socket_timeout
-        @socket_timeout ||= @options[:socket_timeout]
+      def require_auth?
+        !username.nil?
       end
 
       # NOTE: Additional public methods should be overridden in Dalli::Threadsafe
 
       private
 
-      def request_in_progress?
-        @request_in_progress
-      end
-
-      def start_request!
-        @request_in_progress = true
-      end
-
-      def finish_request!
-        @request_in_progress = false
-      end
-
-      def abort_request!
-        @request_in_progress = false
-      end
-
+      ##
+      # Checks to see if we can execute the specified operation.  Checks
+      # whether the connection is in use, and whether the command is allowed
+      ##
       def verify_state(opkey)
-        failure!(RuntimeError.new('Already writing to socket')) if request_in_progress?
-        reconnect_on_fork if fork_detected?
-        verify_allowed_multi!(opkey) if multi?
+        @connection_manager.confirm_ready!
+        verify_allowed_quiet!(opkey) if quiet?
       end
 
-      def fork_detected?
-        @pid && @pid != Process.pid
+      ALLOWED_QUIET_OPS = %i[add delete replace set incr decr append prepend noop flush].freeze
+      def verify_allowed_quiet!(opkey)
+        return if ALLOWED_QUIET_OPS.include?(opkey)
+
+        raise Dalli::NotPermittedMultiOpError, "The operation #{opkey} is not allowed in a quiet block."
       end
 
-      ALLOWED_MULTI_OPS = %i[add addq delete deleteq replace replaceq set setq noop].freeze
-      def verify_allowed_multi!(opkey)
-        return if ALLOWED_MULTI_OPS.include?(opkey)
-
-        raise Dalli::NotPermittedMultiOpError, "The operation #{opkey} is not allowed in a multi block."
-      end
-
-      def reconnect_on_fork
-        message = 'Fork detected, re-connecting child process...'
-        Dalli.logger.info { message }
-        reconnect! message
-      end
-
-      # Marks the server instance as needing reconnect.  Raises a
-      # Dalli::NetworkError with the specified message.  Calls close
-      # to clean up socket state
-      def reconnect!(message)
-        close
-        sleep(options[:socket_failure_delay]) if options[:socket_failure_delay]
-        raise Dalli::NetworkError, message
-      end
-
-      # Raises Dalli::NetworkError
-      def failure!(exception)
-        message = "#{name} failed (count: #{@fail_count}) #{exception.class}: #{exception.message}"
-        Dalli.logger.warn { message }
-
-        @fail_count += 1
-        if @fail_count >= options[:socket_max_failures]
-          down!
-        else
-          reconnect! 'Socket operation failed, retrying...'
-        end
-      end
-
-      # Marks the server instance as down.  Updates the down_at state
-      # and raises an Dalli::NetworkError that includes the underlying
-      # error in the message.  Calls close to clean up socket state
-      def down!
-        close
-        log_down_detected
-
-        @error = $ERROR_INFO&.class&.name
-        @msg ||= $ERROR_INFO&.message
-        raise Dalli::NetworkError, "#{name} is down: #{@error} #{@msg}"
-      end
-
-      def log_down_detected
-        @last_down_at = Time.now
-
-        if @down_at
-          time = Time.now - @down_at
-          Dalli.logger.debug { format('%<name>s is still down (for %<time>.3f seconds now)', name: name, time: time) }
-        else
-          @down_at = @last_down_at
-          Dalli.logger.warn("#{name} is down")
-        end
-      end
-
-      def log_up_detected
-        return unless @down_at
-
-        time = Time.now - @down_at
-        Dalli.logger.warn { format('%<name>s is back (downtime was %<time>.3f seconds)', name: name, time: time) }
-      end
-
-      def up!
-        log_up_detected
-        reset_down_info
-      end
-
-      def reset_down_info
-        @fail_count = 0
-        @down_at = nil
-        @last_down_at = nil
-        @msg = nil
-        @error = nil
-      end
-
-      def multi?
-        Thread.current[::Dalli::MULTI_KEY]
+      def quiet?
+        Thread.current[::Dalli::QUIET]
       end
 
       def cache_nils?(opts)
@@ -375,39 +182,52 @@ module Dalli
         opts[:cache_nils] ? true : false
       end
 
+      # Retrieval Commands
       def get(key, options = nil)
         req = RequestFormatter.standard_request(opkey: :get, key: key)
         write(req)
         @response_processor.generic_response(unpack: true, cache_nils: cache_nils?(options))
       end
 
-      def pipelined_get(keys)
-        req = +''
-        keys.each do |key|
-          req << RequestFormatter.standard_request(opkey: :getkq, key: key)
-        end
-        # Could send noop here instead of in pipeline_response_start
+      def gat(key, ttl, options = nil)
+        ttl = TtlSanitizer.sanitize(ttl)
+        req = RequestFormatter.standard_request(opkey: :gat, key: key, ttl: ttl)
         write(req)
+        @response_processor.generic_response(unpack: true, cache_nils: cache_nils?(options))
       end
 
+      def touch(key, ttl)
+        ttl = TtlSanitizer.sanitize(ttl)
+        write(RequestFormatter.standard_request(opkey: :touch, key: key, ttl: ttl))
+        @response_processor.generic_response
+      end
+
+      # TODO: This is confusing, as there's a cas command in memcached
+      # and this isn't it.  Maybe rename?  Maybe eliminate?
+      def cas(key)
+        req = RequestFormatter.standard_request(opkey: :get, key: key)
+        write(req)
+        @response_processor.data_cas_response
+      end
+
+      # Storage Commands
       def set(key, value, ttl, cas, options)
-        opkey = multi? ? :setq : :set
-        process_value_req(opkey, key, value, ttl, cas, options)
+        opkey = quiet? ? :setq : :set
+        storage_req(opkey, key, value, ttl, cas, options)
       end
 
       def add(key, value, ttl, options)
-        opkey = multi? ? :addq : :add
-        cas = 0
-        process_value_req(opkey, key, value, ttl, cas, options)
+        opkey = quiet? ? :addq : :add
+        storage_req(opkey, key, value, ttl, 0, options)
       end
 
       def replace(key, value, ttl, cas, options)
-        opkey = multi? ? :replaceq : :replace
-        process_value_req(opkey, key, value, ttl, cas, options)
+        opkey = quiet? ? :replaceq : :replace
+        storage_req(opkey, key, value, ttl, cas, options)
       end
 
       # rubocop:disable Metrics/ParameterLists
-      def process_value_req(opkey, key, value, ttl, cas, options)
+      def storage_req(opkey, key, value, ttl, cas, options)
         (value, bitflags) = @value_marshaller.store(key, value, options)
         ttl = TtlSanitizer.sanitize(ttl)
 
@@ -415,21 +235,42 @@ module Dalli
                                                 value: value, bitflags: bitflags,
                                                 ttl: ttl, cas: cas)
         write(req)
-        @response_processor.cas_response unless multi?
+        @response_processor.storage_response unless quiet?
       end
       # rubocop:enable Metrics/ParameterLists
 
-      def delete(key, cas)
-        opkey = multi? ? :deleteq : :delete
-        req = RequestFormatter.standard_request(opkey: opkey, key: key, cas: cas)
-        write(req)
-        @response_processor.generic_response unless multi?
+      def append(key, value)
+        opkey = quiet? ? :appendq : :append
+        write_append_prepend opkey, key, value
       end
 
-      def flush(ttl = 0)
-        req = RequestFormatter.standard_request(opkey: :flush, ttl: ttl)
+      def prepend(key, value)
+        opkey = quiet? ? :prependq : :prepend
+        write_append_prepend opkey, key, value
+      end
+
+      def write_append_prepend(opkey, key, value)
+        write(RequestFormatter.standard_request(opkey: opkey, key: key, value: value))
+        @response_processor.no_body_response unless quiet?
+      end
+
+      # Delete Commands
+      def delete(key, cas)
+        opkey = quiet? ? :deleteq : :delete
+        req = RequestFormatter.standard_request(opkey: opkey, key: key, cas: cas)
         write(req)
-        @response_processor.generic_response
+        @response_processor.no_body_response unless quiet?
+      end
+
+      # Arithmetic Commands
+      def decr(key, count, ttl, initial)
+        opkey = quiet? ? :decrq : :decr
+        decr_incr opkey, key, count, ttl, initial
+      end
+
+      def incr(key, count, ttl, initial)
+        opkey = quiet? ? :incrq : :incr
+        decr_incr opkey, key, count, ttl, initial
       end
 
       # This allows us to special case a nil initial value, and
@@ -444,29 +285,14 @@ module Dalli
         initial ||= 0
         write(RequestFormatter.decr_incr_request(opkey: opkey, key: key,
                                                  count: count, initial: initial, expiry: expiry))
-        @response_processor.decr_incr_response
+        @response_processor.decr_incr_response unless quiet?
       end
 
-      def decr(key, count, ttl, initial)
-        decr_incr :decr, key, count, ttl, initial
-      end
-
-      def incr(key, count, ttl, initial)
-        decr_incr :incr, key, count, ttl, initial
-      end
-
-      def write_append_prepend(opkey, key, value)
-        write_generic RequestFormatter.standard_request(opkey: opkey, key: key, value: value)
-      end
-
-      def write_generic(bytes)
-        write(bytes)
-        @response_processor.generic_response
-      end
-
-      def write_noop
-        req = RequestFormatter.standard_request(opkey: :noop)
-        write(req)
+      # Other Commands
+      def flush(ttl = 0)
+        opkey = quiet? ? :flushq : :flush
+        write(RequestFormatter.standard_request(opkey: opkey, ttl: ttl))
+        @response_processor.no_body_response unless quiet?
       end
 
       # Noop is a keepalive operation but also used to demarcate the end of a set of pipelined commands.
@@ -476,14 +302,6 @@ module Dalli
         @response_processor.multi_with_keys_response
       end
 
-      def append(key, value)
-        write_append_prepend :append, key, value
-      end
-
-      def prepend(key, value)
-        write_append_prepend :prepend, key, value
-      end
-
       def stats(info = '')
         req = RequestFormatter.standard_request(opkey: :stat, key: info)
         write(req)
@@ -491,66 +309,73 @@ module Dalli
       end
 
       def reset_stats
-        write_generic RequestFormatter.standard_request(opkey: :stat, key: 'reset')
-      end
-
-      def cas(key)
-        req = RequestFormatter.standard_request(opkey: :get, key: key)
-        write(req)
-        @response_processor.data_cas_response
+        write(RequestFormatter.standard_request(opkey: :stat, key: 'reset'))
+        @response_processor.generic_response
       end
 
       def version
-        write_generic RequestFormatter.standard_request(opkey: :version)
+        write(RequestFormatter.standard_request(opkey: :version))
+        @response_processor.generic_response
       end
 
-      def touch(key, ttl)
-        ttl = TtlSanitizer.sanitize(ttl)
-        write_generic RequestFormatter.standard_request(opkey: :touch, key: key, ttl: ttl)
-      end
-
-      def gat(key, ttl, options = nil)
-        ttl = TtlSanitizer.sanitize(ttl)
-        req = RequestFormatter.standard_request(opkey: :gat, key: key, ttl: ttl)
+      def write_noop
+        req = RequestFormatter.standard_request(opkey: :noop)
         write(req)
-        @response_processor.generic_response(unpack: true, cache_nils: cache_nils?(options))
       end
 
       def connect
-        Dalli.logger.debug { "Dalli::Server#connect #{name}" }
+        @connection_manager.establish_connection
+        authenticate_connection if require_auth?
+        @version = version # Connect socket if not authed
+        up!
+      rescue Dalli::DalliError
+        raise
+      end
 
-        begin
-          @pid = Process.pid
-          @sock = memcached_socket
-          authenticate_connection if require_auth?
-          @version = version # Connect socket if not authed
-          up!
-        rescue Dalli::DalliError # SASL auth failure
-          raise
-        rescue SystemCallError, Timeout::Error, EOFError, SocketError => e
-          # SocketError = DNS resolution failure
-          failure!(e)
+      def pipelined_get(keys)
+        req = +''
+        keys.each do |key|
+          req << RequestFormatter.standard_request(opkey: :getkq, key: key)
         end
+        # Could send noop here instead of in pipeline_response_setup
+        write(req)
       end
 
-      def memcached_socket
-        if socket_type == :unix
-          Dalli::Socket::UNIX.open(hostname, options)
-        else
-          Dalli::Socket::TCP.open(hostname, port, options)
-        end
+      def response_buffer
+        @response_buffer ||= ResponseBuffer.new(@connection_manager, @response_processor)
       end
 
-      def require_auth?
-        !username.nil?
+      def pipeline_response
+        response_buffer.process_single_getk_response
       end
 
-      def username
-        @options[:username] || ENV['MEMCACHE_USERNAME']
+      # Called after the noop response is received at the end of a set
+      # of pipelined gets
+      def finish_pipeline
+        response_buffer.clear
+        @connection_manager.finish_request!
+
+        true # to simplify response
       end
 
-      def password
-        @options[:password] || ENV['MEMCACHE_PASSWORD']
+      def reconnect_on_pipeline_complete!
+        @connection_manager.reconnect! 'pipelined get has completed' if pipeline_complete?
+      end
+
+      def raise_memcached_down_err
+        raise Dalli::NetworkError,
+              "#{name} is down: #{@error} #{@msg}. If you are sure it is running, "\
+              "ensure memcached version is > #{::Dalli::MIN_SUPPORTED_MEMCACHED_VERSION}."
+      end
+
+      def log_marshal_err(key, err)
+        Dalli.logger.error "Marshalling error for key '#{key}': #{err.message}"
+        Dalli.logger.error 'You are trying to cache a Ruby object which cannot be serialized to memcached.'
+      end
+
+      def log_unexpected_err(err)
+        Dalli.logger.error "Unexpected exception during Dalli request: #{err.class.name}: #{err.message}"
+        Dalli.logger.error err.backtrace.join("\n\t")
       end
 
       include SaslAuthentication

--- a/lib/dalli/protocol/binary/request_formatter.rb
+++ b/lib/dalli/protocol/binary/request_formatter.rb
@@ -31,6 +31,7 @@ module Dalli
           deleteq: 0x14,
           incrq: 0x15,
           decrq: 0x16,
+          flushq: 0x18,
           appendq: 0x19,
           prependq: 0x1A,
           touch: 0x1C,

--- a/lib/dalli/protocol/binary/request_formatter.rb
+++ b/lib/dalli/protocol/binary/request_formatter.rb
@@ -31,11 +31,13 @@ module Dalli
           deleteq: 0x14,
           incrq: 0x15,
           decrq: 0x16,
+          appendq: 0x19,
+          prependq: 0x1A,
+          touch: 0x1C,
+          gat: 0x1D,
           auth_negotiation: 0x20,
           auth_request: 0x21,
-          auth_continue: 0x22,
-          touch: 0x1C,
-          gat: 0x1D
+          auth_continue: 0x22
         }.freeze
 
         REQ_HEADER_FORMAT = 'CCnCCnNNQ'
@@ -56,6 +58,8 @@ module Dalli
 
           append: KEY_AND_VALUE,
           prepend: KEY_AND_VALUE,
+          appendq: KEY_AND_VALUE,
+          prependq: KEY_AND_VALUE,
           auth_request: KEY_AND_VALUE,
           auth_continue: KEY_AND_VALUE,
 
@@ -68,8 +72,11 @@ module Dalli
 
           incr: INCR_DECR,
           decr: INCR_DECR,
+          incrq: INCR_DECR,
+          decrq: INCR_DECR,
 
           flush: TTL_ONLY,
+          flushq: TTL_ONLY,
 
           noop: NO_BODY,
           auth_negotiation: NO_BODY,

--- a/lib/dalli/protocol/connection_manager.rb
+++ b/lib/dalli/protocol/connection_manager.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'English'
 require 'socket'
 require 'timeout'
 
@@ -83,6 +84,10 @@ module Dalli
 
         @error = $ERROR_INFO&.class&.name
         @msg ||= $ERROR_INFO&.message
+        raise_down_error
+      end
+
+      def raise_down_error
         raise Dalli::NetworkError, "#{name} is down: #{@error} #{@msg}"
       end
 

--- a/lib/dalli/protocol/connection_manager.rb
+++ b/lib/dalli/protocol/connection_manager.rb
@@ -1,0 +1,237 @@
+# frozen_string_literal: true
+
+require 'socket'
+require 'timeout'
+
+module Dalli
+  module Protocol
+    ##
+    # Manages the socket connection to the server, including ensuring liveness
+    # and retries.
+    ##
+    class ConnectionManager
+      DEFAULTS = {
+        # seconds between trying to contact a remote server
+        down_retry_delay: 30,
+        # connect/read/write timeout for socket operations
+        socket_timeout: 1,
+        # times a socket operation may fail before considering the server dead
+        socket_max_failures: 2,
+        # amount of time to sleep between retries when a failure occurs
+        socket_failure_delay: 0.1,
+        # Set keepalive
+        keepalive: true
+      }.freeze
+
+      attr_accessor :hostname, :port, :socket_type, :options
+      attr_reader :sock
+
+      def initialize(hostname, port, socket_type, client_options)
+        @hostname = hostname
+        @port = port
+        @socket_type = socket_type
+        @options = DEFAULTS.merge(client_options)
+        @request_in_progress = false
+        @sock = nil
+        @pid = nil
+
+        reset_down_info
+      end
+
+      def name
+        if socket_type == :unix
+          hostname
+        else
+          "#{hostname}:#{port}"
+        end
+      end
+
+      def establish_connection
+        Dalli.logger.debug { "Dalli::Server#connect #{name}" }
+
+        @sock = memcached_socket
+        @pid = Process.pid
+      rescue SystemCallError, Timeout::Error, EOFError, SocketError => e
+        # SocketError = DNS resolution failure
+        error_on_request!(e)
+      end
+
+      def reconnect_down_server?
+        return true unless @last_down_at
+
+        time_to_next_reconnect = @last_down_at + options[:down_retry_delay] - Time.now
+        return true unless time_to_next_reconnect.positive?
+
+        Dalli.logger.debug do
+          format('down_retry_delay not reached for %<name>s (%<time>.3f seconds left)', name: name,
+                                                                                        time: time_to_next_reconnect)
+        end
+        false
+      end
+
+      def up!
+        log_up_detected
+        reset_down_info
+      end
+
+      # Marks the server instance as down.  Updates the down_at state
+      # and raises an Dalli::NetworkError that includes the underlying
+      # error in the message.  Calls close to clean up socket state
+      def down!
+        close
+        log_down_detected
+
+        @error = $ERROR_INFO&.class&.name
+        @msg ||= $ERROR_INFO&.message
+        raise Dalli::NetworkError, "#{name} is down: #{@error} #{@msg}"
+      end
+
+      def socket_timeout
+        @socket_timeout ||= @options[:socket_timeout]
+      end
+
+      def confirm_ready!
+        error_on_request!(RuntimeError.new('Already writing to socket')) if request_in_progress?
+        close_on_fork if fork_detected?
+      end
+
+      def close
+        return unless @sock
+
+        begin
+          @sock.close
+        rescue StandardError
+          nil
+        end
+        @sock = nil
+        @pid = nil
+        abort_request!
+      end
+
+      def connected?
+        !@sock.nil?
+      end
+
+      def request_in_progress?
+        @request_in_progress
+      end
+
+      def start_request!
+        @request_in_progress = true
+      end
+
+      def finish_request!
+        @request_in_progress = false
+      end
+
+      def abort_request!
+        @request_in_progress = false
+      end
+
+      def read(count)
+        start_request!
+        data = @sock.readfull(count)
+        finish_request!
+        data
+      rescue SystemCallError, Timeout::Error, EOFError => e
+        error_on_request!(e)
+      end
+
+      def write(bytes)
+        start_request!
+        result = @sock.write(bytes)
+        finish_request!
+        result
+      rescue SystemCallError, Timeout::Error => e
+        error_on_request!(e)
+      end
+
+      # Non-blocking read.  Should only be used in the context
+      # of a caller who has called start_request!, but not yet
+      # called finish_request!.  Here to support the operation
+      # of the get_multi operation
+      def read_nonblock
+        @sock.read_available
+      end
+
+      def max_allowed_failures
+        @max_allowed_failures ||= @options[:socket_max_failures] || 2
+      end
+
+      def error_on_request!(err_or_string)
+        log_warn_message(err_or_string)
+
+        @fail_count += 1
+        if @fail_count >= max_allowed_failures
+          down!
+        else
+          # Closes the existing socket, setting up for a reconnect
+          # on next request
+          reconnect!('Socket operation failed, retrying...')
+        end
+      end
+
+      def reconnect!(message)
+        close
+        sleep(options[:socket_failure_delay]) if options[:socket_failure_delay]
+        raise Dalli::NetworkError, message
+      end
+
+      def reset_down_info
+        @fail_count = 0
+        @down_at = nil
+        @last_down_at = nil
+        @msg = nil
+        @error = nil
+      end
+
+      def memcached_socket
+        if socket_type == :unix
+          Dalli::Socket::UNIX.open(hostname, options)
+        else
+          Dalli::Socket::TCP.open(hostname, port, options)
+        end
+      end
+
+      def log_warn_message(err_or_string)
+        detail = err_or_string.is_a?(String) ? err_or_string : "#{err_or_string.class}: #{err_or_string.message}"
+        Dalli.logger.warn do
+          detail = err_or_string.is_a?(String) ? err_or_string : "#{err_or_string.class}: #{err_or_string.message}"
+          "#{name} failed (count: #{@fail_count}) #{detail}"
+        end
+      end
+
+      def close_on_fork
+        message = 'Fork detected, re-connecting child process...'
+        Dalli.logger.info { message }
+        # Close socket on a fork, setting us up for reconnect
+        # on next request.
+        close
+        raise Dalli::NetworkError, message
+      end
+
+      def fork_detected?
+        @pid && @pid != Process.pid
+      end
+
+      def log_down_detected
+        @last_down_at = Time.now
+
+        if @down_at
+          time = Time.now - @down_at
+          Dalli.logger.debug { format('%<name>s is still down (for %<time>.3f seconds now)', name: name, time: time) }
+        else
+          @down_at = @last_down_at
+          Dalli.logger.warn("#{name} is down")
+        end
+      end
+
+      def log_up_detected
+        return unless @down_at
+
+        time = Time.now - @down_at
+        Dalli.logger.warn { format('%<name>s is back (downtime was %<time>.3f seconds)', name: name, time: time) }
+      end
+    end
+  end
+end

--- a/lib/dalli/protocol/response_buffer.rb
+++ b/lib/dalli/protocol/response_buffer.rb
@@ -20,18 +20,21 @@ module Dalli
 
       # Attempts to process a single response from the buffer.  Starts
       # by advancing the buffer to the specified start position
-      def process_single_response(start_position = 0)
-        advance(start_position)
-        @response_processor.getk_response_from_buffer(@buffer)
+      def process_single_getk_response
+        bytes, resp_header, key, value = @response_processor.getk_response_from_buffer(@buffer)
+        advance(bytes)
+        [resp_header, key, value]
       end
 
       # Advances the internal response buffer by bytes_to_advance
       # bytes.  The
       def advance(bytes_to_advance)
+        return unless bytes_to_advance.positive?
+
         @buffer = @buffer[bytes_to_advance..-1]
       end
 
-      # Resets the internal  buffer to an empty state,
+      # Resets the internal buffer to an empty state,
       # so that we're ready to read pipelined responses
       def reset
         @buffer = +''
@@ -42,8 +45,8 @@ module Dalli
         @buffer = nil
       end
 
-      def completed?
-        @buffer.nil?
+      def in_progress?
+        !@buffer.nil?
       end
     end
   end

--- a/lib/dalli/protocol/server_config_parser.rb
+++ b/lib/dalli/protocol/server_config_parser.rb
@@ -19,22 +19,22 @@ module Dalli
       DEFAULT_PORT = 11_211
       DEFAULT_WEIGHT = 1
 
-      def self.parse(str, client_options)
-        return parse_non_uri(str, client_options) unless str.start_with?(MEMCACHED_URI_PROTOCOL)
+      def self.parse(str)
+        return parse_non_uri(str) unless str.start_with?(MEMCACHED_URI_PROTOCOL)
 
-        parse_uri(str, client_options)
+        parse_uri(str)
       end
 
-      def self.parse_uri(str, client_options)
+      def self.parse_uri(str)
         uri = URI.parse(str)
         auth_details = {
           username: uri.user,
           password: uri.password
         }
-        [uri.host, normalize_port(uri.port), DEFAULT_WEIGHT, :tcp, client_options.merge(auth_details)]
+        [uri.host, normalize_port(uri.port), :tcp, DEFAULT_WEIGHT, auth_details]
       end
 
-      def self.parse_non_uri(str, client_options)
+      def self.parse_non_uri(str)
         res = deconstruct_string(str)
 
         hostname = normalize_host_from_match(str, res)
@@ -45,7 +45,7 @@ module Dalli
           socket_type = :tcp
           port, weight = attributes_for_tcp_socket(res)
         end
-        [hostname, port, weight, socket_type, client_options]
+        [hostname, port, socket_type, weight, {}]
       end
 
       def self.deconstruct_string(str)

--- a/test/test_binary_protocol.rb
+++ b/test/test_binary_protocol.rb
@@ -99,22 +99,22 @@ describe Dalli::Protocol::Binary do
     end
   end
 
-  describe 'process_outstanding_pipeline_requests' do
+  describe 'pipeline_next_responses' do
     subject { Dalli::Protocol::Binary.new('127.0.0.1') }
 
-    it 'raises NetworkError when called before pipeline_response_start' do
+    it 'raises NetworkError when called before pipeline_response_setup' do
       assert_raises Dalli::NetworkError do
         subject.request(:pipelined_get, %w[a b])
-        subject.process_outstanding_pipeline_requests
+        subject.pipeline_next_responses
       end
     end
 
-    it 'raises NetworkError when called after pipeline_response_abort' do
+    it 'raises NetworkError when called after pipeline_abort' do
       assert_raises Dalli::NetworkError do
         subject.request(:pipelined_get, %w[a b])
-        subject.pipeline_response_start
-        subject.pipeline_response_abort
-        subject.process_outstanding_pipeline_requests
+        subject.pipeline_response_setup
+        subject.pipeline_abort
+        subject.pipeline_next_responses
       end
     end
   end

--- a/test/test_dalli.rb
+++ b/test/test_dalli.rb
@@ -356,12 +356,12 @@ describe 'Dalli' do
         assert_equal 'av', dc.get('a')
         assert_equal 'bv', dc.get('b')
 
-        refute Thread.current[::Dalli::MULTI_KEY]
+        refute Thread.current[::Dalli::QUIET]
         dc.multi do
-          assert Thread.current[::Dalli::MULTI_KEY]
+          assert Thread.current[::Dalli::QUIET]
           dc.delete('non_existent_key')
         end
-        refute Thread.current[::Dalli::MULTI_KEY]
+        refute Thread.current[::Dalli::QUIET]
         assert_equal 'av', dc.get('a')
         assert_equal 'bv', dc.get('b')
       end
@@ -376,14 +376,14 @@ describe 'Dalli' do
         assert_equal 'av', dc.get('a')
         assert_equal 'bv', dc.get('b')
 
-        refute Thread.current[::Dalli::MULTI_KEY]
+        refute Thread.current[::Dalli::QUIET]
         dc.multi do
-          assert Thread.current[::Dalli::MULTI_KEY]
+          assert Thread.current[::Dalli::QUIET]
           assert_raises Dalli::NotPermittedMultiOpError do
             dc.get('a')
           end
         end
-        refute Thread.current[::Dalli::MULTI_KEY]
+        refute Thread.current[::Dalli::QUIET]
       end
     end
 
@@ -532,7 +532,7 @@ describe 'Dalli' do
         dc.set(:a, 1)
         ring = dc.send(:ring)
         server = ring.servers.first
-        socket = server.instance_variable_get('@sock')
+        socket = server.sock
 
         optval = socket.getsockopt(Socket::SOL_SOCKET, Socket::SO_KEEPALIVE)
         optval = optval.unpack 'i'

--- a/test/test_quiet.rb
+++ b/test/test_quiet.rb
@@ -1,0 +1,239 @@
+# frozen_string_literal: true
+
+require_relative 'helper'
+
+describe 'Dalli' do
+  it 'supports the use of set in a quiet block' do
+    memcached_persistent do |dc|
+      dc.close
+      dc.flush
+      key = SecureRandom.hex(3)
+      value = SecureRandom.hex(3)
+      refute Thread.current[::Dalli::QUIET]
+      dc.quiet do
+        assert Thread.current[::Dalli::QUIET]
+
+        # Response should be nil
+        assert_nil dc.set(key, value)
+      end
+      refute Thread.current[::Dalli::QUIET]
+
+      assert_equal value, dc.get(key)
+    end
+  end
+
+  it 'supports the use of add in a quiet block' do
+    memcached_persistent do |dc|
+      dc.close
+      dc.flush
+      key = SecureRandom.hex(3)
+      existing = SecureRandom.hex(4)
+      oldvalue = SecureRandom.hex(3)
+      value = SecureRandom.hex(3)
+      dc.set(existing, oldvalue)
+      refute Thread.current[::Dalli::QUIET]
+      dc.quiet do
+        assert Thread.current[::Dalli::QUIET]
+
+        # Response should be nil
+        assert_nil dc.add(key, value)
+
+        # Should handle error case without error or unexpected behavior
+        assert_nil dc.add(existing, value)
+      end
+      refute Thread.current[::Dalli::QUIET]
+
+      assert_equal value, dc.get(key)
+      assert_equal oldvalue, dc.get(existing)
+    end
+  end
+
+  it 'supports the use of replace in a quiet block' do
+    memcached_persistent do |dc|
+      dc.close
+      dc.flush
+      key = SecureRandom.hex(3)
+      nonexistent = SecureRandom.hex(4)
+      oldvalue = SecureRandom.hex(3)
+      value = SecureRandom.hex(3)
+      dc.set(key, oldvalue)
+      refute Thread.current[::Dalli::QUIET]
+      dc.quiet do
+        assert Thread.current[::Dalli::QUIET]
+
+        # Response should be nil
+        assert_nil dc.replace(key, value)
+
+        # Should handle error case without error or unexpected behavior
+        assert_nil dc.replace(nonexistent, value)
+      end
+      refute Thread.current[::Dalli::QUIET]
+
+      assert_equal value, dc.get(key)
+      assert_nil dc.get(nonexistent)
+    end
+  end
+
+  it 'supports the use of delete in a quiet block' do
+    memcached_persistent do |dc|
+      dc.close
+      dc.flush
+      key = SecureRandom.hex(3)
+      existing = SecureRandom.hex(4)
+      value = SecureRandom.hex(3)
+      dc.set(existing, value)
+      refute Thread.current[::Dalli::QUIET]
+      dc.quiet do
+        assert Thread.current[::Dalli::QUIET]
+
+        # Response should be nil
+        assert_nil dc.delete(existing)
+
+        # Should handle error case without error or unexpected behavior
+        assert_nil dc.delete(key)
+      end
+      refute Thread.current[::Dalli::QUIET]
+
+      assert_nil dc.get(existing)
+      assert_nil dc.get(key)
+    end
+  end
+
+  it 'supports the use of append in a quiet block' do
+    memcached_persistent do |dc|
+      dc.close
+      dc.flush
+      key = SecureRandom.hex(3)
+      value = SecureRandom.hex(3)
+      dc.set(key, value, 90, raw: true)
+      refute Thread.current[::Dalli::QUIET]
+      dc.quiet do
+        assert Thread.current[::Dalli::QUIET]
+
+        # Response should be nil
+        assert_nil dc.append(key, 'abc')
+      end
+      refute Thread.current[::Dalli::QUIET]
+
+      assert_equal "#{value}abc", dc.get(key)
+    end
+  end
+
+  it 'supports the use of prepend in a quiet block' do
+    memcached_persistent do |dc|
+      dc.close
+      dc.flush
+      key = SecureRandom.hex(3)
+      value = SecureRandom.hex(3)
+      dc.set(key, value, 90, raw: true)
+      refute Thread.current[::Dalli::QUIET]
+      dc.quiet do
+        assert Thread.current[::Dalli::QUIET]
+
+        # Response should be nil
+        assert_nil dc.prepend(key, 'abc')
+      end
+      refute Thread.current[::Dalli::QUIET]
+
+      assert_equal "abc#{value}", dc.get(key)
+    end
+  end
+
+  it 'supports the use of incr in a quiet block' do
+    memcached_persistent do |dc|
+      dc.close
+      dc.flush
+      key = SecureRandom.hex(3)
+      value = 546
+      incr = 134
+      dc.set(key, value, 90, raw: true)
+      refute Thread.current[::Dalli::QUIET]
+      dc.quiet do
+        assert Thread.current[::Dalli::QUIET]
+
+        # Response should be nil
+        assert_nil dc.incr(key, incr)
+      end
+      refute Thread.current[::Dalli::QUIET]
+
+      assert_equal 680, dc.get(key).to_i
+    end
+  end
+
+  it 'supports the use of decr in a quiet block' do
+    memcached_persistent do |dc|
+      dc.close
+      dc.flush
+      key = SecureRandom.hex(3)
+      value = 546
+      incr = 134
+      dc.set(key, value, 90, raw: true)
+      refute Thread.current[::Dalli::QUIET]
+      dc.quiet do
+        assert Thread.current[::Dalli::QUIET]
+
+        # Response should be nil
+        assert_nil dc.decr(key, incr)
+      end
+
+      assert_equal 412, dc.get(key).to_i
+    end
+  end
+
+  it 'supports the use of flush in a quiet block' do
+    memcached_persistent do |dc|
+      dc.close
+      dc.flush
+      refute Thread.current[::Dalli::QUIET]
+      dc.quiet do
+        assert Thread.current[::Dalli::QUIET]
+
+        # Response should be a non-empty array of nils
+        arr = dc.flush(90)
+        assert_equal 2, arr.size
+        assert arr.all?(&:nil?)
+      end
+      refute Thread.current[::Dalli::QUIET]
+    end
+  end
+
+  it 'does not corrupt the underlying response buffer when a memcached error occurs in a quiet block' do
+    memcached_persistent do |dc|
+      dc.close
+      dc.flush
+      dc.set('a', 'av')
+      dc.set('b', 'bv')
+      assert_equal 'av', dc.get('a')
+      assert_equal 'bv', dc.get('b')
+
+      refute Thread.current[::Dalli::QUIET]
+      dc.multi do
+        assert Thread.current[::Dalli::QUIET]
+        dc.delete('non_existent_key')
+      end
+      refute Thread.current[::Dalli::QUIET]
+      assert_equal 'av', dc.get('a')
+      assert_equal 'bv', dc.get('b')
+    end
+  end
+
+  it 'raises an error if an invalid operation is used in a multi block' do
+    memcached_persistent do |dc|
+      dc.close
+      dc.flush
+      dc.set('a', 'av')
+      dc.set('b', 'bv')
+      assert_equal 'av', dc.get('a')
+      assert_equal 'bv', dc.get('b')
+
+      refute Thread.current[::Dalli::QUIET]
+      dc.multi do
+        assert Thread.current[::Dalli::QUIET]
+        assert_raises Dalli::NotPermittedMultiOpError do
+          dc.get('a')
+        end
+      end
+      refute Thread.current[::Dalli::QUIET]
+    end
+  end
+end


### PR DESCRIPTION
Once the connection logic is extracted it will become much easier to implement the meta protocol.  The goal is that after this PR, everything that's actually in the Dalli::Protocol::Binary class is related to the binary protocol specifically, and is not reusable for other protocols.  This is basically mapping Ruby commands to memcached binary requests and processing responses, and translating back to appropriate values for the Dalli::Client.

Config parameter parsing, connection handling (initialization, state management, retries), and other shared concerns should be extracted.  Binary protocol specific logic may be extracted into additional classes in the Dalli::Protocol::Binary class scope.

Once this extraction is complete, we may very well wind up inverting this a bit, where we inject the connection manager into a protocol implementation.