### PR TITLE
Create a devcontainer setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,40 @@
+FROM ruby:3.4-bullseye
+
+# Install dependencies
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends \
+    build-essential \
+    git \
+    libsasl2-dev \
+    libsasl2-modules \
+    sasl2-bin \
+    libevent-dev \
+    libmemcached-tools \
+    curl \
+    procps \
+    wget \
+    bash \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+
+# Setup non-root user with sudo access
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    && apt-get update \
+    && apt-get install -y sudo \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME
+
+RUN sudo chown -R $USERNAME:$USERNAME /usr/local/bundle
+
+# Install utilities
+RUN gem install bundler
+
+WORKDIR /workspace
+
+# Switch to non-root user
+USER $USERNAME

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,55 @@
+# Dalli Development Container
+
+This directory contains configuration for a development container that provides a consistent environment for working on Dalli.
+
+## Features
+
+- Ruby 3.2 environment with all necessary dependencies
+- Memcached 1.6.34 installed with SASL and TLS support, matching the GitHub Actions CI environment
+- Configuration for testing, including SASL authentication setup
+- VS Code extensions for Ruby development
+
+## Setup Process
+
+When the container is built and started, the following setup occurs:
+
+1. The container is built with necessary dependencies but without memcached
+2. The `setup.sh` script runs after the container is created which:
+   - Installs memcached 1.6.34 using the same script used in GitHub Actions
+   - Configures SASL authentication for testing
+   - Sets up environment variables needed for tests
+   - Installs gem dependencies
+
+## Running Tests
+
+Once the container is running, you can run tests with:
+
+```bash
+bundle exec rake test
+```
+
+To run specific test files:
+
+```bash
+bundle exec ruby -Ilib:test test/path/to/test_file.rb
+```
+
+## Troubleshooting
+
+If you encounter issues with tests:
+
+1. Verify memcached is running: `ps aux | grep memcached`
+2. Check memcached version: `memcached -h | head -1`
+3. Verify SASL is configured: `cat /usr/lib/sasl2/memcached.conf`
+4. Try restarting memcached: `sudo service memcached restart`
+5. Check logs for any errors: `sudo journalctl -u memcached`
+
+## Port Forwarding
+
+The following memcached ports are forwarded for testing:
+- 11211 - Default memcached port
+- 11212-11215 - Additional ports used by tests
+
+## Environment Variables
+
+- `RUN_SASL_TESTS=1` - Enables SASL authentication tests

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,38 @@
+{
+  "name": "Ruby Dalli Development",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/workspace",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "rebornix.ruby",
+        "castwide.solargraph",
+        "kaiwood.endwise",
+        "misogi.ruby-rubocop"
+      ],
+      "settings": {
+        "ruby.useBundler": true,
+        "ruby.format": "rubocop",
+        "editor.formatOnSave": true,
+        "ruby.useLanguageServer": true,
+        "ruby.lint": {
+          "rubocop": {
+            "useBundler": true
+          }
+        },
+        "terminal.integrated.defaultProfile.linux": "bash"
+      }
+    }
+  },
+  "forwardPorts": [
+    11211,
+    11212,
+    11213,
+    11214,
+    11215
+  ],
+  "postCreateCommand": "chmod +x .devcontainer/setup.sh && .devcontainer/setup.sh",
+  "waitFor": "postCreateCommand",
+  "remoteUser": "vscode"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ..:/workspace:cached
+    command: sleep infinity

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -e
+
+echo "Setting up Dalli development environment..."
+
+# Install memcached using the script from scripts directory
+echo "Installing memcached..."
+cd /workspace
+export MEMCACHED_VERSION=1.6.34
+chmod +x scripts/install_memcached.sh
+scripts/install_memcached.sh
+
+# Clean up memcached installation files
+echo "Cleaning up memcached installation files..."
+rm -f memcached-${MEMCACHED_VERSION}.tar.gz
+rm -rf memcached-${MEMCACHED_VERSION}
+
+# Create symlink for memcached-tool if needed
+if [ ! -f /usr/local/bin/memcached-tool ]; then
+  echo "Creating symlink for memcached-tool..."
+  sudo ln -sf /usr/share/memcached/scripts/memcached-tool /usr/local/bin/memcached-tool
+fi
+
+echo "Setting up environment variables..."
+# Ensure test environment is properly configured
+cat >> ~/.bashrc << EOF
+
+# Dalli test environment
+export RUN_SASL_TESTS=1
+EOF
+
+# Fix permissions
+sudo chown -R vscode:vscode /usr/local/bundle
+echo "Installing dependencies..."
+cd /workspace
+bundle install
+
+echo "Environment setup complete!"
+echo "You can now run tests with: bundle exec rake test"
+echo "To run a specific test file: bundle exec ruby -Ilib:test test/integration/test_fork.rb"


### PR DESCRIPTION
## Reasoning

When I was working on #1036 I needed a clean environment to work from. Since a lot of people use VS Code these days, I setup a devcontainer. I figured I'd share to save others time.

## Change Details

This borrows from the setup that is done in the GHA for running the tests. It should let a contributor get up and running pretty quickly and easily regardless of what system they are developing on.