### PR TITLE
Don't reconnect to send pipelined request no-op

### DIFF
--- a/lib/dalli/pipelined_getter.rb
+++ b/lib/dalli/pipelined_getter.rb
@@ -60,7 +60,7 @@ module Dalli
       deleted = []
 
       servers.each do |server|
-        next unless server.alive?
+        next unless server.connected?
 
         begin
           finish_query_for_server(server)

--- a/test/integration/test_network.rb
+++ b/test/integration/test_network.rb
@@ -113,6 +113,16 @@ describe 'Network' do
         end
       end
 
+      it 'handles timeout error during pipelined get' do
+        with_nil_logger do
+          memcached(p, 19_191) do |dc|
+            dc.send(:ring).server_for_key('abc').sock.stub(:write, proc { raise Timeout::Error }) do
+              assert_empty dc.get_multi(['abc'])
+            end
+          end
+        end
+      end
+
       it 'handles asynchronous Thread#raise' do
         with_nil_logger do
           memcached(p, 19_191) do |dc|


### PR DESCRIPTION
Fixes https://github.com/petergoldstein/dalli/issues/966.

If sending the pipelined get commands fails with a network error, the socket will be closed when we try to send the no-op command. `alive?` reconnects if possible, but we only need to send the no-op if the get commands were successfully sent.

Before https://github.com/petergoldstein/dalli/pull/963, reconnecting to send a no-op was harmless, but now that pipelined requests are tracked in their entirety, an error is raised since there is no request in progress.