### PR TITLE
Remove deprecation warning in client.rb

### DIFF
--- a/lib/dalli/cas/client.rb
+++ b/lib/dalli/cas/client.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-puts "You can remove `require 'dalli/cas/client'` as this code has been rolled into the standard 'dalli/client'."
+# Empty file for backwards compatibility


### PR DESCRIPTION
Hi Team,

I was wondering if you would consider removing this warning from dalli? We use dalli as a dependency of a dependency. The middle dependency is unlikely to be updated (The PR is here https://github.com/nickelser/suo/pull/21). Would you consider removing this warning? As far as I can tell, there is no harm in leaving this file empty.

I'm not asking you to be forever backwards compatible. Just to remove this one grain of sand from our development environment.

Whatever you decide, thank you for maintaining this gem!