### PR TITLE
Fix session recovery after deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Dalli Changelog
 Unreleased
 ==========
 
+- Fix session recovery after deletion (stengineering0)
 - Fix cannot read response data included terminator `\r\n` when use meta protocol (matsubara0507)
 - Support SERVER_ERROR response from Memcached as per the [memcached spec](https://github.com/memcached/memcached/blob/e43364402195c8e822bb8f88755a60ab8bbed62a/doc/protocol.txt#L172) (grcooper)
 - Update Socket timeout handling to use Socket#timeout= when available (nickamorim)


### PR DESCRIPTION
It fixes the session recovery after deletion, the same security advisories were published recently within `rack` repos:
* [rack](https://github.com/rack/rack/security/advisories/GHSA-vpfw-47h7-xj4g)
* [rack-session](https://github.com/rack/rack-session/security/advisories/GHSA-9j94-67jr-4cqj)

[Rack session middleware](https://github.com/rack/rack/blob/v2.2.13/lib/rack/session/abstract/id.rb#L263-L270) prepares the session at the beginning of request, then saves is back to the store with possible changes applied by host rack application. This way the session becomes to be a subject of race conditions in general sense over concurrent rack requests.

In particular the following scenario is possible:

1. Given that user is logged in involving warden gem (devise-backed app);
2. Frontend runs some async request A, it reads the session from the store by _session_id cookie. For instance it might be random ajax or heartbeat API call;
3. User hits logout button which runs logout request B;
4. Request B deletes the session from the store by _session_id cookie for security reasons via :drop or :renew Rack session option, then generates new session_id and responds it via the cookie to the client;
5. Request A at the end will blindly save the fetched session data under old session_id back to the store, effectively restoring it to the state before logout.
6. This way using the old session id we can act as user which logged out just now.

### Steps to reproduce:

```ruby
# Gemfile
source 'https://rubygems.org'

gem 'sinatra'
gem 'rackup'
gem 'dalli'
gem 'puma'
```

```ruby
# demo.rb

require 'sinatra'

use Rack::Session::Dalli

get '/' do
  if session.key?(:current_user)
    "
      <p>Logged in as #{session[:current_user]}</p>
      <p><a href='/long' target='blank'>Long running request</a></p>
      <p><a href='/logout'>Logout</a></p>
    "
  else
    "
      <p>Not logged in</p>
      <p><a href='/login'>Login</a></p>
    "
  end
end

get '/long' do
  session.keys # just trigger
  sleep 10
  '<script>window.close();</script>'
end

get '/login' do
  session[:current_user] = 'Super Admin'
  session.options[:renew] = true
  redirect to('/')
end

get '/logout' do
  session.delete(:current_user)
  session.options[:renew] = true
  redirect to('/')
end
```

1. $> bundle
2. $> bundle exec ruby demo.rb
3. Open app in browser
4. Click on "Login"
5. Copy 'rack.session' cookie into clipboard
6. Click on "Long running request", it will open in new tab
7. Within 10 seconds go back to initial tab and click on "Logout"
8. Wait until "Long running request" tab will be closed
9. Paste 'rack.session' cookie from clipboard back to the browser, refresh the page
10. See that you're logged in