### PR TITLE
Only flush multi responses once

### DIFF
--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -190,10 +190,12 @@ module Dalli
     def quiet
       old = Thread.current[::Dalli::QUIET]
       Thread.current[::Dalli::QUIET] = true
-      yield
-    ensure
-      @ring&.pipeline_consume_and_ignore_responses
-      Thread.current[::Dalli::QUIET] = old
+      begin
+        yield
+      ensure
+        @ring&.pipeline_consume_and_ignore_responses unless old
+        Thread.current[::Dalli::QUIET] = old
+      end
     end
     alias multi quiet
 


### PR DESCRIPTION
`Client#quiet` is reentrant, in that multiple `quiet` blocks can be
nested. We only need to flush the responses at the conclusion of the
outermost block.
