### PR TITLE
add example benchmark showing Dalli doesn't optimally handle large strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ profile.html
 ## Environment normalisation:
 /.bundle/
 /lib/bundler/man/
+dev.yml
 
 # for a library or gem, you might want to ignore these files since the code is
 # intended to run in multiple environments; otherwise, check them in:

--- a/bin/benchmark
+++ b/bin/benchmark
@@ -1,0 +1,41 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'bundler/inline'
+require 'json'
+
+gemfile do
+  source 'https://rubygems.org'
+  gem 'dalli'
+  gem 'benchmark-ips'
+end
+
+require 'dalli'
+require 'benchmark/ips'
+
+##
+# StringSerializer is a serializer that avoids the overhead of Marshal or JSON.
+##
+class StringSerializer
+  def self.dump(value)
+    value
+  end
+
+  def self.load(value)
+    value
+  end
+end
+
+client = Dalli::Client.new('localhost', compress: false)
+json_client = Dalli::Client.new('localhost', serializer: JSON, compress: false)
+string_client = Dalli::Client.new('localhost', serializer: StringSerializer, compress: false)
+
+payload = 'B' * 1_000_000
+client.set('key', payload)
+json_client.set('json_key', payload)
+string_client.set('string_key', payload)
+Benchmark.ips do |x|
+  x.report('get 1MB MARSHAL') { client.get('key') }
+  x.report('get 1MB JSON') { json_client.get('json_key') }
+  x.report('get 1MB STRING') { string_client.get('string_key') }
+end


### PR DESCRIPTION
We will want to start adding some benchmarks as we modify the existing code or specifically target performance improvements. This PR starts with a very simple benchmark example, which we can build on.

OK, yeah there will definitely be some more performance to squeeze from dalli out of the box... Dalli still doesn't have the [string bypass](https://github.com/petergoldstein/dalli/pull/938/files), and even though Rails Active Support Cache handles serialization and compression, it looks like without minor modification Dali still tries to wrap with it's own serialization... 

---

This benchmark shows a quick work around, but I think we could update the original PR and clean up the conflicts and tests so that all Rails users would get a performance boast out of the box and we wouldn't need to configure all of our apps. We have previously avoided this issue as our previous internal adapters did handle this large string bypass.

```
Warming up --------------------------------------
     get 1MB MARSHAL   168.000 i/100ms
        get 1MB JSON    59.000 i/100ms
      get 1MB STRING   225.000 i/100ms
Calculating -------------------------------------
     get 1MB MARSHAL      1.755k (± 5.1%) i/s  (569.80 μs/i) -      8.904k in   5.087145s
        get 1MB JSON    604.734 (± 2.0%) i/s    (1.65 ms/i) -      3.068k in   5.075365s
      get 1MB STRING      2.411k (± 5.6%) i/s  (414.74 μs/i) -     12.150k in   5.056508s
```