### PR TITLE
Fix conflict with resolv-replace gem

### DIFF
--- a/lib/dalli/socket.rb
+++ b/lib/dalli/socket.rb
@@ -89,7 +89,7 @@ module Dalli
       attr_accessor :options
 
       if RUBY_VERSION >= '3.0' &&
-          !::TCPSocket.private_instance_methods.include?(:original_resolv_initialize)
+         !::TCPSocket.private_instance_methods.include?(:original_resolv_initialize)
         def self.open(host, port, options = {})
           sock = new(host, port, connect_timeout: options[:socket_timeout])
           sock.options = { host: host, port: port }.merge(options)

--- a/lib/dalli/socket.rb
+++ b/lib/dalli/socket.rb
@@ -88,7 +88,8 @@ module Dalli
       # options - supports enhanced logging in the case of a timeout
       attr_accessor :options
 
-      if RUBY_VERSION >= '3.0'
+      if RUBY_VERSION >= '3.0' &&
+          !::TCPSocket.private_instance_methods.include?(:original_resolv_initialize)
         def self.open(host, port, options = {})
           sock = new(host, port, connect_timeout: options[:socket_timeout])
           sock.options = { host: host, port: port }.merge(options)

--- a/lib/dalli/socket.rb
+++ b/lib/dalli/socket.rb
@@ -88,6 +88,12 @@ module Dalli
       # options - supports enhanced logging in the case of a timeout
       attr_accessor :options
 
+      # Check that TCPSocket#initialize was not overwritten by resolv-replace gem
+      # (part of ruby standard library since 3.0.0, should be removed in 3.4.0),
+      # as it does not handle keyword arguments correctly.
+      # To check this we are using the fact that resolv-replace
+      # aliases TCPSocket#initialize method to #original_resolv_initialize.
+      # https://github.com/ruby/resolv-replace/blob/v0.1.1/lib/resolv-replace.rb#L8
       if RUBY_VERSION >= '3.0' &&
          !::TCPSocket.private_instance_methods.include?(:original_resolv_initialize)
         def self.open(host, port, options = {})


### PR DESCRIPTION
Closes #987

In version 3.2.7 socket_timeout option was introduced for TCPSocket.

This works unless `resolv-replace` gem is loaded (which was added to ruby standard library since version 3.0.0).

This commit adds another check besides the ruby version check to avoid breaking dalli for applications that have `resolv-replace` gem required.