### PR TITLE
Support old sessions

### DIFF
--- a/lib/rack/session/dalli.rb
+++ b/lib/rack/session/dalli.rb
@@ -90,7 +90,7 @@ module Rack
 
       def delete_session(_req, sid, options)
         with_dalli_client do |dc|
-          dc.delete(memcached_key_from_sid(sid))
+          dc.delete(sid.respond_to?(:private_id) ? memcached_key_from_sid(sid) : sid)
           generate_sid_with(dc) unless options[:drop]
         end
       end


### PR DESCRIPTION
Hi Peter and team,

We have upgraded the version of `dalli` and the old sessions sometimes cause hiccups. Since we have a product installed on customer's sites, we are not totally in control if the customer remembers to flush the `memcached` daemon.

Is it possible to put something in place to more gracefully handle the case where the `dalli` gem has been updated but `memcached` has not been purged?

I wanted to put this out there to see if you were amiable to putting a fix into the core gem.

Thank you,


our current issue: https://github.com/ManageIQ/manageiq/issues/21772