### PR TITLE
Add rubocop-thread_safety for detecting thread-safety issues

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,13 @@ plugins:
   - rubocop-minitest
   - rubocop-performance
   - rubocop-rake
+  - rubocop-thread_safety
+
+ThreadSafety:
+  Enabled: true
+  Exclude:
+    - "**/*.gemspec"
+    - test/**/*
 
 AllCops:
   NewCops: enable

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ group :development, :test do
   gem 'rubocop-minitest'
   gem 'rubocop-performance'
   gem 'rubocop-rake'
+  gem 'rubocop-thread_safety'
   gem 'simplecov'
 end
 

--- a/lib/dalli.rb
+++ b/lib/dalli.rb
@@ -38,7 +38,7 @@ module Dalli
   QUIET = :dalli_multi
 
   def self.logger
-    @logger ||= rails_logger || default_logger
+    @logger ||= rails_logger || default_logger # rubocop:disable ThreadSafety/ClassInstanceVariable
   end
 
   def self.rails_logger
@@ -54,7 +54,7 @@ module Dalli
   end
 
   def self.logger=(logger)
-    @logger = logger
+    @logger = logger # rubocop:disable ThreadSafety/ClassInstanceVariable
   end
 end
 

--- a/lib/dalli/instrumentation.rb
+++ b/lib/dalli/instrumentation.rb
@@ -61,11 +61,13 @@ module Dalli
       # Uses the library name 'dalli' and current Dalli::VERSION.
       #
       # @return [OpenTelemetry::Trace::Tracer, nil] the tracer or nil if OTel unavailable
+      # rubocop:disable ThreadSafety/ClassInstanceVariable
       def tracer
         return @tracer if defined?(@tracer)
 
         @tracer = (OpenTelemetry.tracer_provider.tracer('dalli', Dalli::VERSION) if defined?(OpenTelemetry))
       end
+      # rubocop:enable ThreadSafety/ClassInstanceVariable
 
       # Returns true if instrumentation is enabled (OpenTelemetry SDK is available).
       #

--- a/lib/dalli/pid_cache.rb
+++ b/lib/dalli/pid_cache.rb
@@ -13,7 +13,7 @@ module Dalli
         attr_reader :pid
 
         def update!
-          @pid = Process.pid
+          @pid = Process.pid # rubocop:disable ThreadSafety/ClassInstanceVariable
         end
       end
       update!

--- a/lib/dalli/socket.rb
+++ b/lib/dalli/socket.rb
@@ -108,12 +108,14 @@ module Dalli
       # Detect and cache whether TCPSocket supports the connect_timeout: keyword argument.
       # Returns false if TCPSocket#initialize has been monkey-patched by gems like
       # socksify or resolv-replace, which don't support keyword arguments.
+      # rubocop:disable ThreadSafety/ClassInstanceVariable
       def self.supports_connect_timeout?
         return @supports_connect_timeout if defined?(@supports_connect_timeout)
 
         @supports_connect_timeout = RUBY_VERSION >= '3.0' &&
                                     ::TCPSocket.instance_method(:initialize).parameters == TCPSOCKET_NATIVE_PARAMETERS
       end
+      # rubocop:enable ThreadSafety/ClassInstanceVariable
 
       def self.create_socket_with_timeout(host, port, options)
         if supports_connect_timeout?
@@ -170,12 +172,14 @@ module Dalli
 
       # Detect and cache the correct pack format for struct timeval on this platform.
       # Different architectures have different sizes for time_t and suseconds_t.
+      # rubocop:disable ThreadSafety/ClassInstanceVariable
       def self.timeval_pack_format(sock)
         @timeval_pack_format ||= begin
           expected_size = sock.getsockopt(::Socket::SOL_SOCKET, ::Socket::SO_RCVTIMEO).data.bytesize
           TIMEVAL_PACK_FORMATS.find { |fmt| TIMEVAL_TEST_VALUES.pack(fmt).bytesize == expected_size } || 'll'
         end
       end
+      # rubocop:enable ThreadSafety/ClassInstanceVariable
 
       def self.pack_timeval(sock, seconds, microseconds)
         [seconds, microseconds].pack(timeval_pack_format(sock))


### PR DESCRIPTION
## Summary

- Add `rubocop-thread_safety` gem to detect potential thread-safety issues
- Configure the plugin to exclude test files and gemspec
- Add disable comments to intentional class instance variable usages

## Why these class instance variables are acceptable

The flagged class instance variables are used for caching and are acceptable because they are:

1. **`Dalli.logger`** - Logger configuration, typically set once at application startup
2. **`PIDCache.pid`** - Process ID caching for fork detection (updated atomically after fork)
3. **`Instrumentation.tracer`** - OpenTelemetry tracer caching (initialized once)
4. **`Socket.supports_connect_timeout?`** - Ruby version capability detection (immutable after first check)
5. **`Socket.timeval_pack_format`** - Platform-specific format detection (immutable after first check)

These are all "initialize once, read many" patterns where the worst case of a race condition is redundant initialization, not data corruption.

Ported from Shopify/dalli PR #50.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)