### PR TITLE
Prevent multiget socket corruption - fixes #956

### DIFF
--- a/lib/dalli/options.rb
+++ b/lib/dalli/options.rb
@@ -31,6 +31,12 @@ module Dalli
       end
     end
 
+    def pipeline_get_setup 
+      @lock.synchronize do
+        super
+      end
+    end
+
     def pipeline_response_setup
       @lock.synchronize do
         super

--- a/lib/dalli/pipelined_getter.rb
+++ b/lib/dalli/pipelined_getter.rb
@@ -45,6 +45,7 @@ module Dalli
     ##
     def make_getkq_requests(groups)
       groups.each do |server, keys_for_server|
+        server.pipeline_get_setup
         server.request(:pipelined_get, keys_for_server)
       rescue DalliError, NetworkError => e
         Dalli.logger.debug { e.inspect }

--- a/lib/dalli/protocol/base.rb
+++ b/lib/dalli/protocol/base.rb
@@ -210,7 +210,7 @@ module Dalli
           req << quiet_get_request(key)
         end
         # Could send noop here instead of in pipeline_response_setup
-        write(req)
+        write_nonblock(req)
       end
 
       def response_buffer

--- a/lib/dalli/protocol/base.rb
+++ b/lib/dalli/protocol/base.rb
@@ -59,16 +59,21 @@ module Dalli
 
       def unlock!; end
 
+      # verify and start request before sending GETKQ commands, 
+      # otherwise the socket could get corrupted if we fail to reach pipline_response stage
+      def pipeline_get_setup
+        verify_state(:getkq)
+        @connection_manager.start_request!
+      end 
+
       # Start reading key/value pairs from this connection. This is usually called
       # after a series of GETKQ commands. A NOOP is sent, and the server begins
       # flushing responses for kv pairs that were found.
       #
       # Returns nothing.
       def pipeline_response_setup
-        verify_state(:getkq)
         write_noop
         response_buffer.reset
-        @connection_manager.start_request!
       end
 
       # Attempt to receive and parse as many key/value pairs as possible

--- a/lib/dalli/protocol/binary.rb
+++ b/lib/dalli/protocol/binary.rb
@@ -158,9 +158,13 @@ module Dalli
         response_processor.version
       end
 
-      def write_noop
+      def write_noop(nonblock: false)
         req = RequestFormatter.standard_request(opkey: :noop)
-        write(req)
+        if nonblock
+          write_nonblock(req)
+        else 
+          write(req)
+        end
       end
 
       require_relative 'binary/request_formatter'

--- a/lib/dalli/protocol/connection_manager.rb
+++ b/lib/dalli/protocol/connection_manager.rb
@@ -171,6 +171,16 @@ module Dalli
         @sock.read_available
       end
 
+      # Non-blocking write. Should only be used in the context
+      # of a caller who has called start_request!, but not yet
+      # called finish_request!. Here to support the operation
+      # of the get_multi operation. 
+      def write_nonblock 
+        @sock.write(bytes)
+      rescue SystemCallError, Timeout::Error => e
+        error_on_request!(e)
+      end
+
       def max_allowed_failures
         @max_allowed_failures ||= @options[:socket_max_failures] || 2
       end

--- a/lib/dalli/protocol/connection_manager.rb
+++ b/lib/dalli/protocol/connection_manager.rb
@@ -175,7 +175,7 @@ module Dalli
       # of a caller who has called start_request!, but not yet
       # called finish_request!. Here to support the operation
       # of the get_multi operation. 
-      def write_nonblock 
+      def write_nonblock(bytes) 
         @sock.write(bytes)
       rescue SystemCallError, Timeout::Error => e
         error_on_request!(e)

--- a/lib/dalli/protocol/meta.rb
+++ b/lib/dalli/protocol/meta.rb
@@ -162,8 +162,12 @@ module Dalli
         response_processor.version
       end
 
-      def write_noop
-        write(RequestFormatter.meta_noop)
+      def write_noop(nonblock: false)
+        if nonblock
+          write_nonblock(RequestFormatter.meta_noop)
+        else 
+          write(RequestFormatter.meta_noop)
+        end
       end
 
       def authenticate_connection


### PR DESCRIPTION
See https://github.com/petergoldstein/dalli/issues/956.

The key idea is to treat the entire series of write and read ops as a single "request" for the connection; because if we start the getkq write ops but do not read the results off the socket, the socket is left in an invalid state.

To test this locally in Rails Console I used the snippets referenced in the issue to contrive a timeout error. If you agree with this approach I'd be happy to work out how to test this in specs.