### PR TITLE
Minor response parsing improvements

### DIFF
--- a/lib/dalli/protocol/response_buffer.rb
+++ b/lib/dalli/protocol/response_buffer.rb
@@ -31,13 +31,13 @@ module Dalli
       def advance(bytes_to_advance)
         return unless bytes_to_advance.positive?
 
-        @buffer = @buffer[bytes_to_advance..-1]
+        @buffer = @buffer.byteslice(bytes_to_advance..-1)
       end
 
       # Resets the internal buffer to an empty state,
       # so that we're ready to read pipelined responses
       def reset
-        @buffer = +''
+        @buffer = ''.b
       end
 
       # Clear the internal response buffer


### PR DESCRIPTION
- Get rid of an useless String#byteslice. `unpack1('N')` doesn't care if there's more bytes left.
- Use `String#b` to directly create a binary buffer. Saves some more encoding checks.
- Favor `byteslice` over `slice` and `#[]` as it doesn't need to check encoding as much, and allows shared strings.

For context I wanted to use [the new `unpack(offset: )` to save more allocations](https://bugs.ruby-lang.org/issues/18254), but it's not as easy with the recent refactor. I can look more into it if there's interest.