### PR TITLE
Add logger as a dependency, drop ostruct for tests

### DIFF
--- a/dalli.gemspec
+++ b/dalli.gemspec
@@ -24,4 +24,6 @@ Gem::Specification.new do |s|
     'changelog_uri' => 'https://github.com/petergoldstein/dalli/blob/main/CHANGELOG.md',
     'rubygems_mfa_required' => 'true'
   }
+
+  s.add_dependency 'logger'
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -11,7 +11,6 @@ ENV['SASL_CONF_PATH'] = "#{File.dirname(__FILE__)}/sasl/memcached.conf"
 
 require 'dalli'
 require 'logger'
-require 'ostruct'
 require 'securerandom'
 
 Dalli.logger = Logger.new($stdout)

--- a/test/integration/test_network.rb
+++ b/test/integration/test_network.rb
@@ -15,7 +15,7 @@ describe 'Network' do
 
         describe 'with a fake server' do
           it 'handle connection reset' do
-            memcached_mock(->(sock) { sock.close }) do
+            memcached_mock(lambda(&:close)) do
               dc = Dalli::Client.new('localhost:19123')
               assert_raises Dalli::RingError, message: 'No server available' do
                 dc.get('abc')
@@ -25,7 +25,7 @@ describe 'Network' do
 
           it 'handle connection reset with unix socket' do
             socket_path = MemcachedMock::UNIX_SOCKET_PATH
-            memcached_mock(->(sock) { sock.close }, :start_unix, socket_path) do
+            memcached_mock(lambda(&:close), :start_unix, socket_path) do
               dc = Dalli::Client.new(socket_path)
               assert_raises Dalli::RingError, message: 'No server available' do
                 dc.get('abc')

--- a/test/protocol/test_binary.rb
+++ b/test/protocol/test_binary.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'ostruct'
 require_relative '../helper'
 
 describe Dalli::Protocol::Binary do


### PR DESCRIPTION
This PR avoids a Ruby warning.

There was a warning in ruby-head (3.4) that in Ruby 3.5 `logger` and `ostruct` will not be built-in gems, but regular gems.

```
/home/runner/work/dalli/dalli/test/helper.rb:13: warning: logger was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.5.0. Add logger to your Gemfile or gemspec.
/home/runner/work/dalli/dalli/test/helper.rb:14: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.5.0. Add ostruct to your Gemfile or gemspec.
```


This change avoids that warning.

---

In addition, the `ostruct` dependency wasn't in actual use, just `require 'ostruct'` statements. It was possible to fully omit that and pass all tests.

A second commit with a linting change was added, using the autocorrect feature of RuboCop.