### PR TITLE
Move server initialization into the Ring

### DIFF
--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -47,7 +47,7 @@ module Dalli
     #               to communicate with memcached.
     #
     def initialize(servers = nil, options = {})
-      @servers = ::Dalli::ServersArgNormalizer.normalize_servers(servers)
+      @normalized_servers = ::Dalli::ServersArgNormalizer.normalize_servers(servers)
       @options = normalize_options(options)
       @key_manager = ::Dalli::KeyManager.new(@options)
       @ring = nil
@@ -392,13 +392,7 @@ module Dalli
     end
 
     def ring
-      # TODO: This server initialization should probably be pushed down
-      # to the Ring
-      @ring ||= Dalli::Ring.new(
-        @servers.map do |s|
-          protocol_implementation.new(s, @options)
-        end, @options
-      )
+      @ring ||= Dalli::Ring.new(@normalized_servers, protocol_implementation, @options)
     end
 
     def protocol_implementation

--- a/lib/dalli/ring.rb
+++ b/lib/dalli/ring.rb
@@ -23,8 +23,10 @@ module Dalli
 
     attr_accessor :servers, :continuum
 
-    def initialize(servers, options)
-      @servers = servers
+    def initialize(servers_arg, protocol_implementation, options)
+      @servers = servers_arg.map do |s|
+        protocol_implementation.new(s, options)
+      end
       @continuum = nil
       @continuum = build_continuum(servers) if servers.size > 1
 

--- a/test/test_ring.rb
+++ b/test/test_ring.rb
@@ -2,13 +2,23 @@
 
 require_relative 'helper'
 
-TestServer = Struct.new(:name, :weight)
+class TestServer
+  attr_reader :name
+
+  def initialize(attribs, _client_options = {})
+    @name = attribs
+  end
+
+  def weight
+    1
+  end
+end
 
 describe 'Ring' do
   describe 'a ring of servers' do
     it 'have the continuum sorted by value' do
-      servers = [TestServer.new('localhost:11211', 1), TestServer.new('localhost:9500', 1)]
-      ring = Dalli::Ring.new(servers, {})
+      servers = ['localhost:11211', 'localhost:9500']
+      ring = Dalli::Ring.new(servers, TestServer, {})
       previous_value = 0
       ring.continuum.each do |entry|
         assert entry.value > previous_value
@@ -17,7 +27,7 @@ describe 'Ring' do
     end
 
     it 'raise when no servers are available/defined' do
-      ring = Dalli::Ring.new([], {})
+      ring = Dalli::Ring.new([], TestServer, {})
       assert_raises Dalli::RingError, message: 'No server available' do
         ring.server_for_key('test')
       end
@@ -25,20 +35,16 @@ describe 'Ring' do
 
     describe 'containing only a single server' do
       it "raise correctly when it's not alive" do
-        servers = [
-          Dalli::Protocol::Binary.new('localhost:12345')
-        ]
-        ring = Dalli::Ring.new(servers, {})
+        servers = ['localhost:12345']
+        ring = Dalli::Ring.new(servers, Dalli::Protocol::Binary, {})
         assert_raises Dalli::RingError, message: 'No server available' do
           ring.server_for_key('test')
         end
       end
 
       it "return the server when it's alive" do
-        servers = [
-          Dalli::Protocol::Binary.new('localhost:19191')
-        ]
-        ring = Dalli::Ring.new(servers, {})
+        servers = ['localhost:19191']
+        ring = Dalli::Ring.new(servers, Dalli::Protocol::Binary, {})
         memcached(:binary, 19_191) do |mc|
           ring = mc.send(:ring)
           assert_equal ring.servers.first.port, ring.server_for_key('test').port
@@ -48,22 +54,16 @@ describe 'Ring' do
 
     describe 'containing multiple servers' do
       it 'raise correctly when no server is alive' do
-        servers = [
-          Dalli::Protocol::Binary.new('localhost:12345'),
-          Dalli::Protocol::Binary.new('localhost:12346')
-        ]
-        ring = Dalli::Ring.new(servers, {})
+        servers = ['localhost:12345', 'localhost:12346']
+        ring = Dalli::Ring.new(servers, Dalli::Protocol::Binary, {})
         assert_raises Dalli::RingError, message: 'No server available' do
           ring.server_for_key('test')
         end
       end
 
       it 'return an alive server when at least one is alive' do
-        servers = [
-          Dalli::Protocol::Binary.new('localhost:12346'),
-          Dalli::Protocol::Binary.new('localhost:19191')
-        ]
-        ring = Dalli::Ring.new(servers, {})
+        servers = ['localhost:12346', 'localhost:19191']
+        ring = Dalli::Ring.new(servers, Dalli::Protocol::Binary, {})
         memcached(:binary, 19_191) do |mc|
           ring = mc.send(:ring)
           assert_equal ring.servers.first.port, ring.server_for_key('test').port


### PR DESCRIPTION
This change moves server initialization into the ring.  That's an important step for enabling properly dynamic Rings - where servers may be added or removed over time.  And by passing in the implementation class as an argument, the ring is kept generic.