### PR TITLE
Add `string_fastpath` option to save on serializing simple strings

### DIFF
--- a/test/integration/test_serializer.rb
+++ b/test/integration/test_serializer.rb
@@ -14,6 +14,40 @@ describe 'Serializer configuration' do
         end
       end
 
+      it 'skips the serializer for simple strings when string_fastpath is enabled' do
+        memcached(p, 29_198) do |_dc, port|
+          memcache = Dalli::Client.new("127.0.0.1:#{port}", string_fastpath: true)
+          string = 'héllø'
+          memcache.set 'utf-8', string
+
+          assert_equal string, memcache.get('utf-8')
+          assert_equal Encoding::UTF_8, memcache.get('utf-8').encoding
+
+          binary = "\0\xff".b
+          memcache.set 'binary', binary
+
+          assert_equal binary, memcache.get('binary')
+          assert_equal Encoding::BINARY, memcache.get('binary').encoding
+
+          latin1 = string.encode(Encoding::ISO_8859_1)
+          memcache.set 'latin1', latin1
+
+          assert_equal latin1, memcache.get('latin1')
+          assert_equal Encoding::ISO_8859_1, memcache.get('latin1').encoding
+
+          # Ensure strings that went through the fastpath are properly retreived
+          # by clients without string_fastpath enabled.
+          memcache = Dalli::Client.new("127.0.0.1:#{port}", string_fastpath: false)
+
+          assert_equal string, memcache.get('utf-8')
+          assert_equal Encoding::UTF_8, memcache.get('utf-8').encoding
+          assert_equal binary, memcache.get('binary')
+          assert_equal Encoding::BINARY, memcache.get('binary').encoding
+          assert_equal latin1, memcache.get('latin1')
+          assert_equal Encoding::ISO_8859_1, memcache.get('latin1').encoding
+        end
+      end
+
       it 'supports a custom serializer' do
         memcached(p, 29_198) do |_dc, port|
           memcache = Dalli::Client.new("127.0.0.1:#{port}", serializer: JSON)


### PR DESCRIPTION
Going through `Marshal.load/dump` (or other serializers) when the value is already a string is quite costly for not a whole lot of value.

The only real benefit is that it automatically preserve the string encoding, but we can assume the overwhelming majority of strings are either UTF-8 or BINARY, so we can encode that in the bitflags.

For strings that have a different encoding, or objects that inherit from `String` we can continue to use the serializer.

Note that only the `#store` path checks for the option. `#retrieve` always handle this new format. This is so that you can seemlessly upgrade without having to flush your caches. You can first upgrade dalli and then later turn on the option.

It would be nice to make this option a default at some point though.

@danmayer @nickamorim (Ref: https://github.com/rails/rails/pull/54996)