### PR TITLE
Rescue IOError in connection manager write/flush methods

### DIFF
--- a/lib/dalli/protocol/connection_manager.rb
+++ b/lib/dalli/protocol/connection_manager.rb
@@ -169,13 +169,13 @@ module Dalli
 
       def write(bytes)
         @sock.write(bytes)
-      rescue SystemCallError, *TIMEOUT_ERRORS, *SSL_ERRORS => e
+      rescue SystemCallError, *TIMEOUT_ERRORS, *SSL_ERRORS, IOError => e
         error_on_request!(e)
       end
 
       def flush
         @sock.flush
-      rescue SystemCallError, *TIMEOUT_ERRORS, *SSL_ERRORS => e
+      rescue SystemCallError, *TIMEOUT_ERRORS, *SSL_ERRORS, IOError => e
         error_on_request!(e)
       end
 


### PR DESCRIPTION
## Summary

- Add IOError to rescue clauses in `ConnectionManager#write` and `ConnectionManager#flush` methods
- Add test that verifies the client recovers when the underlying socket is forcibly closed

## Why IOError for write/flush but EOFError for reads?

Ruby's exception hierarchy:
```
IOError (parent)
└── EOFError (subclass)
```

**Read operations** raise `EOFError` when a socket is closed - this signals "end of file" / "no more data". The read methods already rescue `EOFError`.

**Write operations** raise `IOError: closed stream` when writing to an already-closed socket. There's no "end of file" concept for writes - you simply can't write to a closed stream. This is the generic `IOError`, not the more specific `EOFError` subclass.

Since `EOFError` is a subclass of `IOError`:
- Rescuing `IOError` catches both `IOError` AND `EOFError`
- Rescuing only `EOFError` does NOT catch the parent `IOError`

The write/flush methods were missing `IOError` for the "closed stream" case, causing unhandled exceptions instead of triggering the reconnection logic.

References:
- [Ruby EOFError Documentation](https://docs.ruby-lang.org/en/master/EOFError.html)
- [Ruby IOError Documentation](https://ruby-doc.org/core-2.6/IOError.html)

Ported from Shopify/dalli PR #52.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)