### PR TITLE
Add Ruby 4.0 to test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,7 @@ jobs:
       matrix:
         ruby-version:
           - head
+          - '4.0'
           - '3.4'
           - '3.3'
           - '3.2'


### PR DESCRIPTION
Add Ruby 4.0 to the CI test matrix to ensure compatibility with the upcoming Ruby 4.0.0 release. The codebase is already compatible with Ruby 4.0 as it properly handles IO::TimeoutError and uses modern socket initialization patterns.