### PR TITLE
Cache Process.pid on Ruby 3.1+

### DIFF
--- a/lib/dalli/pid_cache.rb
+++ b/lib/dalli/pid_cache.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Dalli
+  ##
+  # Dalli::PIDCache is a wrapper class for PID checking to avoid system calls when checking the PID.
+  ##
+  module PIDCache
+    if !Process.respond_to?(:fork) # JRuby or TruffleRuby
+      @pid = Process.pid
+      singleton_class.attr_reader(:pid)
+    elsif Process.respond_to?(:_fork) # Ruby 3.1+
+      class << self
+        attr_reader :pid
+
+        def update!
+          @pid = Process.pid
+        end
+      end
+      update!
+
+      ##
+      # Dalli::PIDCache::CoreExt hooks into Process to be able to reset the PID cache after fork
+      ##
+      module CoreExt
+        def _fork
+          child_pid = super
+          PIDCache.update! if child_pid.zero?
+          child_pid
+        end
+      end
+      Process.singleton_class.prepend(CoreExt)
+    else # Ruby 3.0 or older
+      class << self
+        def pid
+          Process.pid
+        end
+      end
+    end
+  end
+end

--- a/lib/dalli/protocol/connection_manager.rb
+++ b/lib/dalli/protocol/connection_manager.rb
@@ -4,6 +4,8 @@ require 'English'
 require 'socket'
 require 'timeout'
 
+require 'dalli/pid_cache'
+
 module Dalli
   module Protocol
     ##
@@ -51,7 +53,7 @@ module Dalli
         Dalli.logger.debug { "Dalli::Server#connect #{name}" }
 
         @sock = memcached_socket
-        @pid = Process.pid
+        @pid = PIDCache.pid
       rescue SystemCallError, Timeout::Error, EOFError, SocketError => e
         # SocketError = DNS resolution failure
         error_on_request!(e)
@@ -226,7 +228,7 @@ module Dalli
       end
 
       def fork_detected?
-        @pid && @pid != Process.pid
+        @pid && @pid != PIDCache.pid
       end
 
       def log_down_detected


### PR DESCRIPTION
Ref: https://bugs.ruby-lang.org/issues/19443

Recent `glibc` no longer cache the PID, so every call to `Process.pid` end up emitting a syscall which as an impact on performance.

Ruby 3.3 may or may not do PID caching, in the meantime we can implement our own caching in Ruby 3.1+ using the `Process._fork` callback.

NB: This is very much the same code I'm about to merge in redis-client: https://github.com/redis-rb/redis-client/pull/91, and probably Active Record too https://github.com/rails/rails/pull/47419

FYI @dalehamel