### PR TITLE
Fix: null char not replaced

### DIFF
--- a/lib/dalli/protocol/binary/sasl_authentication.rb
+++ b/lib/dalli/protocol/binary/sasl_authentication.rb
@@ -15,7 +15,7 @@ module Dalli
 
           # Substitute spaces for the \x00 returned by
           # memcached as a separator for easier
-          content&.tr("\u0000", ' ')
+          content&.tr!("\u0000", ' ')
           mechanisms = content&.split
           [status, mechanisms]
         end


### PR DESCRIPTION
Aliyun returns a `null` char in the auth response which should be subbed out, otherwise PLAIN auth fails.