### PR TITLE
Introduce safe_get option which ensures key:value integrity even with socket corruption

### DIFF
--- a/lib/dalli.rb
+++ b/lib/dalli.rb
@@ -12,6 +12,9 @@ module Dalli
   # socket/server communication error
   class NetworkError < DalliError; end
 
+  # socket returned unexpected value error
+  class SocketCorruptionError < NetworkError; end
+
   # no server available/alive error
   class RingError < DalliError; end
 

--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -53,7 +53,7 @@ module Dalli
       @normalized_servers = ::Dalli::ServersArgNormalizer.normalize_servers(servers)
       @options = normalize_options(options)
 
-      if @options[:safe_get].present? && @options[:safe_get] == true && @options[:protocol].present? && @options[:protocol] != :binary
+      if @options[:safe_get] == true && !@options[:protocol].nil? && @options[:protocol] != :binary
         raise NotImplementedError, "Safe get is not implemented for the #{@options[:protocol]} protocol"
       end
 

--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -61,7 +61,7 @@ module Dalli
     # Get the value associated with the key.
     # If a value is not found, then +nil+ is returned.
     def get(key, req_options = nil)
-      perform(:get, key, req_options)
+      perform(:getk, key, req_options)
     end
 
     ##

--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -54,7 +54,7 @@ module Dalli
       @options = normalize_options(options)
 
       if @options[:safe_get].present? && @options[:safe_get] == true && @options[:protocol].present? && @options[:protocol] != :binary
-        raise NotImplementedError, "Safe get is not implemented for the #{@options[:protocol]} protocol}"
+        raise NotImplementedError, "Safe get is not implemented for the #{@options[:protocol]} protocol"
       end
 
       @key_manager = ::Dalli::KeyManager.new(@options)

--- a/lib/dalli/protocol/binary.rb
+++ b/lib/dalli/protocol/binary.rb
@@ -28,7 +28,7 @@ module Dalli
       def safe_get(key, options = nil)
         req = RequestFormatter.standard_request(opkey: :getk, key: key)
         write(req)
-        response_processor.getk(cache_nils: cache_nils?(options), key: key)&.last
+        response_processor.getk(key, cache_nils: cache_nils?(options)).last
       rescue Dalli::SocketCorruptionError => e
         Dalli.logger.debug { e.inspect }
         

--- a/lib/dalli/protocol/binary.rb
+++ b/lib/dalli/protocol/binary.rb
@@ -25,6 +25,12 @@ module Dalli
         response_processor.get(cache_nils: cache_nils?(options))
       end
 
+      def getk(key, options = nil)
+        req = RequestFormatter.standard_request(opkey: :getk, key: key)
+        write(req)
+        response_processor.getk(cache_nils: cache_nils?(options), key: key)&.last
+      end
+
       def quiet_get_request(key)
         RequestFormatter.standard_request(opkey: :getkq, key: key)
       end

--- a/lib/dalli/protocol/binary/request_formatter.rb
+++ b/lib/dalli/protocol/binary/request_formatter.rb
@@ -21,6 +21,7 @@ module Dalli
           flush: 0x08,
           noop: 0x0A,
           version: 0x0B,
+          getk: 0x0c,
           getkq: 0x0D,
           append: 0x0E,
           prepend: 0x0F,
@@ -52,6 +53,7 @@ module Dalli
 
         BODY_FORMATS = {
           get: KEY_ONLY,
+          getk: KEY_ONLY,
           getkq: KEY_ONLY,
           delete: KEY_ONLY,
           deleteq: KEY_ONLY,

--- a/lib/dalli/protocol/binary/response_processor.rb
+++ b/lib/dalli/protocol/binary/response_processor.rb
@@ -66,7 +66,7 @@ module Dalli
           raise Dalli::DalliError, "Response error #{resp_header.status}: #{RESPONSE_CODES[resp_header.status]}"
         end
 
-        def get(cache_nils: false)
+        def getk(cache_nils: false, key: nil)
           resp_header, body = read_response
 
           return false if resp_header.not_stored? # Not stored, normal status for add operation
@@ -75,7 +75,19 @@ module Dalli
           raise_on_not_ok!(resp_header)
           return true unless body
 
-          unpack_response_body(resp_header, body, true).last
+          res = unpack_response_body(resp_header, body, true)
+
+          if key.present?
+            if key != res.first
+              raise Dalli::NetworkError, "Socket corruption detected - key does not match response"
+            end
+          end
+
+          res
+        end
+
+        def get(cache_nils: false)
+          getk(cache_nils: cache_nils).last
         end
 
         ##

--- a/lib/dalli/protocol/binary/response_processor.rb
+++ b/lib/dalli/protocol/binary/response_processor.rb
@@ -66,7 +66,7 @@ module Dalli
           raise Dalli::DalliError, "Response error #{resp_header.status}: #{RESPONSE_CODES[resp_header.status]}"
         end
 
-        def getk(cache_nils: false, key: nil)
+        def get(cache_nils: false)
           resp_header, body = read_response
 
           return false if resp_header.not_stored? # Not stored, normal status for add operation
@@ -75,19 +75,28 @@ module Dalli
           raise_on_not_ok!(resp_header)
           return true unless body
 
+          unpack_response_body(resp_header, body, true).last
+        end
+
+        # returns [key, value]
+        def getk(cache_nils: false, key: nil)
+          resp_header, body = read_response
+
+          return false if resp_header.not_stored? # Not stored, normal status for add operation
+          return cache_nils ? ::Dalli::NOT_FOUND : [key, nil] if resp_header.not_found?
+
+          raise_on_not_ok!(resp_header)
+          return true unless body
+
           res = unpack_response_body(resp_header, body, true)
 
           if key.present?
             if key != res.first
-              raise Dalli::NetworkError, "Socket corruption detected - key does not match response"
+              raise Dalli::SocketCorruptionError, "Socket corruption detected - key does not match response"
             end
           end
 
           res
-        end
-
-        def get(cache_nils: false)
-          getk(cache_nils: cache_nils).last
         end
 
         ##

--- a/lib/dalli/protocol/binary/response_processor.rb
+++ b/lib/dalli/protocol/binary/response_processor.rb
@@ -79,7 +79,9 @@ module Dalli
         end
 
         # returns [key, value]
-        def getk(cache_nils: false, key: nil)
+        # raises SocketCorruptionError if the response key does not match the requested key. 
+        # otherwise mirrors the get implementation 
+        def getk(key, cache_nils: false)
           resp_header, body = read_response
 
           return false if resp_header.not_stored? # Not stored, normal status for add operation
@@ -90,10 +92,8 @@ module Dalli
 
           res = unpack_response_body(resp_header, body, true)
 
-          if key.present?
-            if key != res.first
-              raise Dalli::SocketCorruptionError, "Socket corruption detected - key does not match response"
-            end
+          if key != res.first
+            raise Dalli::SocketCorruptionError, "Socket corruption detected - key does not match response"
           end
 
           res


### PR DESCRIPTION
Thinking more about https://github.com/petergoldstein/dalli/issues/956 - I have high confidence that socket corruption explains the incorrect behavior I observed. But I do not have high confidence I found the exact place socket corruption occurred (unfortunately I do not have the stack trace) or that there are no other potential places. It seems in general that connections do not get locked between write ops and reading responses; an error or timeout between any of those could potentially lead to socket corruption. That may be worth fixing and I think my first PR is still worth considering, but I have thought of a more robust approach.

With `safe_get: true`, we will issue `getk` instead of `get` ops to memcached, and ensure that the returned key matches the requested key. This guarantees that even in the case of socket corruption, we cannot return incorrect values for requested keys. The connection is closed if keys do not match, so that the connection manager will eventually re-establish a connection and recover gracefully.

Using `getk` vs `get` comes at the cost of some performance overhead due to key retrieval and comparison. This performance cost would be most significant when caching a large number of small values with comparatively large keys. That is why I lean towards making this an opt-in change - but certainly for our purposes and likely for many other teams, key:value integrity and safety would far outweigh the marginal performance cost.
