### PR TITLE
Fix benchmark script GC memory leak causing OOM (exit code 137)

### DIFF
--- a/bin/benchmark
+++ b/bin/benchmark
@@ -102,9 +102,13 @@ class GCSuite
     run_gc
   end
 
-  def warmup_stats(*); end
+  def warmup_stats(*)
+    GC.enable
+  end
 
-  def add_report(*); end
+  def add_report(*)
+    GC.enable
+  end
 
   private
 


### PR DESCRIPTION
The GCSuite class was disabling garbage collection during benchmark runs but never re-enabling it, causing unbounded memory growth with large payloads and many iterations. This triggered the OOM killer (SIGKILL = exit code 137).

Add GC.enable calls to warmup_stats and add_report callbacks to ensure GC is re-enabled between benchmark phases while still keeping it disabled during timing-sensitive measurements.