### PR TITLE
Fix cannot read response data included terminator when use meta protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Dalli Changelog
 Unreleased
 ==========
 
+- Fix cannot read response data included terminator `\r\n` when use meta protocol (matsubara0507)
+
 3.2.8
 ==========
 

--- a/lib/dalli/protocol/meta/response_processor.rb
+++ b/lib/dalli/protocol/meta/response_processor.rb
@@ -32,7 +32,7 @@ module Dalli
           return cache_nils ? ::Dalli::NOT_FOUND : nil if tokens.first == EN
           return true unless tokens.first == VA
 
-          @value_marshaller.retrieve(read_line, bitflags_from_tokens(tokens))
+          @value_marshaller.retrieve(read_data(tokens[1].to_i), bitflags_from_tokens(tokens))
         end
 
         def meta_get_with_value_and_cas
@@ -42,7 +42,7 @@ module Dalli
           cas = cas_from_tokens(tokens)
           return [nil, cas] unless tokens.first == VA
 
-          [@value_marshaller.retrieve(read_line, bitflags_from_tokens(tokens)), cas]
+          [@value_marshaller.retrieve(read_data(tokens[1].to_i), bitflags_from_tokens(tokens)), cas]
         end
 
         def meta_get_without_value
@@ -204,6 +204,10 @@ module Dalli
         def next_line_to_tokens
           line = read_line
           line&.split || []
+        end
+
+        def read_data(data_size)
+          @io_source.read(data_size + TERMINATOR.bytesize)&.chomp!(TERMINATOR)
         end
       end
     end

--- a/test/integration/test_operations.rb
+++ b/test/integration/test_operations.rb
@@ -23,6 +23,21 @@ describe 'operations' do
           end
         end
 
+        it 'return the value that include TERMINATOR on a hit' do
+          memcached_persistent(p) do |dc|
+            dc.flush
+
+            val1 = "12345#{Dalli::Protocol::Meta::TERMINATOR}67890"
+            dc.set('a', val1)
+            val2 = dc.get('a')
+
+            assert_equal val1, val2
+
+            assert op_addset_succeeds(dc.set('a', nil))
+            assert_nil dc.get('a')
+          end
+        end
+
         it 'returns nil on a miss' do
           memcached_persistent(p) do |dc|
             assert_nil dc.get('notexist')


### PR DESCRIPTION
if meta protocol `get` response data included terminator `\r\n` then occur error

```
  1) Error:
operations::using the meta protocol::get#test_0002_return the value that include TERMINATOR on a hit:
Dalli::UnmarshalError: Unable to unmarshal value: marshal data too short
    lib/dalli/protocol/value_serializer.rb:65:in `filter_argument_error'
    lib/dalli/protocol/value_serializer.rb:51:in `rescue in retrieve'
    lib/dalli/protocol/value_serializer.rb:45:in `retrieve'
    lib/dalli/protocol/value_marshaller.rb:44:in `retrieve'
    lib/dalli/protocol/meta/response_processor.rb:35:in `meta_get_with_value'
    lib/dalli/protocol/meta.rb:30:in `get'
    lib/dalli/protocol/base.rb:36:in `request'
    lib/dalli/options.rb:18:in `block in request'
    lib/dalli/options.rb:17:in `synchronize'
    lib/dalli/options.rb:17:in `request'
    lib/dalli/client.rb:426:in `perform'
    lib/dalli/client.rb:64:in `get'
    test/integration/test_operations.rb:32:in `block (6 levels) in <top (required)>'
    test/helpers/memcached.rb:41:in `memcached'
    test/helpers/memcached.rb:50:in `memcached_persistent'
    test/integration/test_operations.rb:27:in `block (5 levels) in <top (required)>'
```

Meta get response include size of data block.
ref. https://github.com/memcached/memcached/blob/1.6.29/doc/protocol.txt#L519

Therefore, changed to read response data using size instead of terminator.