### PR TITLE
Add base64 to gemspec

### DIFF
--- a/dalli.gemspec
+++ b/dalli.gemspec
@@ -22,4 +22,6 @@ Gem::Specification.new do |s|
   s.metadata = {
     'rubygems_mfa_required' => 'true'
   }
+
+  s.add_dependency 'base64'
 end


### PR DESCRIPTION
base64 is loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0.

Adding `base64` to gemspec to avoid this warning in Ruby 3.3 and allow Dalli to run against ruby-head

Close #981