### PR TITLE
Changes for new empty line before assert cop.

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -30,6 +30,7 @@ module MiniTest
 
     def assert_error(error, regexp = nil, &block)
       ex = assert_raises(error, &block)
+
       assert_match(regexp, ex.message, "#{ex.class.name}: #{ex.message}\n#{ex.backtrace.join("\n\t")}")
     end
 

--- a/test/integration/test_authentication.rb
+++ b/test/integration/test_authentication.rb
@@ -12,6 +12,7 @@ describe 'authentication' do
           dc.set('key1', 'abcd')
         end
       end
+
       assert_equal 'Authentication not supported for the meta protocol.', err.message
     end
   end

--- a/test/integration/test_cas.rb
+++ b/test/integration/test_cas.rb
@@ -13,6 +13,7 @@ describe 'CAS behavior' do
 
               dc.set('key1', 'abcd')
               value, cas = dc.get_cas('key1')
+
               assert_equal 'abcd', value
               assert valid_cas?(cas)
             end
@@ -26,6 +27,7 @@ describe 'CAS behavior' do
 
               dc.set('key1', 'Not found')
               value, cas = dc.get_cas('key1')
+
               assert_equal 'Not found', value
               assert valid_cas?(cas)
             end
@@ -35,6 +37,7 @@ describe 'CAS behavior' do
             memcached_persistent(p) do |dc|
               dc.flush
               value, cas = dc.get_cas('key1')
+
               assert_nil value
               assert_equal 0, cas
             end
@@ -60,6 +63,7 @@ describe 'CAS behavior' do
                 stored_cas = cas
                 block_value
               end
+
               assert get_block_called
               assert_equal expected, stored_value
               assert valid_cas?(stored_cas)
@@ -88,6 +92,7 @@ describe 'CAS behavior' do
                 stored_cas = cas
                 block_value
               end
+
               assert get_block_called
               assert_equal expected, stored_value
               assert valid_cas?(stored_cas)
@@ -110,6 +115,7 @@ describe 'CAS behavior' do
                 stored_cas = cas
                 block_value
               end
+
               assert get_block_called
               assert_nil stored_value
               assert_equal 0, stored_cas
@@ -134,6 +140,7 @@ describe 'CAS behavior' do
           resp.each_pair do |k, data|
             value = data.first
             cas = data[1]
+
             assert_equal expected_hash[k], value
             assert(cas && cas != 0)
           end
@@ -142,6 +149,7 @@ describe 'CAS behavior' do
           dc.get_multi_cas(%w[a b c d e f]) do |k, data|
             value = data.first
             cas = data[1]
+
             assert_equal expected_hash[k], value
             assert(cas && cas != 0)
           end
@@ -155,6 +163,7 @@ describe 'CAS behavior' do
 
           # Accepts CAS, replaces, and returns new CAS
           cas = dc.replace_cas('key', 'value2', cas)
+
           assert cas.is_a?(Integer)
 
           assert_equal 'value2', dc.get('key')
@@ -176,6 +185,7 @@ describe 'CAS behavior' do
             assert_equal 'some_value', dc.get('some_key')
 
             dc.delete_cas('some_key', cas)
+
             assert_nil dc.get('some_key')
 
             refute dc.delete_cas('nonexist', 123)
@@ -190,16 +200,19 @@ describe 'CAS behavior' do
             dc.set('some_key', expected)
 
             value, cas = dc.get_cas('some_key')
+
             assert_equal value, expected
             assert(!cas.nil? && cas != 0)
 
             # Set operation, first with wrong then with correct CAS
             expected = { 'blah' => 'set succeeded' }
+
             refute(dc.set_cas('some_key', expected, cas + 1))
             assert op_addset_succeeds(cas = dc.set_cas('some_key', expected, cas))
 
             # Replace operation, first with wrong then with correct CAS
             expected = { 'blah' => 'replace succeeded' }
+
             refute(dc.replace_cas('some_key', expected, cas + 1))
             assert op_addset_succeeds(cas = dc.replace_cas('some_key', expected, cas))
 
@@ -218,6 +231,7 @@ describe 'CAS behavior' do
             resp = dc.cas('cas_key') do |_value|
               raise('Value it not exist')
             end
+
             assert_nil resp
             assert_nil dc.cas('cas_key')
           end
@@ -235,9 +249,11 @@ describe 'CAS behavior' do
               assert_equal expected, value
               mutated
             end
+
             assert op_cas_succeeds(resp)
 
             resp = dc.get('cas_key')
+
             assert_equal mutated, resp
           end
         end
@@ -254,9 +270,11 @@ describe 'CAS behavior' do
               assert_equal expected, value
               mutated
             end
+
             assert op_cas_succeeds(resp)
 
             resp = dc.get('cas_key')
+
             assert_equal mutated, resp
           end
         end
@@ -272,9 +290,11 @@ describe 'CAS behavior' do
               assert_nil value
               mutated
             end
+
             assert op_cas_succeeds(resp)
 
             resp = dc.get('cas_key')
+
             assert_equal mutated, resp
           end
         end
@@ -291,9 +311,11 @@ describe 'CAS behavior' do
               assert_equal expected, value
               mutated
             end
+
             assert op_cas_succeeds(resp)
 
             resp = dc.get('cas_key')
+
             assert_equal mutated, resp
           end
         end
@@ -310,9 +332,11 @@ describe 'CAS behavior' do
               assert_equal expected, value
               mutated
             end
+
             assert op_cas_succeeds(resp)
 
             resp = dc.get('cas_key')
+
             assert_equal mutated, resp
           end
         end

--- a/test/integration/test_compressor.rb
+++ b/test/integration/test_compressor.rb
@@ -19,6 +19,7 @@ describe 'Compressor' do
       it 'default to Dalli::Compressor' do
         memcached(p, 29_199) do |dc|
           dc.set 1, 2
+
           assert_equal Dalli::Compressor, dc.instance_variable_get(:@ring).servers.first.compressor
         end
       end
@@ -44,6 +45,7 @@ describe 'Compressor' do
           memcached(p, 19_127) do |_dc|
             memcache = Dalli::Client.new('127.0.0.1:19127', { compress: true, compressor: Dalli::GzipCompressor })
             data = (0...1025).map { rand(65..90).chr }.join
+
             assert memcache.set('test', data)
             assert_equal(data, memcache.get('test'))
             assert_equal Dalli::GzipCompressor, memcache.instance_variable_get(:@ring).servers.first.compressor

--- a/test/integration/test_concurrency.rb
+++ b/test/integration/test_concurrency.rb
@@ -11,6 +11,7 @@ describe 'concurrent behavior' do
           workers = []
 
           cache.set('f', 'zzz')
+
           assert op_cas_succeeds((cache.cas('f') do |value|
             value << 'z'
           end))
@@ -29,12 +30,15 @@ describe 'concurrent behavior' do
                 res = cache.cas('f') do |value|
                   value << 'z'
                 end
+
                 refute_nil res
                 refute cache.add('a', 11)
                 assert_equal({ 'a' => 9, 'b' => 11 }, cache.get_multi(%w[a b]))
                 inc = cache.incr('cat', 10)
+
                 assert_equal 0, inc % 5
                 cache.decr('cat', 5)
+
                 assert_equal 11, cache.get('b')
 
                 assert_equal %w[a b], cache.get_multi('a', 'b', 'c').keys.sort

--- a/test/integration/test_connection_pool.rb
+++ b/test/integration/test_connection_pool.rb
@@ -8,9 +8,11 @@ describe 'connection pool behavior' do
       it 'can masquerade as a connection pool using the with method' do
         memcached_persistent(p) do |dc|
           dc.with { |c| c.set('some_key', 'some_value') }
+
           assert_equal 'some_value', dc.get('some_key')
 
           dc.with { |c| c.delete('some_key') }
+
           assert_nil dc.get('some_key')
         end
       end

--- a/test/integration/test_encoding.rb
+++ b/test/integration/test_encoding.rb
@@ -20,6 +20,7 @@ describe 'Encoding' do
           utf_key = utf8 = 'ƒ©åÍÎ'
 
           dc.set(utf_key, utf8)
+
           assert_equal utf8, dc.get(utf_key)
         end
       end

--- a/test/integration/test_failover.rb
+++ b/test/integration/test_failover.rb
@@ -18,6 +18,7 @@ describe 'failover' do
                   10_000.times do
                     dc.set('test_123', value)
                   end
+
                   flunk("Did not timeout in #{Time.now - start_time}")
                 end
               rescue Timeout::Error
@@ -36,11 +37,13 @@ describe 'failover' do
           memcached_persistent(p, server_port) do |dc, port|
             dc.set 'foo', 'bar'
             foo = dc.get 'foo'
+
             assert_equal('bar', foo)
 
             memcached_kill(port)
             memcached_persistent(p, port) do
               foo = dc.get 'foo'
+
               assert_nil foo
 
               memcached_kill(port)
@@ -58,12 +61,14 @@ describe 'failover' do
               dc.set 'foo', 'bar'
               dc.set 'foo2', 'bar2'
               foo = dc.get_multi 'foo', 'foo2'
+
               assert_equal({ 'foo' => 'bar', 'foo2' => 'bar2' }, foo)
 
               # wait for socket to expire and get cleaned up
               sleep 5
 
               foo = dc.get_multi 'foo', 'foo2'
+
               assert_equal({ 'foo' => 'bar', 'foo2' => 'bar2' }, foo)
             end
           end
@@ -77,12 +82,14 @@ describe 'failover' do
               dc = Dalli::Client.new ["localhost:#{first_port}", "localhost:#{second_port}"]
               dc.set 'foo', 'bar'
               foo = dc.get 'foo'
+
               assert_equal('bar', foo)
 
               memcached_kill(first_port)
 
               dc.set 'foo', 'bar'
               foo = dc.get 'foo'
+
               assert_equal('bar', foo)
 
               memcached_kill(second_port)
@@ -102,11 +109,13 @@ describe 'failover' do
               dc = Dalli::Client.new ["localhost:#{first_port}", "localhost:#{second_port}"]
               dc.set 'a', 'a1'
               result = dc.get_multi ['a']
+
               assert_equal({ 'a' => 'a1' }, result)
 
               memcached_kill(first_port)
 
               result = dc.get_multi ['a']
+
               assert_equal({ 'a' => 'a1' }, result)
             end
           end
@@ -121,6 +130,7 @@ describe 'failover' do
               dc.set 'foo', 'foo1'
               dc.set 'bar', 'bar1'
               result = dc.get_multi %w[foo bar]
+
               assert_equal({ 'foo' => 'foo1', 'bar' => 'bar1' }, result)
 
               memcached_kill(first_port)
@@ -128,11 +138,13 @@ describe 'failover' do
               dc.set 'foo', 'foo1'
               dc.set 'bar', 'bar1'
               result = dc.get_multi %w[foo bar]
+
               assert_equal({ 'foo' => 'foo1', 'bar' => 'bar1' }, result)
 
               memcached_kill(second_port)
 
               result = dc.get_multi %w[foo bar]
+
               assert_empty(result)
             end
           end
@@ -145,6 +157,7 @@ describe 'failover' do
             memcached_persistent(p, port2) do |_second_dc, second_port|
               dc = Dalli::Client.new ["localhost:#{first_port}", "localhost:#{second_port}"]
               result = dc.stats
+
               assert_instance_of Hash, result["localhost:#{first_port}"]
               assert_instance_of Hash, result["localhost:#{second_port}"]
 
@@ -152,6 +165,7 @@ describe 'failover' do
 
               dc = Dalli::Client.new ["localhost:#{first_port}", "localhost:#{second_port}"]
               result = dc.stats
+
               assert_instance_of NilClass, result["localhost:#{first_port}"]
               assert_instance_of Hash, result["localhost:#{second_port}"]
 

--- a/test/integration/test_marshal.rb
+++ b/test/integration/test_marshal.rb
@@ -20,6 +20,7 @@ describe 'Serializer configuration' do
       it 'allow large values under the limit to be set' do
         memcached_persistent(p) do |dc|
           value = '0' * 1024 * 1024
+
           assert dc.set('verylarge', value, nil, compress: true)
         end
       end

--- a/test/integration/test_memcached_admin.rb
+++ b/test/integration/test_memcached_admin.rb
@@ -15,12 +15,14 @@ describe 'memcached admin commands' do
 
             stats = dc.stats
             servers = stats.keys
+
             assert(servers.any? do |s|
               stats[s]['get_hits'].to_i != 0
             end, 'general stats failed')
 
             stats_items = dc.stats(:items)
             servers = stats_items.keys
+
             assert(servers.all? do |s|
               stats_items[s].keys.any? do |key|
                 key =~ /items:[0-9]+:number/
@@ -29,12 +31,14 @@ describe 'memcached admin commands' do
 
             stats_slabs = dc.stats(:slabs)
             servers = stats_slabs.keys
+
             assert(servers.all? do |s|
               stats_slabs[s].keys.any?('active_slabs')
             end, 'stats slabs failed')
 
             # reset_stats test
             results = dc.reset_stats
+
             assert(results.all? { |x| x })
             stats = dc.stats
             servers = stats.keys
@@ -52,6 +56,7 @@ describe 'memcached admin commands' do
           memcached_persistent(p) do |dc|
             v = dc.version
             servers = v.keys
+
             assert(servers.any? do |s|
               !v[s].nil?
             end, 'version failed')

--- a/test/integration/test_namespace_and_key.rb
+++ b/test/integration/test_namespace_and_key.rb
@@ -11,6 +11,7 @@ describe 'Namespace and key behavior' do
           dc.set('namespaced', 1)
           dc2 = Dalli::Client.new("localhost:#{port}", namespace: 'b')
           dc2.set('namespaced', 2)
+
           assert_equal 1, dc.get('namespaced')
           assert_equal 2, dc2.get('namespaced')
         end
@@ -20,6 +21,7 @@ describe 'Namespace and key behavior' do
         memcached_persistent(p) do |_, port|
           dc = Dalli::Client.new("localhost:#{port}", namespace: nil)
           dc.set('key', 1)
+
           assert_equal 1, dc.get('key')
         end
       end
@@ -29,6 +31,7 @@ describe 'Namespace and key behavior' do
           dc = Dalli::Client.new("localhost:#{port}", namespace: 'some:namspace')
           key = 'this-cache-key-is-far-too-long-so-it-must-be-hashed-and-truncated-and-stuff' * 10
           value = 'some value'
+
           assert op_addset_succeeds(dc.set(key, value))
           assert_equal value, dc.get(key)
         end
@@ -39,6 +42,7 @@ describe 'Namespace and key behavior' do
           dc = Dalli::Client.new("localhost:#{port}", namespace: 'a')
           dc.set('a', 1)
           dc.set('b', 2)
+
           assert_equal({ 'a' => 1, 'b' => 2 }, dc.get_multi('a', 'b'))
         end
       end
@@ -49,6 +53,7 @@ describe 'Namespace and key behavior' do
           dc = Dalli::Client.new("localhost:#{port}", namespace: '(?!)')
           dc.set('a', 1)
           dc.set('b', 2)
+
           assert_equal({ 'a' => 1, 'b' => 2 }, dc.get_multi('a', 'b'))
         end
       end
@@ -56,10 +61,13 @@ describe 'Namespace and key behavior' do
       it 'allows whitespace characters in keys' do
         memcached_persistent(p) do |dc|
           dc.set "\t", 1
+
           assert_equal 1, dc.get("\t")
           dc.set "\n", 1
+
           assert_equal 1, dc.get("\n")
           dc.set '   ', 1
+
           assert_equal 1, dc.get('   ')
         end
       end
@@ -79,6 +87,7 @@ describe 'Namespace and key behavior' do
         memcached_persistent(p) do |_, port|
           dc = Dalli::Client.new("localhost:#{port}", namespace: :wunderschoen)
           dc.set 'x' * 251, 1
+
           assert_equal(1, dc.get(('x' * 251).to_s))
         end
       end

--- a/test/integration/test_network.rb
+++ b/test/integration/test_network.rb
@@ -71,9 +71,11 @@ describe 'Network' do
           memcached_persistent(p) do |dc|
             server = dc.send(:ring).servers.first
             sock = Dalli::Socket::TCP.open(server.hostname, server.port, server.options)
+
             assert_equal Dalli::Socket::TCP, sock.class
 
             dc.set('abc', 123)
+
             assert_equal(123, dc.get('abc'))
           end
         end
@@ -82,9 +84,11 @@ describe 'Network' do
           memcached_ssl_persistent(p) do |dc|
             server = dc.send(:ring).servers.first
             sock = Dalli::Socket::TCP.open(server.hostname, server.port, server.options)
+
             assert_equal Dalli::Socket::SSLSocket, sock.class
 
             dc.set('abc', 123)
+
             assert_equal(123, dc.get('abc'))
 
             # Confirm that pipelined get works, since this depends on attributes on
@@ -112,6 +116,7 @@ describe 'Network' do
       it 'passes a simple smoke test on a TCP socket' do
         memcached_persistent(p) do |dc, port|
           resp = dc.flush
+
           refute_nil resp
           assert_equal [true, true], resp
 
@@ -119,11 +124,13 @@ describe 'Network' do
           assert_equal 'bar', dc.get(:foo)
 
           resp = dc.get('123')
+
           assert_nil resp
 
           assert op_addset_succeeds(dc.set('123', 'xyz'))
 
           resp = dc.get('123')
+
           assert_equal 'xyz', resp
 
           assert op_addset_succeeds(dc.set('123', 'abc'))
@@ -143,20 +150,25 @@ describe 'Network' do
           assert op_addset_succeeds(dc.set('456', 'xyz', 0, raw: true))
 
           resp = dc.prepend '456', '0'
+
           assert resp
 
           resp = dc.append '456', '9'
+
           assert resp
 
           resp = dc.get('456', raw: true)
+
           assert_equal '0xyz9', resp
 
           assert op_addset_succeeds(dc.set('456', false))
 
           resp = dc.get('456')
+
           refute resp
 
           resp = dc.stats
+
           assert_equal Hash, resp.class
 
           dc.close
@@ -166,6 +178,7 @@ describe 'Network' do
       it 'passes a simple smoke test on unix socket' do
         memcached_persistent(:binary, MemcachedMock::UNIX_SOCKET_PATH) do |dc, path|
           resp = dc.flush
+
           refute_nil resp
           assert_equal [true], resp
 
@@ -173,11 +186,13 @@ describe 'Network' do
           assert_equal 'bar', dc.get(:foo)
 
           resp = dc.get('123')
+
           assert_nil resp
 
           assert op_addset_succeeds(dc.set('123', 'xyz'))
 
           resp = dc.get('123')
+
           assert_equal 'xyz', resp
 
           assert op_addset_succeeds(dc.set('123', 'abc'))
@@ -197,20 +212,25 @@ describe 'Network' do
           assert op_addset_succeeds(dc.set('456', 'xyz', 0, raw: true))
 
           resp = dc.prepend '456', '0'
+
           assert resp
 
           resp = dc.append '456', '9'
+
           assert resp
 
           resp = dc.get('456', raw: true)
+
           assert_equal '0xyz9', resp
 
           assert op_addset_succeeds(dc.set('456', false))
 
           resp = dc.get('456')
+
           refute resp
 
           resp = dc.stats
+
           assert_equal Hash, resp.class
 
           dc.close

--- a/test/integration/test_operations.rb
+++ b/test/integration/test_operations.rb
@@ -15,6 +15,7 @@ describe 'operations' do
             val1 = '1234567890' * 999_999
             dc.set('a', val1)
             val2 = dc.get('a')
+
             assert_equal val1, val2
 
             assert op_addset_succeeds(dc.set('a', nil))
@@ -33,6 +34,7 @@ describe 'operations' do
         it 'allows "Not found" as value' do
           memcached_persistent(p) do |dc|
             dc.set('key1', 'Not found')
+
             assert_equal 'Not found', dc.get('key1')
           end
         end
@@ -43,6 +45,7 @@ describe 'operations' do
           memcached_persistent(p) do |dc|
             dc.flush
             dc.set 'key', 'value'
+
             assert_equal 'value', dc.gat('key', 10)
             assert_equal 'value', dc.gat('key')
           end
@@ -51,6 +54,7 @@ describe 'operations' do
         it 'returns nil on a miss' do
           memcached_persistent(p) do |dc|
             dc.flush
+
             assert_nil dc.gat('notexist', 10)
           end
         end
@@ -61,6 +65,7 @@ describe 'operations' do
           memcached_persistent(p) do |dc|
             dc.flush
             dc.set 'key', 'value'
+
             assert dc.touch('key', 10)
             assert dc.touch('key')
             assert_equal 'value', dc.get('key')
@@ -74,6 +79,7 @@ describe 'operations' do
         it 'returns nil on a miss' do
           memcached_persistent(p) do |dc|
             dc.flush
+
             assert_nil dc.touch('notexist')
           end
         end
@@ -84,6 +90,7 @@ describe 'operations' do
           memcached_persistent(p) do |dc|
             dc.flush
             dc.set('key', 'value')
+
             assert op_replace_succeeds(dc.set('key', 'value2'))
 
             assert_equal 'value2', dc.get('key')
@@ -93,6 +100,7 @@ describe 'operations' do
         it 'returns a CAS when no pre-existing value exists' do
           memcached_persistent(p) do |dc|
             dc.flush
+
             assert op_replace_succeeds(dc.set('key', 'value2'))
             assert_equal 'value2', dc.get('key')
           end
@@ -104,6 +112,7 @@ describe 'operations' do
           memcached_persistent(p) do |dc|
             dc.flush
             dc.set('key', 'value')
+
             refute dc.add('key', 'value')
 
             assert_equal 'value', dc.get('key')
@@ -113,6 +122,7 @@ describe 'operations' do
         it 'returns a CAS when no pre-existing value exists' do
           memcached_persistent(p) do |dc|
             dc.flush
+
             assert op_replace_succeeds(dc.add('key', 'value2'))
           end
         end
@@ -123,6 +133,7 @@ describe 'operations' do
           memcached_persistent(p) do |dc|
             dc.flush
             dc.set('key', 'value')
+
             assert op_replace_succeeds(dc.replace('key', 'value2'))
 
             assert_equal 'value2', dc.get('key')
@@ -132,6 +143,7 @@ describe 'operations' do
         it 'returns false when no pre-existing value exists' do
           memcached_persistent(p) do |dc|
             dc.flush
+
             refute dc.replace('key', 'value')
           end
         end
@@ -142,6 +154,7 @@ describe 'operations' do
           memcached_persistent(p) do |dc|
             dc.flush
             dc.set('some_key', 'some_value')
+
             assert_equal 'some_value', dc.get('some_key')
 
             assert dc.delete('some_key')
@@ -166,6 +179,7 @@ describe 'operations' do
             dc.flush
             dc.set('fetch_key', 'Not found')
             res = dc.fetch('fetch_key') { flunk 'fetch block called' }
+
             assert_equal 'Not found', res
           end
         end
@@ -180,6 +194,7 @@ describe 'operations' do
               executed = true
               expected
             end
+
             assert_equal expected, value
             assert executed
 
@@ -188,6 +203,7 @@ describe 'operations' do
               executed = true
               expected
             end
+
             assert_equal expected, value
             refute executed
           end
@@ -199,6 +215,7 @@ describe 'operations' do
 
             dc.set('fetch_key', false)
             res = dc.fetch('fetch_key') { flunk 'fetch block called' }
+
             refute res
           end
         end
@@ -209,6 +226,7 @@ describe 'operations' do
 
             dc.set('fetch_key', nil)
             res = dc.fetch('fetch_key') { flunk 'fetch block called' }
+
             assert_nil res
           end
 
@@ -220,6 +238,7 @@ describe 'operations' do
               executed = true
               'bar'
             end
+
             assert_equal 'bar', res
             assert executed
           end
@@ -245,9 +264,11 @@ describe 'operations' do
             client.flush
 
             resp = client.incr('mycounter', 1)
+
             assert_nil resp
 
             resp = client.decr('mycounter', 1)
+
             assert_nil resp
           end
         end
@@ -257,11 +278,14 @@ describe 'operations' do
             client.flush
 
             resp = client.incr('mycounter', 1, 0, 2)
+
             assert_equal 2, resp
             resp = client.incr('mycounter', 1)
+
             assert_equal 3, resp
 
             resp = client.decr('mycounter', 2)
+
             assert_equal 1, resp
           end
         end
@@ -271,17 +295,21 @@ describe 'operations' do
             dc.flush
 
             resp = dc.decr('counter', 100, 5, 0)
+
             assert_equal 0, resp
 
             resp = dc.decr('counter', 10)
+
             assert_equal 0, resp
 
             resp = dc.incr('counter', 10)
+
             assert_equal 10, resp
 
             current = 10
             100.times do |x|
               resp = dc.incr('counter', 10)
+
               assert_equal current + ((x + 1) * 10), resp
             end
           end
@@ -292,30 +320,39 @@ describe 'operations' do
             dc.flush
 
             resp = dc.decr('10billion', 0, 5, 10)
+
             assert_equal 10, resp
             # go over the 32-bit mark to verify proper (un)packing
             resp = dc.incr('10billion', 10_000_000_000)
+
             assert_equal 10_000_000_010, resp
 
             resp = dc.decr('10billion', 1)
+
             assert_equal 10_000_000_009, resp
 
             resp = dc.decr('10billion', 0)
+
             assert_equal 10_000_000_009, resp
 
             resp = dc.incr('10billion', 0)
+
             assert_equal 10_000_000_009, resp
 
             resp = dc.decr('10billion', 9_999_999_999)
+
             assert_equal 10, resp
 
             resp = dc.incr('big', 100, 5, 0xFFFFFFFFFFFFFFFE)
+
             assert_equal 0xFFFFFFFFFFFFFFFE, resp
             resp = dc.incr('big', 1)
+
             assert_equal 0xFFFFFFFFFFFFFFFF, resp
 
             # rollover the 64-bit value, we'll get something undefined.
             resp = dc.incr('big', 1)
+
             refute_equal 0x10000000000000000, resp
             dc.reset
           end
@@ -326,6 +363,7 @@ describe 'operations' do
         it 'support the append and prepend operations' do
           memcached_persistent(p) do |dc|
             dc.flush
+
             assert op_addset_succeeds(dc.set('456', 'xyz', 0, raw: true))
             assert dc.prepend('456', '0')
             assert dc.append('456', '9')

--- a/test/integration/test_pipelined_get.rb
+++ b/test/integration/test_pipelined_get.rb
@@ -10,6 +10,7 @@ describe 'Pipelined Get' do
           dc.close
           dc.flush
           resp = dc.get_multi(%w[a b c d e f])
+
           assert_empty(resp)
 
           dc.set('a', 'foo')
@@ -19,6 +20,7 @@ describe 'Pipelined Get' do
           # Invocation without block
           resp = dc.get_multi(%w[a b c d e f])
           expected_resp = { 'a' => 'foo', 'b' => 123, 'c' => %w[a b c] }
+
           assert_equal(expected_resp, resp)
 
           # Invocation with block
@@ -26,6 +28,7 @@ describe 'Pipelined Get' do
             assert(expected_resp.key?(k) && expected_resp[k] == v)
             expected_resp.delete(k)
           end
+
           assert_empty expected_resp
 
           # Perform a big quiet set with 1000 elements.
@@ -39,6 +42,7 @@ describe 'Pipelined Get' do
 
           # Retrieve the elements with a pipelined get
           result = dc.get_multi(arr)
+
           assert_equal(1000, result.size)
           assert_equal(50, result['50'])
         end
@@ -52,6 +56,7 @@ describe 'Pipelined Get' do
           keys_to_query = ['a', 'b', 'contains space', 'ƒ©åÍÎ']
 
           resp = dc.get_multi(keys_to_query)
+
           assert_empty(resp)
 
           dc.set('a', 'foo')
@@ -61,6 +66,7 @@ describe 'Pipelined Get' do
           # Invocation without block
           resp = dc.get_multi(keys_to_query)
           expected_resp = { 'a' => 'foo', 'contains space' => 123, 'ƒ©åÍÎ' => %w[a b c] }
+
           assert_equal(expected_resp, resp)
 
           # Invocation with block
@@ -68,6 +74,7 @@ describe 'Pipelined Get' do
             assert(expected_resp.key?(k) && expected_resp[k] == v)
             expected_resp.delete(k)
           end
+
           assert_empty expected_resp
         end
       end

--- a/test/integration/test_quiet.rb
+++ b/test/integration/test_quiet.rb
@@ -11,6 +11,7 @@ describe 'Quiet behavior' do
           dc.flush
           key = SecureRandom.hex(3)
           value = SecureRandom.hex(3)
+
           refute Thread.current[::Dalli::QUIET]
           dc.quiet do
             assert Thread.current[::Dalli::QUIET]
@@ -18,6 +19,7 @@ describe 'Quiet behavior' do
             # Response should be nil
             assert_nil dc.set(key, value)
           end
+
           refute Thread.current[::Dalli::QUIET]
 
           assert_equal value, dc.get(key)
@@ -33,6 +35,7 @@ describe 'Quiet behavior' do
           oldvalue = SecureRandom.hex(3)
           value = SecureRandom.hex(3)
           dc.set(existing, oldvalue)
+
           refute Thread.current[::Dalli::QUIET]
           dc.quiet do
             assert Thread.current[::Dalli::QUIET]
@@ -43,6 +46,7 @@ describe 'Quiet behavior' do
             # Should handle error case without error or unexpected behavior
             assert_nil dc.add(existing, value)
           end
+
           refute Thread.current[::Dalli::QUIET]
 
           assert_equal value, dc.get(key)
@@ -59,6 +63,7 @@ describe 'Quiet behavior' do
           oldvalue = SecureRandom.hex(3)
           value = SecureRandom.hex(3)
           dc.set(key, oldvalue)
+
           refute Thread.current[::Dalli::QUIET]
           dc.quiet do
             assert Thread.current[::Dalli::QUIET]
@@ -69,6 +74,7 @@ describe 'Quiet behavior' do
             # Should handle error case without error or unexpected behavior
             assert_nil dc.replace(nonexistent, value)
           end
+
           refute Thread.current[::Dalli::QUIET]
 
           assert_equal value, dc.get(key)
@@ -84,6 +90,7 @@ describe 'Quiet behavior' do
           existing = SecureRandom.hex(4)
           value = SecureRandom.hex(3)
           dc.set(existing, value)
+
           refute Thread.current[::Dalli::QUIET]
           dc.quiet do
             assert Thread.current[::Dalli::QUIET]
@@ -94,6 +101,7 @@ describe 'Quiet behavior' do
             # Should handle error case without error or unexpected behavior
             assert_nil dc.delete(key)
           end
+
           refute Thread.current[::Dalli::QUIET]
 
           assert_nil dc.get(existing)
@@ -108,6 +116,7 @@ describe 'Quiet behavior' do
           key = SecureRandom.hex(3)
           value = SecureRandom.hex(3)
           dc.set(key, value, 90, raw: true)
+
           refute Thread.current[::Dalli::QUIET]
           dc.quiet do
             assert Thread.current[::Dalli::QUIET]
@@ -115,6 +124,7 @@ describe 'Quiet behavior' do
             # Response should be nil
             assert_nil dc.append(key, 'abc')
           end
+
           refute Thread.current[::Dalli::QUIET]
 
           assert_equal "#{value}abc", dc.get(key)
@@ -128,6 +138,7 @@ describe 'Quiet behavior' do
           key = SecureRandom.hex(3)
           value = SecureRandom.hex(3)
           dc.set(key, value, 90, raw: true)
+
           refute Thread.current[::Dalli::QUIET]
           dc.quiet do
             assert Thread.current[::Dalli::QUIET]
@@ -135,6 +146,7 @@ describe 'Quiet behavior' do
             # Response should be nil
             assert_nil dc.prepend(key, 'abc')
           end
+
           refute Thread.current[::Dalli::QUIET]
 
           assert_equal "abc#{value}", dc.get(key)
@@ -149,6 +161,7 @@ describe 'Quiet behavior' do
           value = 546
           incr = 134
           dc.set(key, value, 90, raw: true)
+
           refute Thread.current[::Dalli::QUIET]
           dc.quiet do
             assert Thread.current[::Dalli::QUIET]
@@ -156,6 +169,7 @@ describe 'Quiet behavior' do
             # Response should be nil
             assert_nil dc.incr(key, incr)
           end
+
           refute Thread.current[::Dalli::QUIET]
 
           assert_equal 680, dc.get(key).to_i
@@ -170,6 +184,7 @@ describe 'Quiet behavior' do
           value = 546
           incr = 134
           dc.set(key, value, 90, raw: true)
+
           refute Thread.current[::Dalli::QUIET]
           dc.quiet do
             assert Thread.current[::Dalli::QUIET]
@@ -186,15 +201,18 @@ describe 'Quiet behavior' do
         memcached_persistent(p) do |dc|
           dc.close
           dc.flush
+
           refute Thread.current[::Dalli::QUIET]
           dc.quiet do
             assert Thread.current[::Dalli::QUIET]
 
             # Response should be a non-empty array of nils
             arr = dc.flush(90)
+
             assert_equal 2, arr.size
             assert arr.all?(&:nil?)
           end
+
           refute Thread.current[::Dalli::QUIET]
         end
       end
@@ -205,6 +223,7 @@ describe 'Quiet behavior' do
           dc.flush
           dc.set('a', 'av')
           dc.set('b', 'bv')
+
           assert_equal 'av', dc.get('a')
           assert_equal 'bv', dc.get('b')
 
@@ -213,6 +232,7 @@ describe 'Quiet behavior' do
             assert Thread.current[::Dalli::QUIET]
             dc.delete('non_existent_key')
           end
+
           refute Thread.current[::Dalli::QUIET]
           assert_equal 'av', dc.get('a')
           assert_equal 'bv', dc.get('b')
@@ -225,6 +245,7 @@ describe 'Quiet behavior' do
           dc.flush
           dc.set('a', 'av')
           dc.set('b', 'bv')
+
           assert_equal 'av', dc.get('a')
           assert_equal 'bv', dc.get('b')
 
@@ -235,6 +256,7 @@ describe 'Quiet behavior' do
               dc.get('a')
             end
           end
+
           refute Thread.current[::Dalli::QUIET]
         end
       end
@@ -243,6 +265,7 @@ describe 'Quiet behavior' do
         it 'has protocol instances that respond to quiet?' do
           memcached_persistent(p) do |dc|
             s = dc.send(:ring).servers.first
+
             assert_respond_to s, :quiet?
           end
         end
@@ -250,6 +273,7 @@ describe 'Quiet behavior' do
         it 'has protocol instances that respond to multi?' do
           memcached_persistent(p) do |dc|
             s = dc.send(:ring).servers.first
+
             assert_respond_to s, :multi?
           end
         end

--- a/test/integration/test_serializer.rb
+++ b/test/integration/test_serializer.rb
@@ -9,6 +9,7 @@ describe 'Serializer configuration' do
       it 'defaults to Marshal' do
         memcached(p, 29_198) do |dc|
           dc.set 1, 2
+
           assert_equal Marshal, dc.instance_variable_get(:@ring).servers.first.serializer
         end
       end

--- a/test/integration/test_ttl.rb
+++ b/test/integration/test_ttl.rb
@@ -17,9 +17,11 @@ describe 'TTL behavior' do
       it 'supports a TTL on set' do
         memcached_persistent(p) do |dc|
           key = 'foo'
+
           assert dc.set(key, 'bar', 1)
           assert_equal 'bar', dc.get(key)
           sleep 1.2
+
           assert_nil dc.get(key)
         end
       end

--- a/test/protocol/meta/test_request_formatter.rb
+++ b/test/protocol/meta/test_request_formatter.rb
@@ -225,16 +225,19 @@ describe Dalli::Protocol::Meta::RequestFormatter do
 
     it 'returns the expected string with a delay argument' do
       delay = rand(1000..1999)
+
       assert_equal "flush_all #{delay}\r\n", Dalli::Protocol::Meta::RequestFormatter.flush(delay: delay)
     end
 
     it 'santizes the delay argument' do
       delay = "\nset importantkey 1 1000 8\ninjected"
+
       assert_equal "flush_all 0\r\n", Dalli::Protocol::Meta::RequestFormatter.flush(delay: delay)
     end
 
     it 'adds noreply with a delay and quiet argument' do
       delay = rand(1000..1999)
+
       assert_equal "flush_all #{delay} noreply\r\n",
                    Dalli::Protocol::Meta::RequestFormatter.flush(delay: delay, quiet: true)
     end

--- a/test/protocol/test_binary.rb
+++ b/test/protocol/test_binary.rb
@@ -7,6 +7,7 @@ describe Dalli::Protocol::Binary do
   describe 'hostname parsing' do
     it 'handles unix socket with no weight' do
       s = Dalli::Protocol::Binary.new('/var/run/memcached/sock')
+
       assert_equal '/var/run/memcached/sock', s.hostname
       assert_equal 1, s.weight
       assert_equal :unix, s.socket_type
@@ -14,6 +15,7 @@ describe Dalli::Protocol::Binary do
 
     it 'handles unix socket with a weight' do
       s = Dalli::Protocol::Binary.new('/var/run/memcached/sock:2')
+
       assert_equal '/var/run/memcached/sock', s.hostname
       assert_equal 2, s.weight
       assert_equal :unix, s.socket_type
@@ -21,6 +23,7 @@ describe Dalli::Protocol::Binary do
 
     it 'handles no port or weight' do
       s = Dalli::Protocol::Binary.new('localhost')
+
       assert_equal 'localhost', s.hostname
       assert_equal 11_211, s.port
       assert_equal 1, s.weight
@@ -29,6 +32,7 @@ describe Dalli::Protocol::Binary do
 
     it 'handles a port, but no weight' do
       s = Dalli::Protocol::Binary.new('localhost:11212')
+
       assert_equal 'localhost', s.hostname
       assert_equal 11_212, s.port
       assert_equal 1, s.weight
@@ -37,6 +41,7 @@ describe Dalli::Protocol::Binary do
 
     it 'handles a port and a weight' do
       s = Dalli::Protocol::Binary.new('localhost:11212:2')
+
       assert_equal 'localhost', s.hostname
       assert_equal 11_212, s.port
       assert_equal 2, s.weight
@@ -45,6 +50,7 @@ describe Dalli::Protocol::Binary do
 
     it 'handles ipv4 addresses' do
       s = Dalli::Protocol::Binary.new('127.0.0.1')
+
       assert_equal '127.0.0.1', s.hostname
       assert_equal 11_211, s.port
       assert_equal 1, s.weight
@@ -53,6 +59,7 @@ describe Dalli::Protocol::Binary do
 
     it 'handles ipv6 addresses' do
       s = Dalli::Protocol::Binary.new('[::1]')
+
       assert_equal '::1', s.hostname
       assert_equal 11_211, s.port
       assert_equal 1, s.weight
@@ -61,6 +68,7 @@ describe Dalli::Protocol::Binary do
 
     it 'handles ipv6 addresses with port' do
       s = Dalli::Protocol::Binary.new('[::1]:11212')
+
       assert_equal '::1', s.hostname
       assert_equal 11_212, s.port
       assert_equal 1, s.weight
@@ -69,6 +77,7 @@ describe Dalli::Protocol::Binary do
 
     it 'handles ipv6 addresses with port and weight' do
       s = Dalli::Protocol::Binary.new('[::1]:11212:2')
+
       assert_equal '::1', s.hostname
       assert_equal 11_212, s.port
       assert_equal 2, s.weight
@@ -77,6 +86,7 @@ describe Dalli::Protocol::Binary do
 
     it 'handles a FQDN' do
       s = Dalli::Protocol::Binary.new('my.fqdn.com')
+
       assert_equal 'my.fqdn.com', s.hostname
       assert_equal 11_211, s.port
       assert_equal 1, s.weight
@@ -85,6 +95,7 @@ describe Dalli::Protocol::Binary do
 
     it 'handles a FQDN with port and weight' do
       s = Dalli::Protocol::Binary.new('my.fqdn.com:11212:2')
+
       assert_equal 'my.fqdn.com', s.hostname
       assert_equal 11_212, s.port
       assert_equal 2, s.weight

--- a/test/protocol/test_server_config_parser.rb
+++ b/test/protocol/test_server_config_parser.rb
@@ -81,6 +81,7 @@ describe Dalli::Protocol::ServerConfigParser do
           err = assert_raises Dalli::DalliError do
             Dalli::Protocol::ServerConfigParser.parse("#{hostname}:#{port}:#{weight}")
           end
+
           assert_equal err.message, "Could not parse hostname #{hostname}:#{port}:#{weight}"
         end
       end
@@ -117,6 +118,7 @@ describe Dalli::Protocol::ServerConfigParser do
           err = assert_raises Dalli::DalliError do
             Dalli::Protocol::ServerConfigParser.parse('')
           end
+
           assert_equal('Could not parse hostname ', err.message)
         end
       end
@@ -126,6 +128,7 @@ describe Dalli::Protocol::ServerConfigParser do
           err = assert_raises Dalli::DalliError do
             Dalli::Protocol::ServerConfigParser.parse(':1:2')
           end
+
           assert_equal('Could not parse hostname :1:2', err.message)
         end
       end
@@ -135,6 +138,7 @@ describe Dalli::Protocol::ServerConfigParser do
           err = assert_raises Dalli::DalliError do
             Dalli::Protocol::ServerConfigParser.parse('abc.com:')
           end
+
           assert_equal('Could not parse hostname abc.com:', err.message)
         end
       end

--- a/test/protocol/test_value_compressor.rb
+++ b/test/protocol/test_value_compressor.rb
@@ -116,6 +116,7 @@ describe Dalli::Protocol::ValueCompressor do
 
               it 'does not compress the argument' do
                 val, newbitflags = vc.store(raw_value, req_options, bitflags)
+
                 assert_equal val, raw_value
                 assert_equal newbitflags, bitflags
                 compressor.verify
@@ -127,6 +128,7 @@ describe Dalli::Protocol::ValueCompressor do
 
               it 'does not compress the argument' do
                 val, newbitflags = vc.store(raw_value, req_options, bitflags)
+
                 assert_equal val, raw_value
                 assert_equal newbitflags, bitflags
                 compressor.verify
@@ -138,6 +140,7 @@ describe Dalli::Protocol::ValueCompressor do
 
               it 'does not compress the argument' do
                 val, newbitflags = vc.store(raw_value, req_options, bitflags)
+
                 assert_equal val, raw_value
                 assert_equal newbitflags, bitflags
                 compressor.verify
@@ -153,6 +156,7 @@ describe Dalli::Protocol::ValueCompressor do
 
               it 'does not compress the argument' do
                 val, newbitflags = vc.store(raw_value, req_options, bitflags)
+
                 assert_equal val, raw_value
                 assert_equal newbitflags, bitflags
                 compressor.verify
@@ -164,6 +168,7 @@ describe Dalli::Protocol::ValueCompressor do
 
               it 'does not compress the argument' do
                 val, newbitflags = vc.store(raw_value, req_options, bitflags)
+
                 assert_equal val, raw_value
                 assert_equal newbitflags, bitflags
                 compressor.verify
@@ -175,6 +180,7 @@ describe Dalli::Protocol::ValueCompressor do
 
               it 'does not compress the argument' do
                 val, newbitflags = vc.store(raw_value, req_options, bitflags)
+
                 assert_equal val, raw_value
                 assert_equal newbitflags, bitflags
                 compressor.verify
@@ -195,6 +201,7 @@ describe Dalli::Protocol::ValueCompressor do
               it 'compresses the argument' do
                 compressor.expect :compress, compressed_dummy, [raw_value]
                 val, newbitflags = vc.store(raw_value, req_options, bitflags)
+
                 assert_equal val, compressed_dummy
                 assert_equal newbitflags, (bitflags | 0x2)
                 compressor.verify
@@ -207,6 +214,7 @@ describe Dalli::Protocol::ValueCompressor do
               it 'compresses the argument' do
                 compressor.expect :compress, compressed_dummy, [raw_value]
                 val, newbitflags = vc.store(raw_value, req_options, bitflags)
+
                 assert_equal val, compressed_dummy
                 assert_equal newbitflags, (bitflags | 0x2)
                 compressor.verify
@@ -218,6 +226,7 @@ describe Dalli::Protocol::ValueCompressor do
 
               it 'does not compress the argument' do
                 val, newbitflags = vc.store(raw_value, req_options, bitflags)
+
                 assert_equal val, raw_value
                 assert_equal newbitflags, bitflags
                 compressor.verify
@@ -233,6 +242,7 @@ describe Dalli::Protocol::ValueCompressor do
 
               it 'does not compress the argument' do
                 val, newbitflags = vc.store(raw_value, req_options, bitflags)
+
                 assert_equal val, raw_value
                 assert_equal newbitflags, bitflags
                 compressor.verify
@@ -245,6 +255,7 @@ describe Dalli::Protocol::ValueCompressor do
               it 'compresses the argument' do
                 compressor.expect :compress, compressed_dummy, [raw_value]
                 val, newbitflags = vc.store(raw_value, req_options, bitflags)
+
                 assert_equal val, compressed_dummy
                 assert_equal newbitflags, (bitflags | 0x2)
                 compressor.verify
@@ -256,6 +267,7 @@ describe Dalli::Protocol::ValueCompressor do
 
               it 'does not compress the argument' do
                 val, newbitflags = vc.store(raw_value, req_options, bitflags)
+
                 assert_equal val, raw_value
                 assert_equal newbitflags, bitflags
                 compressor.verify
@@ -280,6 +292,7 @@ describe Dalli::Protocol::ValueCompressor do
 
               it 'does not compress the argument' do
                 val, newbitflags = vc.store(raw_value, req_options, bitflags)
+
                 assert_equal val, raw_value
                 assert_equal newbitflags, bitflags
                 compressor.verify
@@ -291,6 +304,7 @@ describe Dalli::Protocol::ValueCompressor do
 
               it 'does not compress the argument' do
                 val, newbitflags = vc.store(raw_value, req_options, bitflags)
+
                 assert_equal val, raw_value
                 assert_equal newbitflags, bitflags
                 compressor.verify
@@ -302,6 +316,7 @@ describe Dalli::Protocol::ValueCompressor do
 
               it 'does not compress the argument' do
                 val, newbitflags = vc.store(raw_value, req_options, bitflags)
+
                 assert_equal val, raw_value
                 assert_equal newbitflags, bitflags
                 compressor.verify
@@ -317,6 +332,7 @@ describe Dalli::Protocol::ValueCompressor do
 
               it 'does not compress the argument' do
                 val, newbitflags = vc.store(raw_value, req_options, bitflags)
+
                 assert_equal val, raw_value
                 assert_equal newbitflags, bitflags
                 compressor.verify
@@ -328,6 +344,7 @@ describe Dalli::Protocol::ValueCompressor do
 
               it 'does not compress the argument' do
                 val, newbitflags = vc.store(raw_value, req_options, bitflags)
+
                 assert_equal val, raw_value
                 assert_equal newbitflags, bitflags
                 compressor.verify
@@ -339,6 +356,7 @@ describe Dalli::Protocol::ValueCompressor do
 
               it 'does not compress the argument' do
                 val, newbitflags = vc.store(raw_value, req_options, bitflags)
+
                 assert_equal val, raw_value
                 assert_equal newbitflags, bitflags
                 compressor.verify
@@ -359,6 +377,7 @@ describe Dalli::Protocol::ValueCompressor do
               it 'compresses the argument' do
                 compressor.expect :compress, compressed_dummy, [raw_value]
                 val, newbitflags = vc.store(raw_value, req_options, bitflags)
+
                 assert_equal val, compressed_dummy
                 assert_equal newbitflags, (bitflags | 0x2)
                 compressor.verify
@@ -371,6 +390,7 @@ describe Dalli::Protocol::ValueCompressor do
               it 'compresses the argument' do
                 compressor.expect :compress, compressed_dummy, [raw_value]
                 val, newbitflags = vc.store(raw_value, req_options, bitflags)
+
                 assert_equal val, compressed_dummy
                 assert_equal newbitflags, (bitflags | 0x2)
                 compressor.verify
@@ -382,6 +402,7 @@ describe Dalli::Protocol::ValueCompressor do
 
               it 'does not compress the argument' do
                 val, newbitflags = vc.store(raw_value, req_options, bitflags)
+
                 assert_equal val, raw_value
                 assert_equal newbitflags, bitflags
                 compressor.verify
@@ -397,6 +418,7 @@ describe Dalli::Protocol::ValueCompressor do
 
               it 'does not compress the argument' do
                 val, newbitflags = vc.store(raw_value, req_options, bitflags)
+
                 assert_equal val, raw_value
                 assert_equal newbitflags, bitflags
                 compressor.verify
@@ -409,6 +431,7 @@ describe Dalli::Protocol::ValueCompressor do
               it 'compresses the argument' do
                 compressor.expect :compress, compressed_dummy, [raw_value]
                 val, newbitflags = vc.store(raw_value, req_options, bitflags)
+
                 assert_equal val, compressed_dummy
                 assert_equal newbitflags, (bitflags | 0x2)
                 compressor.verify
@@ -420,6 +443,7 @@ describe Dalli::Protocol::ValueCompressor do
 
               it 'does not compress the argument' do
                 val, newbitflags = vc.store(raw_value, req_options, bitflags)
+
                 assert_equal val, raw_value
                 assert_equal newbitflags, bitflags
                 compressor.verify
@@ -443,6 +467,7 @@ describe Dalli::Protocol::ValueCompressor do
       it 'should return the value without decompressing' do
         bitflags = rand(32)
         bitflags &= 0xFFFD
+
         assert_equal(0, bitflags & 0x2)
         assert_equal vc.retrieve(raw_value, bitflags), raw_value
         compressor.verify
@@ -457,6 +482,7 @@ describe Dalli::Protocol::ValueCompressor do
         compressor.expect :decompress, decompressed_dummy, [raw_value]
         bitflags = rand(32)
         bitflags |= 0x2
+
         assert_equal(0x2, bitflags & 0x2)
         assert_equal vc.retrieve(raw_value, bitflags), decompressed_dummy
         compressor.verify
@@ -472,10 +498,12 @@ describe Dalli::Protocol::ValueCompressor do
         ::Dalli::Compressor.stub :decompress, error do
           bitflags = rand(32)
           bitflags |= 0x2
+
           assert_equal(0x2, bitflags & 0x2)
           exception = assert_raises Dalli::UnmarshalError do
             vc.retrieve(raw_value, bitflags)
           end
+
           assert_equal exception.message, "Unable to uncompress value: #{error_message}"
         end
       end

--- a/test/protocol/test_value_marshaller.rb
+++ b/test/protocol/test_value_marshaller.rb
@@ -90,6 +90,7 @@ describe Dalli::Protocol::ValueMarshaller do
             exception = assert_raises Dalli::ValueOverMaxSize do
               marshaller.store(key, val, req_options)
             end
+
             assert_equal "Value for #{key} over max size: #{1024 * 1024} <= #{compressed_serialized_value.size}",
                          exception.message
           end
@@ -122,6 +123,7 @@ describe Dalli::Protocol::ValueMarshaller do
             exception = assert_raises Dalli::ValueOverMaxSize do
               marshaller.store(key, val, req_options)
             end
+
             assert_equal "Value for #{key} over max size: #{1024 * 1024} <= #{compressed_raw_value.size}",
                          exception.message
           end
@@ -159,6 +161,7 @@ describe Dalli::Protocol::ValueMarshaller do
             exception = assert_raises Dalli::ValueOverMaxSize do
               marshaller.store(key, val, req_options)
             end
+
             assert_equal "Value for #{key} over max size: #{value_max_bytes} <= #{compressed_serialized_value.size}",
                          exception.message
           end
@@ -183,6 +186,7 @@ describe Dalli::Protocol::ValueMarshaller do
             exception = assert_raises Dalli::ValueOverMaxSize do
               marshaller.store(key, val, req_options)
             end
+
             assert_equal "Value for #{key} over max size: #{value_max_bytes} <= #{compressed_raw_value.size}",
                          exception.message
           end

--- a/test/protocol/test_value_serializer.rb
+++ b/test/protocol/test_value_serializer.rb
@@ -41,6 +41,7 @@ describe Dalli::Protocol::ValueSerializer do
       it 'serializes the value' do
         serializer.expect :dump, serialized_dummy, [raw_value]
         val, newbitflags = vs.store(raw_value, req_options, bitflags)
+
         assert_equal val, serialized_dummy
         assert_equal newbitflags, (bitflags | 0x1)
         serializer.verify
@@ -53,6 +54,7 @@ describe Dalli::Protocol::ValueSerializer do
       it 'serializes the value' do
         serializer.expect :dump, serialized_dummy, [raw_value]
         val, newbitflags = vs.store(raw_value, req_options, bitflags)
+
         assert_equal val, serialized_dummy
         assert_equal newbitflags, (bitflags | 0x1)
         serializer.verify
@@ -65,6 +67,7 @@ describe Dalli::Protocol::ValueSerializer do
       it 'serializes the value' do
         serializer.expect :dump, serialized_dummy, [raw_value]
         val, newbitflags = vs.store(raw_value, req_options, bitflags)
+
         assert_equal val, serialized_dummy
         assert_equal newbitflags, (bitflags | 0x1)
         serializer.verify
@@ -76,6 +79,7 @@ describe Dalli::Protocol::ValueSerializer do
 
       it 'does not call the serializer and just converts the input value to a string' do
         val, newbitflags = vs.store(raw_value, req_options, bitflags)
+
         assert_equal val, raw_value.to_s
         assert_equal newbitflags, bitflags
         serializer.verify
@@ -93,6 +97,7 @@ describe Dalli::Protocol::ValueSerializer do
           exception = assert_raises Timeout::Error do
             vs.store(raw_value, req_options, bitflags)
           end
+
           assert_equal exception.message, error_message
         end
       end
@@ -109,6 +114,7 @@ describe Dalli::Protocol::ValueSerializer do
           exception = assert_raises Dalli::MarshalError do
             vs.store(raw_value, req_options, bitflags)
           end
+
           assert_equal exception.message, error_message
         end
       end
@@ -125,6 +131,7 @@ describe Dalli::Protocol::ValueSerializer do
           exception = assert_raises Dalli::MarshalError do
             vs.store(raw_value, req_options, bitflags)
           end
+
           assert_equal exception.message, error_message
         end
       end
@@ -142,6 +149,7 @@ describe Dalli::Protocol::ValueSerializer do
       it 'should return the value without deserializing' do
         bitflags = rand(32)
         bitflags &= 0xFFFE
+
         assert_equal(0, bitflags & 0x1)
         assert_equal vs.retrieve(raw_value, bitflags), raw_value
         serializer.verify
@@ -153,6 +161,7 @@ describe Dalli::Protocol::ValueSerializer do
         serializer.expect :load, deserialized_dummy, [raw_value]
         bitflags = rand(32)
         bitflags |= 0x1
+
         assert_equal(0x1, bitflags & 0x1)
         assert_equal vs.retrieve(raw_value, bitflags), deserialized_dummy
         serializer.verify
@@ -171,6 +180,7 @@ describe Dalli::Protocol::ValueSerializer do
             vs.retrieve(raw_value, Dalli::Protocol::ValueSerializer::FLAG_SERIALIZED)
           end
         end
+
         assert_equal exception.message, "Unable to unmarshal value: #{error_message}"
       end
     end
@@ -187,6 +197,7 @@ describe Dalli::Protocol::ValueSerializer do
             vs.retrieve(raw_value, Dalli::Protocol::ValueSerializer::FLAG_SERIALIZED)
           end
         end
+
         assert_equal exception.message, "Unable to unmarshal value: #{error_message}"
       end
     end
@@ -200,6 +211,7 @@ describe Dalli::Protocol::ValueSerializer do
         exception = assert_raises Dalli::UnmarshalError do
           vs.retrieve(raw_value, Dalli::Protocol::ValueSerializer::FLAG_SERIALIZED)
         end
+
         assert_equal exception.message, "Unable to unmarshal value: #{error_message}"
       end
     end
@@ -213,6 +225,7 @@ describe Dalli::Protocol::ValueSerializer do
         exception = assert_raises Dalli::UnmarshalError do
           vs.retrieve(raw_value, Dalli::Protocol::ValueSerializer::FLAG_SERIALIZED)
         end
+
         assert exception.message.start_with?("Unable to unmarshal value: #{error_message}")
       end
     end
@@ -228,6 +241,7 @@ describe Dalli::Protocol::ValueSerializer do
             vs.retrieve(raw_value, Dalli::Protocol::ValueSerializer::FLAG_SERIALIZED)
           end
         end
+
         assert_equal error_message, exception.message
       end
     end
@@ -244,6 +258,7 @@ describe Dalli::Protocol::ValueSerializer do
             vs.retrieve(raw_value, Dalli::Protocol::ValueSerializer::FLAG_SERIALIZED)
           end
         end
+
         assert exception.message.start_with?("Unable to unmarshal value: #{error_message}")
       end
     end
@@ -259,6 +274,7 @@ describe Dalli::Protocol::ValueSerializer do
             vs.retrieve(raw_value, Dalli::Protocol::ValueSerializer::FLAG_SERIALIZED)
           end
         end
+
         assert exception.message.start_with?(error_message)
       end
     end
@@ -272,6 +288,7 @@ describe Dalli::Protocol::ValueSerializer do
         exception = assert_raises Dalli::UnmarshalError do
           vs.retrieve(raw_value, Dalli::Protocol::ValueSerializer::FLAG_SERIALIZED)
         end
+
         assert_equal exception.message, "Unable to unmarshal value: #{error_message}"
       end
     end
@@ -285,6 +302,7 @@ describe Dalli::Protocol::ValueSerializer do
         exception = assert_raises Dalli::UnmarshalError do
           vs.retrieve(raw_value, Dalli::Protocol::ValueSerializer::FLAG_SERIALIZED)
         end
+
         assert_equal exception.message, "Unable to unmarshal value: #{error_message}"
       end
     end
@@ -300,6 +318,7 @@ describe Dalli::Protocol::ValueSerializer do
             vs.retrieve(raw_value, Dalli::Protocol::ValueSerializer::FLAG_SERIALIZED)
           end
         end
+
         assert_equal exception.message, error_message
       end
     end

--- a/test/test_client_options.rb
+++ b/test/test_client_options.rb
@@ -14,18 +14,21 @@ describe 'Dalli client options' do
       dc = Dalli::Client.new
       ring = dc.send(:ring)
       s1 = ring.servers.first.hostname
+
       assert_equal 1, ring.servers.size
       dc.close
 
       dc = Dalli::Client.new('localhost:11211')
       ring = dc.send(:ring)
       s2 = ring.servers.first.hostname
+
       assert_equal 1, ring.servers.size
       dc.close
 
       dc = Dalli::Client.new(['localhost:11211'])
       ring = dc.send(:ring)
       s3 = ring.servers.first.hostname
+
       assert_equal 1, ring.servers.size
       dc.close
 
@@ -36,8 +39,10 @@ describe 'Dalli client options' do
     it 'accept comma separated string' do
       dc = Dalli::Client.new('server1.example.com:11211,server2.example.com:11211')
       ring = dc.send(:ring)
+
       assert_equal 2, ring.servers.size
       s1, s2 = ring.servers.map(&:hostname)
+
       assert_equal 'server1.example.com', s1
       assert_equal 'server2.example.com', s2
     end
@@ -45,8 +50,10 @@ describe 'Dalli client options' do
     it 'accept array of servers' do
       dc = Dalli::Client.new(['server1.example.com:11211', 'server2.example.com:11211'])
       ring = dc.send(:ring)
+
       assert_equal 2, ring.servers.size
       s1, s2 = ring.servers.map(&:hostname)
+
       assert_equal 'server1.example.com', s1
       assert_equal 'server2.example.com', s2
     end

--- a/test/test_key_manager.rb
+++ b/test/test_key_manager.rb
@@ -31,6 +31,7 @@ describe 'KeyManager' do
             err = assert_raises ArgumentError do
               key_manager
             end
+
             assert_equal 'The digest_class object must respond to the hexdigest method', err.message
           end
         end
@@ -113,6 +114,7 @@ describe 'KeyManager' do
           err = assert_raises ArgumentError do
             subject
           end
+
           assert_equal 'key cannot be blank', err.message
         end
       end
@@ -124,6 +126,7 @@ describe 'KeyManager' do
           err = assert_raises ArgumentError do
             subject
           end
+
           assert_equal 'key cannot be blank', err.message
         end
       end
@@ -187,6 +190,7 @@ describe 'KeyManager' do
           err = assert_raises ArgumentError do
             subject
           end
+
           assert_equal 'key cannot be blank', err.message
         end
       end
@@ -198,6 +202,7 @@ describe 'KeyManager' do
           err = assert_raises ArgumentError do
             subject
           end
+
           assert_equal 'key cannot be blank', err.message
         end
       end

--- a/test/test_ring.rb
+++ b/test/test_ring.rb
@@ -47,6 +47,7 @@ describe 'Ring' do
         ring = Dalli::Ring.new(servers, Dalli::Protocol::Binary, {})
         memcached(:binary, 19_191) do |mc|
           ring = mc.send(:ring)
+
           assert_equal ring.servers.first.port, ring.server_for_key('test').port
         end
       end
@@ -66,6 +67,7 @@ describe 'Ring' do
         ring = Dalli::Ring.new(servers, Dalli::Protocol::Binary, {})
         memcached(:binary, 19_191) do |mc|
           ring = mc.send(:ring)
+
           assert_equal ring.servers.first.port, ring.server_for_key('test').port
         end
       end
@@ -75,6 +77,7 @@ describe 'Ring' do
       memcached(:binary, 19_997) do
         down_retry_delay = 0.5
         dc = Dalli::Client.new(['localhost:19997', 'localhost:19998'], down_retry_delay: down_retry_delay)
+
         assert_equal 1, dc.stats.values.compact.count
 
         memcached(:binary, 19_998) do

--- a/test/test_servers_arg_normalizer.rb
+++ b/test/test_servers_arg_normalizer.rb
@@ -112,6 +112,7 @@ describe Dalli::ServersArgNormalizer do
         err = assert_raises ArgumentError do
           subject
         end
+
         assert_equal 'An explicit servers argument must be a comma separated string or an array containing strings.',
                      err.message
       end
@@ -124,6 +125,7 @@ describe Dalli::ServersArgNormalizer do
         err = assert_raises ArgumentError do
           subject
         end
+
         assert_equal 'An explicit servers argument must be a comma separated string or an array containing strings.',
                      err.message
       end


### PR DESCRIPTION
This includes several spacing changes to satisfy the latest Rubocop::Minitest.

There is also a [bug in the latest version](https://github.com/rubocop/rubocop-minitest/issues/187) that is causing errors in the Rubocop run.  So my expectation is that this doesn't run green, but will be fixed once that bug is resolved.