### PR TITLE
Evaluate Proc namespaces every time (not just at initialization)

### DIFF
--- a/lib/dalli/key_manager.rb
+++ b/lib/dalli/key_manager.rb
@@ -61,7 +61,7 @@ module Dalli
     def key_with_namespace(key)
       return key if namespace.nil?
 
-      "#{namespace}#{NAMESPACE_SEPARATOR}#{key}"
+      "#{evaluate_namespace}#{NAMESPACE_SEPARATOR}#{key}"
     end
 
     def key_without_namespace(key)
@@ -75,6 +75,8 @@ module Dalli
     end
 
     def namespace_regexp
+      return /\A#{Regexp.escape(evaluate_namespace)}:/ if namespace.is_a?(Proc)
+
       @namespace_regexp ||= /\A#{Regexp.escape(namespace)}:/.freeze unless namespace.nil?
     end
 
@@ -87,9 +89,15 @@ module Dalli
     def namespace_from_options
       raw_namespace = @key_options[:namespace]
       return nil unless raw_namespace
-      return raw_namespace.call.to_s if raw_namespace.is_a?(Proc)
+      return raw_namespace.to_s unless raw_namespace.is_a?(Proc)
 
-      raw_namespace.to_s
+      raw_namespace
+    end
+
+    def evaluate_namespace
+      return namespace.call.to_s if namespace.is_a?(Proc)
+
+      namespace
     end
 
     ##

--- a/test/test_key_manager.rb
+++ b/test/test_key_manager.rb
@@ -66,13 +66,34 @@ describe 'KeyManager' do
       end
 
       describe 'when there is a Proc provided as a namespace parameter' do
-        let(:options) { { namespace: namespace_as_symbol } }
+        let(:options) { { namespace: namespace_as_proc } }
         let(:namespace_as_proc) { proc { namespace_as_symbol } }
         let(:namespace_as_symbol) { namespace_as_s.to_sym }
         let(:namespace_as_s) { SecureRandom.hex(5) }
 
-        it 'the namespace is the stringified symbol' do
-          assert_equal namespace_as_s, key_manager.namespace
+        it 'the namespace is the proc' do
+          assert_equal namespace_as_proc, key_manager.namespace
+        end
+
+        it 'the evaluated namespace is the stringified symbol' do
+          assert_equal namespace_as_s, key_manager.evaluate_namespace
+        end
+      end
+
+      describe 'when the namespace Proc returns dynamic results' do
+        count = 0
+
+        let(:options) { { namespace: namespace_as_proc } }
+        let(:namespace_as_proc) do
+          proc { count += 1 }
+        end
+
+        it 'evaluates the namespace proc every time we need it' do
+          assert_equal 0, count
+          assert_equal '1', key_manager.evaluate_namespace
+          assert_equal(/\A2:/, key_manager.namespace_regexp)
+          assert_equal '3', key_manager.evaluate_namespace
+          assert_equal '4:test', key_manager.key_with_namespace('test')
         end
       end
     end


### PR DESCRIPTION
When creating a dalli client with a Proc for the namespace option, it
would generally mean that the namespace may change from operation to
operation. Saving the result of calling the proc in the KeyManager
instance at initialisation time means that the client will always use
the value of the namespace as it was when the client was created. If
this was the desired behaviour, it would be just as easy to pass that
value as a string instead of a Proc.

Given test/test_key_manager.rb:69 is passing a namespace_as_symbol instead of namespace_as_proc, I'm assuming this is an unintended regression from when this logic was pulled out into KeyManager