### PR TITLE
Handle OpenSSL::SSL::SSLError in connection manager

### DIFF
--- a/lib/dalli/protocol.rb
+++ b/lib/dalli/protocol.rb
@@ -15,5 +15,15 @@ module Dalli
       else
         [Timeout::Error]
       end
+
+    # SSL errors that occur during read/write operations (not during initial
+    # handshake) should trigger reconnection. These indicate transient network
+    # issues, not configuration problems.
+    SSL_ERRORS =
+      if defined?(OpenSSL::SSL::SSLError)
+        [OpenSSL::SSL::SSLError]
+      else
+        []
+      end
   end
 end

--- a/lib/dalli/protocol/base.rb
+++ b/lib/dalli/protocol/base.rb
@@ -106,7 +106,7 @@ module Dalli
         end
 
         values
-      rescue SystemCallError, *TIMEOUT_ERRORS, EOFError => e
+      rescue SystemCallError, *TIMEOUT_ERRORS, *SSL_ERRORS, EOFError => e
         @connection_manager.error_on_request!(e)
       end
 

--- a/lib/dalli/protocol/connection_manager.rb
+++ b/lib/dalli/protocol/connection_manager.rb
@@ -150,19 +150,19 @@ module Dalli
         data = @sock.gets("\r\n")
         error_on_request!('EOF in read_line') if data.nil?
         data
-      rescue SystemCallError, *TIMEOUT_ERRORS, EOFError => e
+      rescue SystemCallError, *TIMEOUT_ERRORS, *SSL_ERRORS, EOFError => e
         error_on_request!(e)
       end
 
       def read(count)
         @sock.readfull(count)
-      rescue SystemCallError, *TIMEOUT_ERRORS, EOFError => e
+      rescue SystemCallError, *TIMEOUT_ERRORS, *SSL_ERRORS, EOFError => e
         error_on_request!(e)
       end
 
       def write(bytes)
         @sock.write(bytes)
-      rescue SystemCallError, *TIMEOUT_ERRORS => e
+      rescue SystemCallError, *TIMEOUT_ERRORS, *SSL_ERRORS => e
         error_on_request!(e)
       end
 


### PR DESCRIPTION
Add SSL error handling to read/write operations so that transient SSL errors (like "SSL_read: unexpected eof while reading") trigger automatic reconnection and retry, similar to how EOFError and SystemCallError are handled.

SSL errors during initial connection (handshake failures, certificate verification) continue to propagate as configuration errors.

Fixes #1045