### PR TITLE
Double splat options hash to kwargs for connection pool 3.0

### DIFF
--- a/lib/rack/session/dalli.rb
+++ b/lib/rack/session/dalli.rb
@@ -157,7 +157,7 @@ module Rack
           ::Dalli::Client.new(server_configurations, client_options)
         else
           ensure_connection_pool_added!
-          ConnectionPool.new(pool_options) do
+          ConnectionPool.new(**pool_options) do
             ::Dalli::Client.new(server_configurations, client_options.merge(threadsafe: false))
           end
         end


### PR DESCRIPTION
See https://www.github.com/mperham/connection_pool/pull/209

Note, connection pool 3.0 dropped support for ruby 3.1 and older so they'll continue to use up to 2.5.x.  I suspect keyword arguments handling with **splat may not work with ruby 2.6. The tests pass on 2.7.

Fixes the test failure:

```
  1) Error:
Rack::Session::Dalli#test_0006_upgrades to a connection pool:
ArgumentError: wrong number of arguments (given 1, expected 0)
    /Users/joerafaniello/.gem/ruby/3.3.9/gems/connection_pool-3.0.1/lib/connection_pool.rb:48:in `initialize'
    lib/rack/session/dalli.rb:160:in `new'
    lib/rack/session/dalli.rb:160:in `build_data_source'
    lib/rack/session/dalli.rb:74:in `initialize'
    test/test_rack_session.rb:122:in `new'
    test/test_rack_session.rb:122:in `block (3 levels) in <main>'
    test/helper.rb:55:in `with_connectionpool'
    test/test_rack_session.rb:121:in `block (2 levels) in <main>'
```