### PR TITLE
Preallocate the read buffer in Socket#readfull

### DIFF
--- a/lib/dalli/socket.rb
+++ b/lib/dalli/socket.rb
@@ -13,7 +13,7 @@ module Dalli
     ##
     module InstanceMethods
       def readfull(count)
-        value = +''
+        value = String.new(capacity: count + 1)
         loop do
           result = read_nonblock(count - value.bytesize, exception: false)
           value << result if append_to_buffer?(result)


### PR DESCRIPTION
Since we know exactly how many bytes we expect, instead of stating with an empty string and resizing many times, we can directly ask Ruby to preallocate the necessary space.

For large responses this saves many reallocations and copies.