### PR TITLE
fix: stop double recording exceptions on spans

### DIFF
--- a/lib/dalli/instrumentation.rb
+++ b/lib/dalli/instrumentation.rb
@@ -92,10 +92,6 @@ module Dalli
 
         tracer.in_span(name, attributes: DEFAULT_ATTRIBUTES.merge(attributes), kind: :client) do |span|
           yield
-        rescue StandardError => e
-          span.record_exception(e)
-          span.status = OpenTelemetry::Trace::Status.error(e.message)
-          raise
         end
       end
 
@@ -128,10 +124,6 @@ module Dalli
 
         tracer.in_span(name, attributes: DEFAULT_ATTRIBUTES.merge(attributes), kind: :client) do |span|
           yield(span)
-        rescue StandardError => e
-          span.record_exception(e)
-          span.status = OpenTelemetry::Trace::Status.error(e.message)
-          raise
         end
       end
     end


### PR DESCRIPTION
The [in_span](https://github.com/open-telemetry/opentelemetry-ruby/blob/main/api/lib/opentelemetry/trace/tracer.rb#L38-L43) method already records exceptions. So the explicit recording of exceptions here could result in doubling the exception event count.

On a high volume traced service an error with memcached could result in a lot of stacktraces, doubling them can compound the issue.

```rb
require 'bundler/inline'

gemfile(true) do
  source 'https://rubygems.org'

  gem 'debug'
  gem 'dalli', "4.2.0"
  gem 'opentelemetry-api'
  gem 'opentelemetry-sdk'
end

require 'opentelemetry-api'
require 'opentelemetry-sdk'
require 'dalli'

exporter = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
OpenTelemetry::SDK.configure do |c|
  c.service_name = "test"
  c.add_span_processor(OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(
    exporter
  ))
end

begin
  Dalli::Instrumentation.trace("foo") { raise StandardError.new("foo") }
rescue => e
  #
end

puts exporter.finished_spans[0].events
```

Lightly formatted the output
```
#<struct OpenTelemetry::SDK::Trace::Event 
    name="exception", 
    attributes={
        "exception.type" => "StandardError", 
        "exception.message" => "foo", 
        "exception.stacktrace" => "dalli_span.rb:26:in 'block in <main>': foo (StandardError)\n\tfrom..."
    }, 
    timestamp=1770245395869251000>

#<struct OpenTelemetry::SDK::Trace::Event 
    name="exception", 
        attributes={
        "exception.type" => "StandardError", 
        "exception.message" => "foo", 
        "exception.stacktrace" => "dalli_span.rb:26:in 'block in <main>': foo (StandardError)\n\tfrom ..."
    }, 
    timestamp=1770245395869262000>
```

The tests are currently mocking out OpenTelemetry entirely which means they would not catch this issue. Is it ok to bring in Otel as a test dependency, if so then I can add some proper regression tests here, or we can just remove the tests that assert the recording of exceptions as its a feature of the otel library itself and doesn't really need to be retested. 