### PR TITLE
Pass Encoding instances rather than encoding names as String

### DIFF
--- a/lib/dalli/protocol/binary/response_processor.rb
+++ b/lib/dalli/protocol/binary/response_processor.rb
@@ -50,7 +50,7 @@ module Dalli
           extra_len = resp_header.extra_len
           key_len = resp_header.key_len
           bitflags = extra_len.positive? ? body.unpack1('N') : 0x0
-          key = body.byteslice(extra_len, key_len).force_encoding('UTF-8') if key_len.positive?
+          key = body.byteslice(extra_len, key_len).force_encoding(Encoding::UTF_8) if key_len.positive?
           value = body.byteslice((extra_len + key_len)..-1)
           value = parse_as_stored_value ? @value_marshaller.retrieve(value, bitflags) : value
           [key, value]

--- a/lib/dalli/protocol/meta/key_regularizer.rb
+++ b/lib/dalli/protocol/meta/key_regularizer.rb
@@ -23,7 +23,7 @@ module Dalli
         def self.decode(encoded_key, base64_encoded)
           return encoded_key unless base64_encoded
 
-          Base64.strict_decode64(encoded_key).force_encoding('UTF-8')
+          Base64.strict_decode64(encoded_key).force_encoding(Encoding::UTF_8)
         end
       end
     end

--- a/test/test_compressor.rb
+++ b/test/test_compressor.rb
@@ -4,10 +4,9 @@ require_relative 'helper'
 
 describe 'Dalli::Compressor' do
   it 'compresses data using Zlib::Deflate' do
-    assert_equal (+"x\x9CKLJN\x01\x00\x03\xD8\x01\x8B").force_encoding('ASCII-8BIT'),
+    assert_equal "x\x9CKLJN\x01\x00\x03\xD8\x01\x8B".b,
                  ::Dalli::Compressor.compress('abcd')
-    assert_equal (+"x\x9C+\xC9HU(,\xCDL\xCEVH*\xCA/\xCFSH\xCB\xAFP\xC8*\xCD-(\x06\x00z\x06\t\x83")
-      .force_encoding('ASCII-8BIT'),
+    assert_equal "x\x9C+\xC9HU(,\xCDL\xCEVH*\xCA/\xCFSH\xCB\xAFP\xC8*\xCD-(\x06\x00z\x06\t\x83".b,
                  ::Dalli::Compressor.compress('the quick brown fox jumps')
   end
 


### PR DESCRIPTION
This doesn't really matter much in the grand scheme of things but is a pet peeve of mine. It's very marginally faster as Ruby doesn't have to search for that name in the encoding table.