### PR TITLE
Raise Dalli::UnmarshalError on ArgumentError "dump format error (user class)"

### DIFF
--- a/lib/dalli/protocol/value_serializer.rb
+++ b/lib/dalli/protocol/value_serializer.rb
@@ -38,7 +38,7 @@ module Dalli
       # in current systems
       # rubocop:disable Layout/LineLength
       TYPE_ERR_REGEXP = %r{needs to have method `_load'|exception class/object expected|instance of IO needed|incompatible marshal file format}.freeze
-      ARGUMENT_ERR_REGEXP = /undefined class|marshal data too short/.freeze
+      ARGUMENT_ERR_REGEXP = /undefined class|marshal data too short|dump format error \(user class\)/.freeze
       NAME_ERR_STR = 'uninitialized constant'
       # rubocop:enable Layout/LineLength
 

--- a/test/integration/test_network.rb
+++ b/test/integration/test_network.rb
@@ -15,7 +15,7 @@ describe 'Network' do
 
         describe 'with a fake server' do
           it 'handle connection reset' do
-            memcached_mock(->(sock) { sock.close }) do
+            memcached_mock(lambda(&:close)) do
               dc = Dalli::Client.new('localhost:19123')
               assert_raises Dalli::RingError, message: 'No server available' do
                 dc.get('abc')
@@ -25,7 +25,7 @@ describe 'Network' do
 
           it 'handle connection reset with unix socket' do
             socket_path = MemcachedMock::UNIX_SOCKET_PATH
-            memcached_mock(->(sock) { sock.close }, :start_unix, socket_path) do
+            memcached_mock(lambda(&:close), :start_unix, socket_path) do
               dc = Dalli::Client.new(socket_path)
               assert_raises Dalli::RingError, message: 'No server available' do
                 dc.get('abc')


### PR DESCRIPTION
This PR makes Rails recognize the unmarshalling error and can deal with it normally.

Before this change, such an ArgumentError would bubble up and raise in Rails.

## Details

In Marshal, a "user class" is a class which extends a "core class" (String, Hash...).

When a "user class" is dumped by `Marshal.dump`, it becomes a binary string. `Marshal.load`, expects that the inheritance of this class looks the same as it did when the binary string was created.

_If the classes do not match_, due to some change in the code, an ArgumentError is raised. (The specific [ArgumentError is raised in marshal.c](https://github.com/ruby/ruby/blob/master/marshal.c#L1897).)

Marshal's concept of "user class" is explained in: ["Caching With MessagePack" by Chris Salzberg at RubyKaigi 2022](https://rubykaigi.org/2022/presentations/shioyama.html)

## Context for Rails

This Rails commit, which is in Rails 7.1, https://github.com/rails/rails/commit/a6be798e5c5b47de333a768de31ae1ef53f205e9, expects Dalli to reraise such errors, so that Rails can decide to regenerate that cache entry.

Between 7.0 and 7.1 Rails changed the inheritance hierarchy in its String-extending classes OutputBuffer and SafeBuffer, which triggered this error in production for me.

## Further

In #1009 I made the regular expression-making code a little easier to read, using Regexp.union.

But, later, in #1011, I made a wider change, reraising Dalli::UnmarshalError for _all_ errors raised during `serializer.load`. It's a simplification of the code, of the solution, but takes more steps than this tiny change.

---

EDIT: I posted [a feature request in bugs.ruby-lang.org](https://bugs.ruby-lang.org/issues/20669) for having error classes for these ArgumentError instances, instead. (Perhaps they can become 1 error, (`class UnmarshalingError < ArgumentError`), or something.)