### PR TITLE
Better handle Thread#raise and Thread#kill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,14 @@ Dalli Changelog
 Unreleased
 ==========
 
+- Better handle memcached requests being interrupted by Thread#raise or Thread#kill (byroot)
+- Unexpected errors are no longer treated as `Dalli::NetworkError`, including errors raised by `Timeout.timeout` (byroot)
+
 3.2.4
 ==========
 
-- Cache PID calls for performance since glibc no longer caches in recent versions (casperisfine)
-- Preallocate the read buffer in Socket#readfull (casperisfine)
+- Cache PID calls for performance since glibc no longer caches in recent versions (byroot)
+- Preallocate the read buffer in Socket#readfull (byroot)
 
 3.2.3
 ==========
@@ -51,7 +54,7 @@ Unreleased
 3.1.4
 ==========
 
-- Improve response parsing performance (casperisfine)
+- Improve response parsing performance (byroot)
 - Reorganize binary protocol parsing a bit (petergoldstein)
 - Fix handling of non-ASCII keys in get_multi (petergoldstein)
 

--- a/test/integration/test_pipelined_get.rb
+++ b/test/integration/test_pipelined_get.rb
@@ -82,7 +82,7 @@ describe 'Pipelined Get' do
       describe 'pipeline_next_responses' do
         it 'raises NetworkError when called before pipeline_response_setup' do
           memcached_persistent(p) do |dc|
-            server = dc.instance_variable_get(:@ring).servers.first
+            server = dc.send(:ring).servers.first
             server.request(:pipelined_get, %w[a b])
             assert_raises Dalli::NetworkError do
               server.pipeline_next_responses
@@ -92,7 +92,7 @@ describe 'Pipelined Get' do
 
         it 'raises NetworkError when called after pipeline_abort' do
           memcached_persistent(p) do |dc|
-            server = dc.instance_variable_get(:@ring).servers.first
+            server = dc.send(:ring).servers.first
             server.request(:pipelined_get, %w[a b])
             server.pipeline_response_setup
             server.pipeline_abort


### PR DESCRIPTION
Fix: https://github.com/petergoldstein/dalli/issues/956

While it's heavily discouraged, `Timeout.timeout` end up being relatively frequently used in production, so ideally it's better to try to handle it gracefully.

This patch is inspired from https://github.com/redis-rb/redis-client/commit/5f82254583c75b1f914590ae6a3e159ed07c0ac9 before sending a request we increment a counter, and once we fully read the response(s), we decrement it.

If the counter is not 0 when we start a request, we know the connection may have unread responses from a previously aborted request, and we automatically discard it.
