### PR TITLE
Handle IO::TimeoutError when establishing connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Dalli Changelog
 Unreleased
 ==========
 
+ - Handle IO::TimeoutError when establishing connection (eugeneius)
+
 3.2.7
 ==========
 

--- a/lib/dalli/protocol/connection_manager.rb
+++ b/lib/dalli/protocol/connection_manager.rb
@@ -55,7 +55,7 @@ module Dalli
         @sock = memcached_socket
         @pid = PIDCache.pid
         @request_in_progress = false
-      rescue SystemCallError, Timeout::Error, EOFError, SocketError => e
+      rescue SystemCallError, *TIMEOUT_ERRORS, EOFError, SocketError => e
         # SocketError = DNS resolution failure
         error_on_request!(e)
       end

--- a/test/integration/test_network.rb
+++ b/test/integration/test_network.rb
@@ -42,6 +42,13 @@ describe 'Network' do
             end
           end
 
+          it 'handle socket timeouts' do
+            dc = Dalli::Client.new('localhost:19123', socket_timeout: 0)
+            assert_raises Dalli::RingError, message: 'No server available' do
+              dc.get('abc')
+            end
+          end
+
           it 'handle connect timeouts' do
             memcached_mock(lambda { |sock|
                              sleep(0.6)


### PR DESCRIPTION
Since https://github.com/petergoldstein/dalli/pull/977, `Dalli::Socket::TCP.open` can also raise this error.