### PR TITLE
Use ubuntu-latest for tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,7 @@ jobs:
           - jruby-9.4
         memcached-version: ['1.5.22', '1.6.34']
 
+    name: "Ruby ${{ matrix.ruby-version }} / Memcached ${{ matrix.memcached-version }}"
     steps:
     - uses: actions/checkout@v4
     - name: Install Memcached ${{ matrix.memcached-version }}

--- a/scripts/install_memcached.sh
+++ b/scripts/install_memcached.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-version=$MEMCACHED_VERSION
+set -euo pipefail
 
+version=$MEMCACHED_VERSION
 
 sudo apt-get -y remove memcached
 sudo apt-get install libevent-dev libsasl2-dev sasl2-bin

--- a/scripts/install_memcached.sh
+++ b/scripts/install_memcached.sh
@@ -13,6 +13,12 @@ echo Installing Memcached version ${version}
 wget https://memcached.org/files/memcached-${version}.tar.gz
 tar -zxvf memcached-${version}.tar.gz
 cd memcached-${version}
+
+# Manual patch so 1.5 will compile
+if [[ -f "../memcached_${version}.patch" ]]; then
+  patch -p1 < "../memcached_${version}.patch"
+fi
+
 ./configure --enable-sasl --enable-tls
 make
 sudo mv memcached /usr/local/bin/

--- a/scripts/memcached_1.5.22.patch
+++ b/scripts/memcached_1.5.22.patch
@@ -1,0 +1,48 @@
+diff --git a/hash.c b/hash.c
+index a0c3036..b5ff28a 100644
+--- a/hash.c
++++ b/hash.c
+@@ -4,6 +4,8 @@
+ #include "jenkins_hash.h"
+ #include "murmur3_hash.h"
+
++hash_func hash;
++
+ int hash_init(enum hashfunc_type type) {
+     switch(type) {
+         case JENKINS_HASH:
+diff --git a/hash.h b/hash.h
+index 059d1e2..3b2a984 100644
+--- a/hash.h
++++ b/hash.h
+@@ -2,7 +2,7 @@
+ #define    HASH_H
+
+ typedef uint32_t (*hash_func)(const void *key, size_t length);
+-hash_func hash;
++extern hash_func hash;
+
+ enum hashfunc_type {
+     JENKINS_HASH=0, MURMUR3_HASH
+diff --git a/memcached.c b/memcached.c
+index 3010236..0916f94 100644
+--- a/memcached.c
++++ b/memcached.c
+@@ -9528,7 +9528,7 @@ int main (int argc, char **argv) {
+     /* daemonize if requested */
+     /* if we want to ensure our ability to dump core, don't chdir to / */
+     if (do_daemonize) {
+-        if (sigignore(SIGHUP) == -1) {
++        if (signal(SIGHUP, SIG_IGN) == SIG_ERR) {
+             perror("Failed to ignore SIGHUP");
+         }
+         if (daemonize(maxcore, settings.verbose) == -1) {
+@@ -9677,7 +9677,7 @@ int main (int argc, char **argv) {
+      * ignore SIGPIPE signals; we can use errno == EPIPE if we
+      * need that information
+      */
+-    if (sigignore(SIGPIPE) == -1) {
++    if (signal(SIGPIPE, SIG_IGN) == SIG_ERR) {
+         perror("failed to ignore SIGPIPE; sigaction");
+         exit(EX_OSERR);
+     }


### PR DESCRIPTION
Avoids brownouts on deprecated ubuntu-20 and matches everything else.

In order to compile memcached 1.5 (last released in 2020) on a recent ubuntu I had to manually patch some compiler errors