### PR TITLE
Require "uri" from stdlib

### DIFF
--- a/lib/dalli/protocol/server_config_parser.rb
+++ b/lib/dalli/protocol/server_config_parser.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "uri"
+
 module Dalli
   module Protocol
     ##


### PR DESCRIPTION
`URI` is used for parsing server config but is never explicitly required.