### PR TITLE
rescue IO::TimeoutError raised by Ruby since 3.2.0 on blocking reads/writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Dalli Changelog
 Unreleased
 ==========
 
+- Rescue IO::TimeoutError raised by Ruby since 3.2.0 on blocking reads/writes (skaes)
 
 3.2.5
 ==========

--- a/lib/dalli/protocol.rb
+++ b/lib/dalli/protocol.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'timeout'
+
 module Dalli
   module Protocol
     # Preserved for backwards compatibility.  Should be removed in 4.0
@@ -7,7 +9,6 @@ module Dalli
 
     # Ruby 3.2 raises IO::TimeoutError on blocking reads/writes, but
     # it is not defined in earlier Ruby versions.
-    require 'timeout'
     TIMEOUT_ERRORS =
       if defined?(IO::TimeoutError)
         [Timeout::Error, IO::TimeoutError]

--- a/lib/dalli/protocol.rb
+++ b/lib/dalli/protocol.rb
@@ -4,5 +4,14 @@ module Dalli
   module Protocol
     # Preserved for backwards compatibility.  Should be removed in 4.0
     NOT_FOUND = ::Dalli::NOT_FOUND
+
+    # Ruby 3.2 raises IO::TimeoutError on blocking reads/writes, but
+    # it is not defined in earlier Ruby versions.
+    require 'timeout'
+    if defined?(IO::TimeoutError)
+      TIMEOUT_ERRORS = [Timeout::Error, IO::TimeoutError]
+    else
+      TIMEOUT_ERRORS = [Timeout::Error]
+    end
   end
 end

--- a/lib/dalli/protocol.rb
+++ b/lib/dalli/protocol.rb
@@ -8,10 +8,11 @@ module Dalli
     # Ruby 3.2 raises IO::TimeoutError on blocking reads/writes, but
     # it is not defined in earlier Ruby versions.
     require 'timeout'
-    if defined?(IO::TimeoutError)
-      TIMEOUT_ERRORS = [Timeout::Error, IO::TimeoutError]
-    else
-      TIMEOUT_ERRORS = [Timeout::Error]
-    end
+    TIMEOUT_ERRORS =
+      if defined?(IO::TimeoutError)
+        [Timeout::Error, IO::TimeoutError]
+      else
+        [Timeout::Error]
+      end
   end
 end

--- a/lib/dalli/protocol/base.rb
+++ b/lib/dalli/protocol/base.rb
@@ -106,7 +106,7 @@ module Dalli
         end
 
         values
-      rescue SystemCallError, Timeout::Error, EOFError => e
+      rescue SystemCallError, *TIMEOUT_ERRORS, EOFError => e
         @connection_manager.error_on_request!(e)
       end
 

--- a/lib/dalli/protocol/connection_manager.rb
+++ b/lib/dalli/protocol/connection_manager.rb
@@ -150,19 +150,19 @@ module Dalli
         data = @sock.gets("\r\n")
         error_on_request!('EOF in read_line') if data.nil?
         data
-      rescue SystemCallError, Timeout::Error, EOFError => e
+      rescue SystemCallError, *TIMEOUT_ERRORS, EOFError => e
         error_on_request!(e)
       end
 
       def read(count)
         @sock.readfull(count)
-      rescue SystemCallError, Timeout::Error, EOFError => e
+      rescue SystemCallError, *TIMEOUT_ERRORS, EOFError => e
         error_on_request!(e)
       end
 
       def write(bytes)
         @sock.write(bytes)
-      rescue SystemCallError, Timeout::Error => e
+      rescue SystemCallError, *TIMEOUT_ERRORS => e
         error_on_request!(e)
       end
 


### PR DESCRIPTION
One scenario in which this happens is when a firewall silently drops connections between clients and memcached instances.

With this patch the client reopens the connection and the request succeeds. Without it, IO:TimeoutError is raised for the application to handle which deviates from Dalli behavior under Ruby 3.1 and earlier.

Addresses #967 and fixes the remaining lint in #968 