### PR TITLE
Fix replace so that it returns nil rather than raising an error on a miss

### DIFF
--- a/History.md
+++ b/History.md
@@ -5,6 +5,7 @@ Unreleased
 ==========
 
 - Fix bug with get_cas key with "Not found" value [petergoldstein]
+- Replace should return nil, not raise error, on miss (petergoldstein)
 
 3.1.4
 ==========

--- a/lib/dalli/protocol/binary/response_processor.rb
+++ b/lib/dalli/protocol/binary/response_processor.rb
@@ -85,6 +85,7 @@ module Dalli
         ##
         def storage_response
           resp_header, = read_response
+          return nil if resp_header.not_found?
           return false if resp_header.not_stored? # Not stored, normal status for add operation
 
           raise_on_not_ok!(resp_header)

--- a/test/integration/test_operations.rb
+++ b/test/integration/test_operations.rb
@@ -8,7 +8,7 @@ describe 'operations' do
   MemcachedManager.supported_protocols.each do |p|
     describe "using the #{p} protocol" do
       describe 'get' do
-        it 'support get/set' do
+        it 'returns the value on a hit' do
           memcached_persistent(p) do |dc|
             dc.flush
 
@@ -22,12 +22,14 @@ describe 'operations' do
           end
         end
 
-        it 'returns nil for nonexist key' do
+        it 'returns nil on a miss' do
           memcached_persistent(p) do |dc|
             assert_nil dc.get('notexist')
           end
         end
 
+        # This is historical, as the 'Not found' value was
+        # treated as a special case at one time
         it 'allows "Not found" as value' do
           memcached_persistent(p) do |dc|
             dc.set('key1', 'Not found')
@@ -37,22 +39,25 @@ describe 'operations' do
       end
 
       describe 'gat' do
-        it 'supports gat operation' do
+        it 'returns the value and touches on a hit' do
           memcached_persistent(p) do |dc|
             dc.flush
             dc.set 'key', 'value'
             assert_equal 'value', dc.gat('key', 10)
             assert_equal 'value', dc.gat('key')
+          end
+        end
+
+        it 'returns nil on a miss' do
+          memcached_persistent(p) do |dc|
+            dc.flush
             assert_nil dc.gat('notexist', 10)
-          rescue Dalli::DalliError => e
-            # This will happen when memcached is in lesser version than 1.4.8
-            assert_equal 'Response error 129: Unknown command', e.message
           end
         end
       end
 
       describe 'touch' do
-        it 'supports touch operation' do
+        it 'returns true on a hit' do
           memcached_persistent(p) do |dc|
             dc.flush
             dc.set 'key', 'value'
@@ -65,16 +70,90 @@ describe 'operations' do
             assert_equal 'Response error 129: Unknown command', e.message
           end
         end
+
+        it 'returns nil on a miss' do
+          memcached_persistent(p) do |dc|
+            dc.flush
+            assert_nil dc.touch('notexist')
+          end
+        end
+      end
+
+      describe 'set' do
+        it 'returns a CAS when the key exists and updates the value' do
+          memcached_persistent(p) do |dc|
+            dc.flush
+            dc.set('key', 'value')
+            assert op_replace_succeeds(dc.set('key', 'value2'))
+
+            assert_equal 'value2', dc.get('key')
+          end
+        end
+
+        it 'returns a CAS when no pre-existing value exists' do
+          memcached_persistent(p) do |dc|
+            dc.flush
+            assert op_replace_succeeds(dc.set('key', 'value2'))
+            assert_equal 'value2', dc.get('key')
+          end
+        end
+      end
+
+      describe 'add' do
+        it 'returns false when replacing an existing value and does not update the value' do
+          memcached_persistent(p) do |dc|
+            dc.flush
+            dc.set('key', 'value')
+            refute dc.add('key', 'value')
+
+            assert_equal 'value', dc.get('key')
+          end
+        end
+
+        it 'returns a CAS when no pre-existing value exists' do
+          memcached_persistent(p) do |dc|
+            dc.flush
+            assert op_replace_succeeds(dc.add('key', 'value2'))
+          end
+        end
+      end
+
+      describe 'replace' do
+        it 'returns a CAS when the key exists and updates the value' do
+          memcached_persistent(p) do |dc|
+            dc.flush
+            dc.set('key', 'value')
+            assert op_replace_succeeds(dc.replace('key', 'value2'))
+
+            assert_equal 'value2', dc.get('key')
+          end
+        end
+
+        it 'returns false when no pre-existing value exists' do
+          memcached_persistent(p) do |dc|
+            dc.flush
+            refute dc.replace('key', 'value')
+          end
+        end
       end
 
       describe 'delete' do
-        it 'supports delete' do
+        it 'returns true on a hit and deletes the entry' do
           memcached_persistent(p) do |dc|
+            dc.flush
             dc.set('some_key', 'some_value')
             assert_equal 'some_value', dc.get('some_key')
 
-            dc.delete('some_key')
+            assert dc.delete('some_key')
             assert_nil dc.get('some_key')
+
+            refute dc.delete('nonexist')
+          end
+        end
+
+        it 'returns false on a miss' do
+          memcached_persistent(p) do |dc|
+            dc.flush
 
             refute dc.delete('nonexist')
           end
@@ -82,6 +161,15 @@ describe 'operations' do
       end
 
       describe 'fetch' do
+        it 'fetches pre-existing values' do
+          memcached_persistent(p) do |dc|
+            dc.flush
+            dc.set('fetch_key', 'Not found')
+            res = dc.fetch('fetch_key') { flunk 'fetch block called' }
+            assert_equal 'Not found', res
+          end
+        end
+
         it 'supports with default values' do
           memcached_persistent(p) do |dc|
             dc.flush
@@ -139,7 +227,7 @@ describe 'operations' do
       end
 
       describe 'incr/decr' do
-        it 'supports on existing values' do
+        it 'supports incrementing and decrementing existing values' do
           memcached_persistent(p) do |client|
             client.flush
 
@@ -148,28 +236,37 @@ describe 'operations' do
             assert_equal 2, client.incr('fakecounter', 1)
             assert_equal 3, client.incr('fakecounter', 1)
             assert_equal 1, client.decr('fakecounter', 2)
-            assert_equal '1', client.get('fakecounter', raw: true)
+            assert_equal '1', client.get('fakecounter')
+          end
+        end
 
-            resp = client.incr('mycounter', 0)
+        it 'returns nil on a miss with no initial value' do
+          memcached_persistent(p) do |client|
+            client.flush
+
+            resp = client.incr('mycounter', 1)
             assert_nil resp
+
+            resp = client.decr('mycounter', 1)
+            assert_nil resp
+          end
+        end
+
+        it 'enables setting an initial value with incr and subsequently incrementing/decrementing' do
+          memcached_persistent(p) do |client|
+            client.flush
 
             resp = client.incr('mycounter', 1, 0, 2)
             assert_equal 2, resp
             resp = client.incr('mycounter', 1)
             assert_equal 3, resp
 
-            resp = client.set('rawcounter', 10, 0, raw: true)
-            assert op_cas_succeeds(resp)
-
-            resp = client.get('rawcounter', raw: true)
-            assert_equal '10', resp
-
-            resp = client.incr('rawcounter', 1)
-            assert_equal 11, resp
+            resp = client.decr('mycounter', 2)
+            assert_equal 1, resp
           end
         end
 
-        it 'supports setting the initial value with incr/decr' do
+        it 'supports setting the initial value decr and subsequently incrementing/decrementing' do
           memcached_persistent(p) do |dc|
             dc.flush
 
@@ -187,8 +284,15 @@ describe 'operations' do
               resp = dc.incr('counter', 10)
               assert_equal current + ((x + 1) * 10), resp
             end
+          end
+        end
+
+        it 'supports 64-bit values' do
+          memcached_persistent(p) do |dc|
+            dc.flush
 
             resp = dc.decr('10billion', 0, 5, 10)
+            assert_equal 10, resp
             # go over the 32-bit mark to verify proper (un)packing
             resp = dc.incr('10billion', 10_000_000_000)
             assert_equal 10_000_000_010, resp
@@ -202,8 +306,8 @@ describe 'operations' do
             resp = dc.incr('10billion', 0)
             assert_equal 10_000_000_009, resp
 
-            assert_nil dc.incr('DNE', 10)
-            assert_nil dc.decr('DNE', 10)
+            resp = dc.decr('10billion', 9_999_999_999)
+            assert_equal 10, resp
 
             resp = dc.incr('big', 100, 5, 0xFFFFFFFFFFFFFFFE)
             assert_equal 0xFFFFFFFFFFFFFFFE, resp
@@ -225,23 +329,10 @@ describe 'operations' do
             assert op_addset_succeeds(dc.set('456', 'xyz', 0, raw: true))
             assert dc.prepend('456', '0')
             assert dc.append('456', '9')
-            assert_equal '0xyz9', dc.get('456', raw: true)
             assert_equal '0xyz9', dc.get('456')
 
             refute dc.append('nonexist', 'abc')
             refute dc.prepend('nonexist', 'abc')
-          end
-        end
-      end
-
-      describe 'replace' do
-        it 'supports replace operation' do
-          memcached_persistent(p) do |dc|
-            dc.flush
-            dc.set('key', 'value')
-            assert op_replace_succeeds(dc.replace('key', 'value2'))
-
-            assert_equal 'value2', dc.get('key')
           end
         end
       end


### PR DESCRIPTION
Fixes #882 