### PR TITLE
Handle SERVER_ERROR from Memcached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
 ==========
 
 - Fix cannot read response data included terminator `\r\n` when use meta protocol (matsubara0507)
+- Support SERVER_ERROR response from Memcached as per the [memcached spec](https://github.com/memcached/memcached/blob/e43364402195c8e822bb8f88755a60ab8bbed62a/doc/protocol.txt#L172) (grcooper)
 
 3.2.8
 ==========

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gemspec
 
 group :development, :test do
   gem 'connection_pool'
+  gem 'debug' unless RUBY_PLATFORM == 'java'
   gem 'minitest', '~> 5'
   gem 'rack', '~> 2.0', '>= 2.2.0'
   gem 'rake', '~> 13.0'

--- a/lib/dalli.rb
+++ b/lib/dalli.rb
@@ -27,6 +27,9 @@ module Dalli
   # operation is not permitted in a multi block
   class NotPermittedMultiOpError < DalliError; end
 
+  # raised when Memcached response with a SERVER_ERROR
+  class ServerError < DalliError; end
+
   # Implements the NullObject pattern to store an application-defined value for 'Key not found' responses.
   class NilObject; end # rubocop:disable Lint/EmptyClass
   NOT_FOUND = NilObject.new

--- a/lib/dalli/protocol/meta/response_processor.rb
+++ b/lib/dalli/protocol/meta/response_processor.rb
@@ -21,6 +21,7 @@ module Dalli
         STAT = 'STAT'
         VA = 'VA'
         VERSION = 'VERSION'
+        SERVER_ERROR = 'SERVER_ERROR'
 
         def initialize(io_source, value_marshaller)
           @io_source = io_source
@@ -167,9 +168,12 @@ module Dalli
 
         def error_on_unexpected!(expected_codes)
           tokens = next_line_to_tokens
-          raise Dalli::DalliError, "Response error: #{tokens.first}" unless expected_codes.include?(tokens.first)
 
-          tokens
+          return tokens if expected_codes.include?(tokens.first)
+
+          raise Dalli::ServerError, tokens.join(' ').to_s if tokens.first == SERVER_ERROR
+
+          raise Dalli::DalliError, "Response error: #{tokens.first}"
         end
 
         def bitflags_from_tokens(tokens)

--- a/test/integration/test_network.rb
+++ b/test/integration/test_network.rb
@@ -361,4 +361,19 @@ describe 'Network' do
       end
     end
   end
+
+  if MemcachedManager.supported_protocols.include?(:meta)
+    describe 'ServerError' do
+      it 'is raised when Memcached response with a SERVER_ERROR' do
+        memcached_mock(->(sock) { sock.write("SERVER_ERROR foo bar\r\n") }) do
+          dc = Dalli::Client.new('localhost:19123', protocol: :meta)
+          err = assert_raises Dalli::ServerError do
+            dc.get('abc')
+          end
+
+          assert_equal 'SERVER_ERROR foo bar', err.message
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
As per the Memcached spec, SERVER_ERROR is a valid value to return, alongside the error message. This only seems to be valid for the Meta/Text protocols.

I have added support so things like Envoy that return SERVER_ERROR will be handled correctly and raised as an appropriate error.

I also added the `debug` gem to `:development` and `:test` since it is very useful to be able to add things like breakpoints while debugging.