### PR TITLE
Drop dependency on base64

### DIFF
--- a/dalli.gemspec
+++ b/dalli.gemspec
@@ -22,6 +22,4 @@ Gem::Specification.new do |s|
   s.metadata = {
     'rubygems_mfa_required' => 'true'
   }
-
-  s.add_dependency 'base64'
 end

--- a/lib/dalli/protocol/meta/key_regularizer.rb
+++ b/lib/dalli/protocol/meta/key_regularizer.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'base64'
-
 module Dalli
   module Protocol
     class Meta
@@ -17,13 +15,15 @@ module Dalli
         def self.encode(key)
           return [key, false] if key.ascii_only? && !WHITESPACE.match(key)
 
-          [Base64.strict_encode64(key), true]
+          strict_base64_encoded = [key].pack('m0')
+          [strict_base64_encoded, true]
         end
 
         def self.decode(encoded_key, base64_encoded)
           return encoded_key unless base64_encoded
 
-          Base64.strict_decode64(encoded_key).force_encoding(Encoding::UTF_8)
+          strict_base64_decoded = encoded_key.unpack1('m0')
+          strict_base64_decoded.force_encoding(Encoding::UTF_8)
         end
       end
     end


### PR DESCRIPTION
#982 added `base64` as a dependency in order to avoid a warning with Ruby 3.3

The `base64` gem is mostly a wrapper around `pack`/`unpack` and as such is easy to replace. Other gems have opted for the same approach:
* https://github.com/rack/rack/pull/2110
* https://github.com/lostisland/faraday/pull/1541
* https://github.com/rubocop/rubocop/pull/12313
* https://github.com/sidekiq/sidekiq/pull/6151
* etc