### PR TITLE
feat: Use bulk attr setter for span

### DIFF
--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -522,8 +522,10 @@ module Dalli
     def record_hit_miss_metrics(span, key_count, hit_count)
       return unless span
 
-      span.set_attribute('db.memcached.hit_count', hit_count)
-      span.set_attribute('db.memcached.miss_count', key_count - hit_count)
+      span.add_attributes({
+                            'db.memcached.hit_count' => hit_count,
+                            'db.memcached.miss_count' => key_count - hit_count
+                          })
     end
 
     def get_multi_yielding(keys)


### PR DESCRIPTION
There is an interface for setting [individual span attributes or adding multiple](https://github.com/open-telemetry/opentelemetry-ruby/blob/main/sdk/lib/opentelemetry/sdk/trace/span.rb#L65-L119). As the otel sdk was written to be thread safe there is a lock when mutating spans. This small change just means we only hit that lock once instead of twice.

