### PR TITLE
update benchmark & profile to support meta client and commit performance fix for meta protocol

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.2
+        ruby-version: 3.4
         bundler-cache: true # 'bundle install' and cache
     - name: Run Benchmarks
       run: RUBY_YJIT_ENABLE=1 BENCH_TARGET=all bundle exec bin/benchmark

--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -23,6 +23,9 @@ jobs:
         bundler-cache: true # 'bundle install' and cache
     - name: Run Profiles
       run: RUBY_YJIT_ENABLE=1 BENCH_TARGET=all bundle exec bin/profile
+    # NOTE: to pull profile results, visit https://github.com/petergoldstein/dalli/actions/workflows/profile.yml
+    # click to view the run you are interested in (ex https://github.com/petergoldstein/dalli/actions/runs/13296952241)
+    # in the artifacts section, download the profile results
     - name: Upload profile results
       uses: actions/upload-artifact@v4
       with:
@@ -36,3 +39,7 @@ jobs:
           socket_get_multi_profile.json
           client_set_multi_profile.json
           socket_set_multi_profile.json
+          meta_client_get_multi_profile.json
+          meta_client_get_profile.json
+          meta_client_set_multi_profile.json
+          meta_client_set_profile.json

--- a/bin/benchmark
+++ b/bin/benchmark
@@ -43,6 +43,7 @@ TERMINATOR = "\r\n"
 puts "yjit: #{RubyVM::YJIT.enabled?}"
 
 client = Dalli::Client.new(dalli_url, serializer: StringSerializer, compress: false, raw: true)
+meta_client = Dalli::Client.new(dalli_url, protocol: :meta, serializer: StringSerializer, compress: false, raw: true)
 multi_client = Dalli::Client.new('localhost:11211,localhost:11222', serializer: StringSerializer, compress: false,
                                                                     raw: true)
 
@@ -58,6 +59,7 @@ sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_KEEPALIVE, true)
 
 # ensure the clients are all connected and working
 client.set('key', payload)
+meta_client.set('meta_key', payload)
 multi_client.set('multi_key', payload)
 sock.write("set sock_key 0 3600 #{payload.bytesize}\r\n")
 sock.write(payload)
@@ -150,6 +152,7 @@ if %w[all set].include?(bench_target)
   Benchmark.ips do |x|
     x.config(warmup: bench_warmup, time: bench_time, suite: suite)
     x.report('client set') { client.set('key', payload) }
+    x.report('meta client set') { meta_client.set('meta_key', payload) }
     # x.report('multi client set') { multi_client.set('string_key', payload) }
     x.report('raw sock set') do
       sock.write("ms sock_key #{payload.bytesize} T3600 MS\r\n")
@@ -168,6 +171,10 @@ if %w[all get].include?(bench_target)
     x.config(warmup: bench_warmup, time: bench_time, suite: suite)
     x.report('get dalli') do
       result = client.get('key')
+      raise 'mismatch' unless result == payload
+    end
+    x.report('get meta client') do
+      result = meta_client.get('meta_key')
       raise 'mismatch' unless result == payload
     end
     # NOTE: while this is the fastest it is not thread safe and is blocking vs IO sharing friendly
@@ -212,6 +219,10 @@ if %w[all get_multi].include?(bench_target)
       result = client.get_multi(pairs.keys)
       raise 'mismatch' unless result == pairs
     end
+    x.report('get 100 keys meta client') do
+      result = meta_client.get_multi(pairs.keys)
+      raise 'mismatch' unless result == pairs
+    end
     x.report('get 100 keys raw sock') do
       result = sock_get_multi(sock, pairs)
       raise 'mismatch' unless result == pairs
@@ -227,6 +238,13 @@ if %w[all set_multi].include?(bench_target)
       client.quiet do
         pairs.each do |key, value|
           client.set(key, value, 3600, raw: true)
+        end
+      end
+    end
+    x.report('write 100 keys meta client') do
+      meta_client.quiet do
+        pairs.each do |key, value|
+          meta_client.set(key, value, 3600, raw: true)
         end
       end
     end

--- a/bin/benchmark
+++ b/bin/benchmark
@@ -2,13 +2,12 @@
 # frozen_string_literal: true
 
 # This helps benchmark current performance of Dalli
-# as well as compare performance of optimizated and non-optimized calls like multi-set vs set
+# as well as compare performance of optimized and non-optimized calls like multi-set vs set
 #
 # run with:
 # bundle exec bin/benchmark
 # RUBY_YJIT_ENABLE=1 BENCH_TARGET=get bundle exec bin/benchmark
 require 'bundler/inline'
-require 'json'
 
 gemfile do
   source 'https://rubygems.org'
@@ -16,14 +15,15 @@ gemfile do
   gem 'logger'
 end
 
-require_relative '../lib/dalli'
+require 'json'
 require 'benchmark/ips'
 require 'monitor'
+require_relative '../lib/dalli'
 
 ##
-# StringSerializer is a serializer that avoids the overhead of Marshal or JSON.
+# NoopSerializer is a serializer that avoids the overhead of Marshal or JSON.
 ##
-class StringSerializer
+class NoopSerializer
   def self.dump(value)
     value
   end
@@ -34,7 +34,7 @@ class StringSerializer
 end
 
 dalli_url = ENV['BENCH_CACHE_URL'] || '127.0.0.1:11211'
-bench_target = ENV['BENCH_TARGET'] || 'set'
+bench_target = ENV['BENCH_TARGET'] || 'all'
 bench_time = (ENV['BENCH_TIME'] || 10).to_i
 bench_warmup = (ENV['BENCH_WARMUP'] || 3).to_i
 bench_payload_size = (ENV['BENCH_PAYLOAD_SIZE'] || 700_000).to_i
@@ -42,9 +42,9 @@ payload = 'B' * bench_payload_size
 TERMINATOR = "\r\n"
 puts "yjit: #{RubyVM::YJIT.enabled?}"
 
-client = Dalli::Client.new(dalli_url, serializer: StringSerializer, compress: false, raw: true)
-meta_client = Dalli::Client.new(dalli_url, protocol: :meta, serializer: StringSerializer, compress: false, raw: true)
-multi_client = Dalli::Client.new('localhost:11211,localhost:11222', serializer: StringSerializer, compress: false,
+client = Dalli::Client.new(dalli_url, serializer: NoopSerializer, compress: false, raw: true)
+meta_client = Dalli::Client.new(dalli_url, protocol: :meta, serializer: NoopSerializer, compress: false, raw: true)
+multi_client = Dalli::Client.new('localhost:11211,localhost:11222', serializer: NoopSerializer, compress: false,
                                                                     raw: true)
 
 # The raw socket implementation is used to benchmark the performance of dalli & the overhead of the various abstractions
@@ -54,7 +54,7 @@ sock.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, true)
 sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_KEEPALIVE, true)
 # Benchmarks didn't see any performance gains from increasing the SO_RCVBUF buffer size
 # sock.setsockopt(Socket::SOL_SOCKET, ::Socket::SO_RCVBUF, 1024 * 1024 * 8)
-# Benchamrks did see an improvement in performance when increasing the SO_SNDBUF buffer size
+# Benchmarks did see an improvement in performance when increasing the SO_SNDBUF buffer size
 # sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF, 1024 * 1024 * 8)
 
 # ensure the clients are all connected and working

--- a/bin/profile
+++ b/bin/profile
@@ -7,7 +7,6 @@
 # run with:
 # RUBY_YJIT_ENABLE=1 bundle exec bin/profile
 require 'bundler/inline'
-require 'json'
 
 gemfile do
   source 'https://rubygems.org'
@@ -16,14 +15,15 @@ gemfile do
   gem 'logger'
 end
 
-require_relative '../lib/dalli'
+require 'json'
 require 'benchmark/ips'
 require 'vernier'
+require_relative '../lib/dalli'
 
 ##
-# StringSerializer is a serializer that avoids the overhead of Marshal or JSON.
+# NoopSerializer is a serializer that avoids the overhead of Marshal or JSON.
 ##
-class StringSerializer
+class NoopSerializer
   def self.dump(value)
     value
   end
@@ -34,14 +34,14 @@ class StringSerializer
 end
 
 dalli_url = ENV['BENCH_CACHE_URL'] || '127.0.0.1:11211'
-bench_target = ENV['BENCH_TARGET'] || 'get'
-bench_time = (ENV['BENCH_TIME'] || 10).to_i
+bench_target = ENV['BENCH_TARGET'] || 'all'
+bench_time = (ENV['BENCH_TIME'] || 8).to_i
 bench_payload_size = (ENV['BENCH_PAYLOAD_SIZE'] || 700_000).to_i
 TERMINATOR = "\r\n"
 puts "yjit: #{RubyVM::YJIT.enabled?}"
 
-client = Dalli::Client.new(dalli_url, serializer: StringSerializer, compress: false)
-meta_client = Dalli::Client.new(dalli_url, protocol: :meta, serializer: StringSerializer, compress: false, raw: true)
+client = Dalli::Client.new(dalli_url, serializer: NoopSerializer, compress: false)
+meta_client = Dalli::Client.new(dalli_url, protocol: :meta, serializer: NoopSerializer, compress: false, raw: true)
 
 # The raw socket implementation is used to benchmark the performance of dalli & the overhead of the various abstractions
 # in the library.
@@ -50,7 +50,7 @@ sock.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, true)
 sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_KEEPALIVE, true)
 # Benchmarks didn't see any performance gains from increasing the SO_RCVBUF buffer size
 # sock.setsockopt(Socket::SOL_SOCKET, ::Socket::SO_RCVBUF, 1024 * 1024 * 8)
-# Benchamrks did see an improvement in performance when increasing the SO_SNDBUF buffer size
+# Benchmarks did see an improvement in performance when increasing the SO_SNDBUF buffer size
 # sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF, 1024 * 1024 * 8)
 
 payload = 'B' * bench_payload_size

--- a/bin/profile
+++ b/bin/profile
@@ -41,6 +41,7 @@ TERMINATOR = "\r\n"
 puts "yjit: #{RubyVM::YJIT.enabled?}"
 
 client = Dalli::Client.new(dalli_url, serializer: StringSerializer, compress: false)
+meta_client = Dalli::Client.new(dalli_url, protocol: :meta, serializer: StringSerializer, compress: false, raw: true)
 
 # The raw socket implementation is used to benchmark the performance of dalli & the overhead of the various abstractions
 # in the library.
@@ -56,6 +57,7 @@ payload = 'B' * bench_payload_size
 dalli_key = 'dalli_key'
 # ensure the clients are all connected and working
 client.set(dalli_key, payload)
+meta_client.set(dalli_key, payload)
 sock.write("set sock_key 0 3600 #{payload.bytesize}\r\n")
 sock.write(payload)
 sock.write(TERMINATOR)
@@ -132,6 +134,14 @@ if %w[all get].include?(bench_target)
     end
   end
 
+  Vernier.profile(out: 'meta_client_get_profile.json') do
+    start_time = Time.now
+    while Time.now - start_time < bench_time
+      result = meta_client.get(dalli_key)
+      raise 'mismatch' unless result == payload
+    end
+  end
+
   Vernier.profile(out: 'socket_get_profile.json') do
     start_time = Time.now
     while Time.now - start_time < bench_time
@@ -148,6 +158,11 @@ if %w[all set].include?(bench_target)
   Vernier.profile(out: 'client_set_profile.json') do
     start_time = Time.now
     client.set(dalli_key, payload, 3600, raw: true) while Time.now - start_time < bench_time
+  end
+
+  Vernier.profile(out: 'meta_client_set_profile.json') do
+    start_time = Time.now
+    meta_client.set(dalli_key, payload, 3600, raw: true) while Time.now - start_time < bench_time
   end
 
   Vernier.profile(out: 'socket_set_profile.json') do
@@ -171,6 +186,14 @@ if %w[all get_multi].include?(bench_target)
     end
   end
 
+  Vernier.profile(out: 'meta_client_get_multi_profile.json') do
+    start_time = Time.now
+    while Time.now - start_time < bench_time
+      result = meta_client.get_multi(pairs.keys)
+      raise 'mismatch' unless result == pairs
+    end
+  end
+
   Vernier.profile(out: 'socket_get_multi_profile.json') do
     start_time = Time.now
     while Time.now - start_time < bench_time
@@ -188,6 +211,15 @@ if %w[all set_multi].include?(bench_target)
     while Time.now - start_time < bench_time
       pairs.each do |key, value|
         client.set(key, value, 3600, raw: true)
+      end
+    end
+  end
+
+  Vernier.profile(out: 'meta_client_set_multi_profile.json') do
+    start_time = Time.now
+    while Time.now - start_time < bench_time
+      pairs.each do |key, value|
+        meta_client.set(key, value, 3600, raw: true)
       end
     end
   end

--- a/lib/dalli/protocol/meta.rb
+++ b/lib/dalli/protocol/meta.rb
@@ -85,6 +85,8 @@ module Dalli
                                         bitflags: bitflags, cas: cas,
                                         ttl: ttl, mode: mode, quiet: quiet?, base64: base64)
         write(req)
+        write(value)
+        write(TERMINATOR)
       end
       # rubocop:enable Metrics/ParameterLists
 
@@ -105,6 +107,8 @@ module Dalli
         req = RequestFormatter.meta_set(key: encoded_key, value: value, base64: base64,
                                         cas: cas, ttl: ttl, mode: mode, quiet: quiet?)
         write(req)
+        write(value)
+        write(TERMINATOR)
       end
       # rubocop:enable Metrics/ParameterLists
 

--- a/lib/dalli/protocol/meta/request_formatter.rb
+++ b/lib/dalli/protocol/meta/request_formatter.rb
@@ -13,7 +13,6 @@ module Dalli
         # and introducing an intermediate object seems like overkill.
         #
         # rubocop:disable Metrics/CyclomaticComplexity
-        # rubocop:disable Metrics/MethodLength
         # rubocop:disable Metrics/ParameterLists
         # rubocop:disable Metrics/PerceivedComplexity
         def self.meta_get(key:, value: true, return_cas: false, ttl: nil, base64: false, quiet: false)
@@ -36,8 +35,6 @@ module Dalli
           cmd << " M#{mode_to_token(mode)}"
           cmd << ' q' if quiet
           cmd << TERMINATOR
-          cmd << value
-          cmd + TERMINATOR
         end
 
         def self.meta_delete(key:, cas: nil, ttl: nil, base64: false, quiet: false)
@@ -62,7 +59,6 @@ module Dalli
           cmd + TERMINATOR
         end
         # rubocop:enable Metrics/CyclomaticComplexity
-        # rubocop:enable Metrics/MethodLength
         # rubocop:enable Metrics/ParameterLists
         # rubocop:enable Metrics/PerceivedComplexity
 

--- a/test/protocol/meta/test_request_formatter.rb
+++ b/test/protocol/meta/test_request_formatter.rb
@@ -41,61 +41,61 @@ describe Dalli::Protocol::Meta::RequestFormatter do
     let(:ttl) { rand(500..999) }
 
     it 'returns the default (treat as a set, no CAS check) when just passed key, datalen, and bitflags' do
-      assert_equal "ms #{key} #{val.bytesize} c F#{bitflags} MS\r\n#{val}\r\n",
+      assert_equal "ms #{key} #{val.bytesize} c F#{bitflags} MS\r\n",
                    Dalli::Protocol::Meta::RequestFormatter.meta_set(key: key, value: val, bitflags: bitflags)
     end
 
     it 'supports the add mode' do
-      assert_equal "ms #{key} #{val.bytesize} c F#{bitflags} ME\r\n#{val}\r\n",
+      assert_equal "ms #{key} #{val.bytesize} c F#{bitflags} ME\r\n",
                    Dalli::Protocol::Meta::RequestFormatter.meta_set(key: key, value: val, bitflags: bitflags,
                                                                     mode: :add)
     end
 
     it 'supports the replace mode' do
-      assert_equal "ms #{key} #{val.bytesize} c F#{bitflags} MR\r\n#{val}\r\n",
+      assert_equal "ms #{key} #{val.bytesize} c F#{bitflags} MR\r\n",
                    Dalli::Protocol::Meta::RequestFormatter.meta_set(key: key, value: val, bitflags: bitflags,
                                                                     mode: :replace)
     end
 
     it 'passes a TTL if one is provided' do
-      assert_equal "ms #{key} #{val.bytesize} c F#{bitflags} T#{ttl} MS\r\n#{val}\r\n",
+      assert_equal "ms #{key} #{val.bytesize} c F#{bitflags} T#{ttl} MS\r\n",
                    Dalli::Protocol::Meta::RequestFormatter.meta_set(key: key, value: val, ttl: ttl, bitflags: bitflags)
     end
 
     it 'omits the CAS flag on append' do
-      assert_equal "ms #{key} #{val.bytesize} MA\r\n#{val}\r\n",
+      assert_equal "ms #{key} #{val.bytesize} MA\r\n",
                    Dalli::Protocol::Meta::RequestFormatter.meta_set(key: key, value: val, mode: :append)
     end
 
     it 'omits the CAS flag on prepend' do
-      assert_equal "ms #{key} #{val.bytesize} MP\r\n#{val}\r\n",
+      assert_equal "ms #{key} #{val.bytesize} MP\r\n",
                    Dalli::Protocol::Meta::RequestFormatter.meta_set(key: key, value: val, mode: :prepend)
     end
 
     it 'passes a CAS if one is provided' do
-      assert_equal "ms #{key} #{val.bytesize} c F#{bitflags} C#{cas} MS\r\n#{val}\r\n",
+      assert_equal "ms #{key} #{val.bytesize} c F#{bitflags} C#{cas} MS\r\n",
                    Dalli::Protocol::Meta::RequestFormatter.meta_set(key: key, value: val, bitflags: bitflags, cas: cas)
     end
 
     it 'excludes CAS if set to 0' do
-      assert_equal "ms #{key} #{val.bytesize} c F#{bitflags} MS\r\n#{val}\r\n",
+      assert_equal "ms #{key} #{val.bytesize} c F#{bitflags} MS\r\n",
                    Dalli::Protocol::Meta::RequestFormatter.meta_set(key: key, value: val, bitflags: bitflags, cas: 0)
     end
 
     it 'excludes non-numeric CAS values' do
-      assert_equal "ms #{key} #{val.bytesize} c F#{bitflags} MS\r\n#{val}\r\n",
+      assert_equal "ms #{key} #{val.bytesize} c F#{bitflags} MS\r\n",
                    Dalli::Protocol::Meta::RequestFormatter.meta_set(key: key, value: val, bitflags: bitflags,
                                                                     cas: "\nset importantkey 1 1000 8\ninjected")
     end
 
     it 'sets the quiet mode if configured' do
-      assert_equal "ms #{key} #{val.bytesize} c F#{bitflags} MS q\r\n#{val}\r\n",
+      assert_equal "ms #{key} #{val.bytesize} c F#{bitflags} MS q\r\n",
                    Dalli::Protocol::Meta::RequestFormatter.meta_set(key: key, value: val, bitflags: bitflags,
                                                                     quiet: true)
     end
 
     it 'sets the base64 mode if configured' do
-      assert_equal "ms #{key} #{val.bytesize} c b F#{bitflags} MS\r\n#{val}\r\n",
+      assert_equal "ms #{key} #{val.bytesize} c b F#{bitflags} MS\r\n",
                    Dalli::Protocol::Meta::RequestFormatter.meta_set(key: key, value: val, bitflags: bitflags,
                                                                     base64: true)
     end


### PR DESCRIPTION
Ok, with the benchmark and profile we can start to pull over some performance improvements. I updated the benchmark and profile to support the meta protocol client as well as the binary. We haven't been working on the binary, but it is good to have both as we don't want to accidentally cause any regressions with the binary protocol support before we deprecate it.

![dalli_string_profile](https://github.com/user-attachments/assets/490b1470-6ad5-4357-994b-f549a500edf7)
> using vernier profiler on the set command we can see it is spending a lot of time with string manipulation, this can be especially bad with very large values.

The before benchmark, shows that meta set is the slowest 
```
❯❯❯$ BENCH_TARGET=set RUBY_YJIT_ENABLE=1 bundle exec bin/benchmark                                                 <bundler> [main 
yjit: true
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
Warming up --------------------------------------
          client set   730.000 i/100ms
     meta client set   509.000 i/100ms
        raw sock set     1.221k i/100ms
Calculating -------------------------------------
          client set      6.279k (±10.3%) i/s -     62.780k in  10.101866s
     meta client set      4.547k (±13.4%) i/s -     44.792k in  10.012413s
        raw sock set     13.935k (± 2.2%) i/s -    140.415k in  10.082106s

Comparison:
        raw sock set:    13934.8 i/s
          client set:     6278.6 i/s - 2.22x  slower
     meta client set:     4546.7 i/s - 3.06x  slower
```

after benchmark, shows meta is now nearly as fast as raw socket
```
❯❯❯$ BENCH_TARGET=set RUBY_YJIT_ENABLE=1 bundle exec bin/benchmark                                                 <bundler> 
yjit: true
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
Warming up --------------------------------------
          client set   303.000 i/100ms
     meta client set     1.025k i/100ms
        raw sock set     1.436k i/100ms
Calculating -------------------------------------
          client set      6.573k (±10.8%) i/s -     64.842k in  10.004278s
     meta client set     13.347k (± 6.2%) i/s -    133.250k in  10.024490s
        raw sock set     14.580k (± 5.2%) i/s -    146.472k in  10.073444s

Comparison:
        raw sock set:    14580.3 i/s
     meta client set:    13347.1 i/s - same-ish: difference falls within error
          client set:     6573.4 i/s - 2.22x  slower
```