### PR TITLE
Further encapsulate response header

### DIFF
--- a/lib/dalli/protocol/binary/response_processor.rb
+++ b/lib/dalli/protocol/binary/response_processor.rb
@@ -179,7 +179,7 @@ module Dalli
         ##
         def getk_response_from_buffer(buf)
           # There's no header in the buffer, so don't advance
-          return [0, nil, nil, nil] unless contains_header?(buf)
+          return [0, nil, nil, nil, nil] unless contains_header?(buf)
 
           resp_header = response_header_from_buffer(buf)
           body_len = resp_header.body_len
@@ -188,18 +188,18 @@ module Dalli
           # This is either the response to the terminating
           # noop or, if the status is not zero, an intermediate
           # error response that needs to be discarded.
-          return [ResponseHeader::SIZE, resp_header, nil, nil] if body_len.zero?
+          return [ResponseHeader::SIZE, resp_header.ok?, resp_header.cas, nil, nil] if body_len.zero?
 
           resp_size = ResponseHeader::SIZE + body_len
           # The header is in the buffer, but the body is not.  As we don't have
           # a complete response, don't advance the buffer
-          return [0, nil, nil, nil] unless buf.bytesize >= resp_size
+          return [0, nil, nil, nil, nil] unless buf.bytesize >= resp_size
 
           # The full response is in our buffer, so parse it and return
           # the values
           body = buf.byteslice(ResponseHeader::SIZE, body_len)
           key, value = unpack_response_body(resp_header.extra_len, resp_header.key_len, body, true)
-          [resp_size, resp_header, key, value]
+          [resp_size, resp_header.ok?, resp_header.cas, key, value]
         end
       end
     end

--- a/lib/dalli/protocol/response_buffer.rb
+++ b/lib/dalli/protocol/response_buffer.rb
@@ -21,9 +21,9 @@ module Dalli
       # Attempts to process a single response from the buffer.  Starts
       # by advancing the buffer to the specified start position
       def process_single_getk_response
-        bytes, resp_header, key, value = @response_processor.getk_response_from_buffer(@buffer)
+        bytes, status, cas, key, value = @response_processor.getk_response_from_buffer(@buffer)
         advance(bytes)
-        [resp_header, key, value]
+        [status, cas, key, value]
       end
 
       # Advances the internal response buffer by bytes_to_advance


### PR DESCRIPTION
The response header differs substantially between binary and meta protocol, to the level that what's in the header vs a body is really different.  It's not clear that exposing a "ResponseHeader" outside of the protocol specific package has value.  This change hides the ResponseHeader from the buffer, making it easier to make the buffer protocol agnostic.