### PR TITLE
Forward-port pipeline allocation optimizations from v4.3

### DIFF
--- a/bin/compare_versions
+++ b/bin/compare_versions
@@ -1,0 +1,292 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Cross-version Dalli benchmark for investigating performance regression (Issue #930)
+#
+# Installs a specific Dalli version from RubyGems via bundler/inline and runs
+# identical workloads against a local memcached instance.
+#
+# Environment variables:
+#   DALLI_VERSION   - Dalli gem version to benchmark (e.g., "2.7.11", "4.3.2", "5.0.0")
+#   DALLI_PROTOCOL  - Protocol to use: "binary" or "meta" (ignored for 2.x and 5.x)
+#   BENCH_TIME      - Benchmark time in seconds per test (default: 8)
+#   BENCH_WARMUP    - Warmup time in seconds (default: 3)
+#   BENCH_PORT      - Memcached port (default: auto-selected)
+#
+# Usage:
+#   DALLI_VERSION=2.7.11 ruby bin/compare_versions
+#   DALLI_VERSION=4.3.2 DALLI_PROTOCOL=binary ruby bin/compare_versions
+#   DALLI_VERSION=4.3.2 DALLI_PROTOCOL=meta ruby bin/compare_versions
+#   DALLI_VERSION=5.0.0 ruby bin/compare_versions
+#
+# Recommended: run all versions on the same Ruby (e.g., Ruby 3.3) for consistency:
+#   rbenv shell 3.3.4
+#   DALLI_VERSION=2.7.11 ruby bin/compare_versions
+#   DALLI_VERSION=4.3.2 DALLI_PROTOCOL=binary ruby bin/compare_versions
+#   DALLI_VERSION=4.3.2 DALLI_PROTOCOL=meta ruby bin/compare_versions
+#   DALLI_VERSION=5.0.0 ruby bin/compare_versions
+
+dalli_version = ENV.fetch('DALLI_VERSION') do
+  abort 'DALLI_VERSION env var required (e.g., 2.7.11, 4.3.2, 5.0.0)'
+end
+
+require 'bundler/inline'
+
+gemfile do
+  source 'https://rubygems.org'
+  gem 'benchmark-ips'
+  gem 'dalli', dalli_version
+  gem 'logger'
+end
+
+require 'benchmark/ips'
+require 'dalli'
+require 'socket'
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+dalli_protocol = ENV.fetch('DALLI_PROTOCOL', nil)
+bench_time     = (ENV['BENCH_TIME'] || 8).to_i
+bench_warmup   = (ENV['BENCH_WARMUP'] || 3).to_i
+memcached_port = (ENV['BENCH_PORT'] || 0).to_i
+
+# Determine effective protocol based on version
+major_version = Gem::Version.new(dalli_version).segments.first
+effective_protocol = case major_version
+                     when 0..2
+                       'binary'
+                     when 5..99
+                       'meta'
+                     else
+                       dalli_protocol || 'meta'
+                     end
+
+puts '=' * 70
+puts 'Dalli Cross-Version Benchmark'
+puts '=' * 70
+puts "  Dalli version:  #{dalli_version}"
+puts "  Protocol:       #{effective_protocol}"
+puts "  Ruby:           #{RUBY_DESCRIPTION}"
+yjit_status = defined?(RubyVM::YJIT) && RubyVM::YJIT.respond_to?(:enabled?) ? RubyVM::YJIT.enabled? : 'N/A'
+puts "  YJIT:           #{yjit_status}"
+puts "  Bench time:     #{bench_time}s"
+puts "  Warmup:         #{bench_warmup}s"
+
+# ---------------------------------------------------------------------------
+# Start a dedicated memcached instance
+# ---------------------------------------------------------------------------
+
+def find_memcached
+  ['', '/opt/homebrew/bin/', '/usr/local/bin/', '/usr/bin/'].each do |prefix|
+    path = "#{prefix}memcached"
+    version_output = `#{path} -h 2>&1`.lines.first.to_s.strip
+    return [path, Regexp.last_match(1)] if version_output =~ /^memcached (\d+\.\d+\.\d+)/
+  end
+  abort 'Could not find memcached binary'
+end
+
+def find_available_port
+  server = TCPServer.new('127.0.0.1', 0)
+  port = server.addr[1]
+  server.close
+  port
+end
+
+memcached_bin, memcached_version = find_memcached
+memcached_port = find_available_port if memcached_port.zero?
+
+puts "  Memcached:      #{memcached_version} on port #{memcached_port}"
+puts '=' * 70
+puts
+
+# Start memcached
+memcached_pid = spawn("#{memcached_bin} -p #{memcached_port} -m 64 -l 127.0.0.1",
+                      out: '/dev/null', err: '/dev/null')
+at_exit do
+  begin
+    Process.kill('TERM', memcached_pid)
+  rescue StandardError
+    nil
+  end
+  begin
+    Process.wait(memcached_pid)
+  rescue StandardError
+    nil
+  end
+end
+
+# Wait for memcached to be ready
+20.times do
+  s = TCPSocket.new('127.0.0.1', memcached_port)
+  s.close
+  break
+rescue Errno::ECONNREFUSED
+  sleep 0.1
+end
+
+# ---------------------------------------------------------------------------
+# Build Dalli client with version-appropriate options
+# ---------------------------------------------------------------------------
+
+server_addr = "127.0.0.1:#{memcached_port}"
+
+client_options = { compress: false }
+
+# Dalli 3.x+ supports the protocol option; 2.x does not
+client_options[:protocol] = :meta if major_version >= 3 && major_version < 5 && effective_protocol == 'meta'
+
+# Dalli 2.x uses :raw differently and doesn't have a NoopSerializer-style option,
+# but we can use raw: true for string values to skip Marshal
+client = Dalli::Client.new(server_addr, **client_options)
+
+puts 'Setting up test data...'
+
+# ---------------------------------------------------------------------------
+# Test data — realistic small payloads
+# ---------------------------------------------------------------------------
+
+small_value   = 'x' * 100      # 100 bytes — typical cache value
+medium_value  = 'y' * 1_000    # 1 KB
+marshal_value = { user_id: 42, name: 'test', email: 'test@example.com', roles: %w[admin user] }
+
+# Pre-populate keys for get and get_multi tests
+client.set('bench_raw', small_value, 3600, raw: true)
+client.set('bench_medium', medium_value, 3600, raw: true)
+client.set('bench_marshal', marshal_value, 3600)
+
+# Pre-populate keys for get_multi (6 keys matching reported workload)
+multi_keys = (1..6).map { |i| "multi_#{i}" }
+multi_keys.each { |k| client.set(k, small_value, 3600, raw: true) }
+
+# Pre-populate a counter for incr tests
+client.set('bench_counter', '0', 3600, raw: true)
+
+# Verify everything works
+raise 'raw get failed' unless client.get('bench_raw', raw: true) == small_value
+raise 'marshal get failed' unless client.get('bench_marshal') == marshal_value
+raise 'get_multi failed' unless client.get_multi(*multi_keys).size == 6
+
+puts "Setup complete. Running benchmarks...\n\n"
+
+# ---------------------------------------------------------------------------
+# GC Suite — benchmark without GC skewing results
+# ---------------------------------------------------------------------------
+
+# Disables GC during benchmark iterations to reduce noise
+class GCSuite
+  def warming(*) = run_gc
+  def running(*) = run_gc
+  def warmup_stats(*) = GC.enable
+  def add_report(*) = GC.enable
+
+  private
+
+  def run_gc
+    GC.enable
+    GC.start
+    GC.disable
+  end
+end
+
+suite = GCSuite.new
+
+# ---------------------------------------------------------------------------
+# Benchmarks
+# ---------------------------------------------------------------------------
+
+results = {}
+
+# --- Single key GET (raw string) ---
+puts '>>> get (raw, 100B)'
+Benchmark.ips do |x|
+  x.config(warmup: bench_warmup, time: bench_time, suite: suite)
+  x.report("get_raw [#{dalli_version}]") do
+    client.get('bench_raw', raw: true)
+  end
+  x.report("get_medium_raw [#{dalli_version}]") do
+    client.get('bench_medium', raw: true)
+  end
+  results[:get_raw] = x
+end
+
+puts
+
+# --- Single key GET (marshalled object) ---
+puts '>>> get (marshalled)'
+Benchmark.ips do |x|
+  x.config(warmup: bench_warmup, time: bench_time, suite: suite)
+  x.report("get_marshal [#{dalli_version}]") do
+    client.get('bench_marshal')
+  end
+  results[:get_marshal] = x
+end
+
+puts
+
+# --- Single key SET (raw string) ---
+puts '>>> set (raw, 100B)'
+Benchmark.ips do |x|
+  x.config(warmup: bench_warmup, time: bench_time, suite: suite)
+  x.report("set_raw [#{dalli_version}]") do
+    client.set('bench_raw', small_value, 3600, raw: true)
+  end
+  results[:set_raw] = x
+end
+
+puts
+
+# --- Single key SET (marshalled object) ---
+puts '>>> set (marshalled)'
+Benchmark.ips do |x|
+  x.config(warmup: bench_warmup, time: bench_time, suite: suite)
+  x.report("set_marshal [#{dalli_version}]") do
+    client.set('bench_marshal', marshal_value, 3600)
+  end
+  results[:set_marshal] = x
+end
+
+puts
+
+# --- get_multi (6 keys — matches reported workload) ---
+puts '>>> get_multi (6 keys)'
+Benchmark.ips do |x|
+  x.config(warmup: bench_warmup, time: bench_time, suite: suite)
+  x.report("get_multi_6 [#{dalli_version}]") do
+    client.get_multi(*multi_keys)
+  end
+  results[:get_multi] = x
+end
+
+puts
+
+# --- Mixed workload (interleaved set/get) ---
+puts '>>> mixed (set + get interleaved)'
+Benchmark.ips do |x|
+  x.config(warmup: bench_warmup, time: bench_time, suite: suite)
+  x.report("mixed [#{dalli_version}]") do
+    client.set('bench_mixed', small_value, 3600, raw: true)
+    client.get('bench_mixed', raw: true)
+    client.set('bench_mixed2', medium_value, 3600, raw: true)
+    client.get('bench_mixed2', raw: true)
+  end
+  results[:mixed] = x
+end
+
+puts
+
+# --- Increment ---
+puts '>>> incr'
+Benchmark.ips do |x|
+  x.config(warmup: bench_warmup, time: bench_time, suite: suite)
+  x.report("incr [#{dalli_version}]") do
+    client.incr('bench_counter', 1)
+  end
+  results[:incr] = x
+end
+
+puts
+puts '=' * 70
+puts "Benchmark complete for Dalli #{dalli_version} (#{effective_protocol})"
+puts '=' * 70

--- a/lib/dalli/protocol/base.rb
+++ b/lib/dalli/protocol/base.rb
@@ -92,10 +92,13 @@ module Dalli
       # repeatedly whenever this server's socket is readable until
       # #pipeline_complete?.
       #
-      # Returns a Hash of kv pairs received.
-      def pipeline_next_responses
+      # When a block is given, yields (key, value, cas) for each response,
+      # avoiding intermediate Hash allocation. Returns nil.
+      # Without a block, returns a Hash of { key => [value, cas] }.
+      # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+      def pipeline_next_responses(&block)
         reconnect_on_pipeline_complete!
-        values = {}
+        values = nil
 
         response_buffer.read
 
@@ -109,16 +112,24 @@ module Dalli
 
           # If the status is ok and the key is not nil, then this is a
           # getkq response with a value that we want to set in the response hash
-          values[key] = [value, cas] unless key.nil?
+          unless key.nil?
+            if block
+              yield key, value, cas
+            else
+              values ||= {}
+              values[key] = [value, cas]
+            end
+          end
 
           # Get the next response from the buffer
           status, cas, key, value = response_buffer.process_single_getk_response
         end
 
-        values
+        values || {}
       rescue SystemCallError, *TIMEOUT_ERRORS, *SSL_ERRORS, EOFError => e
         @connection_manager.error_on_request!(e)
       end
+      # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
       # Abort current pipelined get. Generally used to signal an external
       # timeout during pipelined get.  The underlying socket is

--- a/lib/dalli/protocol/response_buffer.rb
+++ b/lib/dalli/protocol/response_buffer.rb
@@ -7,38 +7,39 @@ module Dalli
   module Protocol
     ##
     # Manages the buffer for responses from memcached.
+    # Uses an offset-based approach to avoid string allocations
+    # when advancing through parsed responses.
     ##
     class ResponseBuffer
+      # Compact the buffer when the consumed portion exceeds this
+      # threshold and represents more than half the buffer
+      COMPACT_THRESHOLD = 4096
+
       def initialize(io_source, response_processor)
         @io_source = io_source
         @response_processor = response_processor
         @buffer = nil
+        @offset = 0
       end
 
       def read
         @buffer << @io_source.read_nonblock
       end
 
-      # Attempts to process a single response from the buffer.  Starts
-      # by advancing the buffer to the specified start position
+      # Attempts to process a single response from the buffer,
+      # advancing the offset past the consumed bytes.
       def process_single_getk_response
-        bytes, status, cas, key, value = @response_processor.getk_response_from_buffer(@buffer)
-        advance(bytes)
+        bytes, status, cas, key, value = @response_processor.getk_response_from_buffer(@buffer, @offset)
+        @offset += bytes
+        compact_if_needed
         [status, cas, key, value]
-      end
-
-      # Advances the internal response buffer by bytes_to_advance
-      # bytes.  The
-      def advance(bytes_to_advance)
-        return unless bytes_to_advance.positive?
-
-        @buffer = @buffer.byteslice(bytes_to_advance..-1)
       end
 
       # Resets the internal buffer to an empty state,
       # so that we're ready to read pipelined responses
       def reset
         @buffer = ''.b
+        @offset = 0
       end
 
       # Ensures the buffer is initialized for reading without discarding
@@ -48,15 +49,29 @@ module Dalli
         return if in_progress?
 
         @buffer = ''.b
+        @offset = 0
       end
 
       # Clear the internal response buffer
       def clear
         @buffer = nil
+        @offset = 0
       end
 
       def in_progress?
         !@buffer.nil?
+      end
+
+      private
+
+      # Only compact when we've consumed a significant portion of the buffer.
+      # This avoids per-response string allocation while preventing unbounded
+      # memory growth for large pipelines.
+      def compact_if_needed
+        return unless @offset > COMPACT_THRESHOLD && @offset > @buffer.bytesize / 2
+
+        @buffer = @buffer.byteslice(@offset..)
+        @offset = 0
       end
     end
   end


### PR DESCRIPTION
## Summary

Brings the pipelined get performance optimizations from PR #1072 (`v4.3` branch) forward to `main` (5.0), following the `FORWARD_PORT_5.0.md` guide on v4.3.

- **Offset-based ResponseBuffer**: Track a read offset instead of slicing a new string after every parsed response. Compact only when the consumed portion exceeds 4KB and more than half the buffer — eliminates O(n) string allocations per `get_multi` call
- **Inline response processor parsing**: Accept offset parameter in `getk_response_from_buffer`. Inline `contains_header?`/`header_from_buffer`/`tokens_from_header_buffer` helpers to avoid intermediate array allocations from `split`-based header parsing
- **Block-based `pipeline_next_responses`**: Yield `(key, value, cas)` directly when a block is given, avoiding per-call Hash allocation. Falls back to existing Hash return for backward compatibility
- **PipelinedGetter minor optimizations**: Use block form in `process_server`; replace Hash-based socket→server mapping with linear scan (faster for typical 1-5 server counts); use `Process.clock_gettime(CLOCK_MONOTONIC)` instead of `Time.now`
- **Benchmark script**: Add `bin/compare_versions` for cross-version performance comparisons

Binary protocol changes from #1072 are skipped since the binary protocol was removed in 5.0.

## Test plan

- [x] `bundle exec rubocop` — 0 offenses
- [x] `bundle exec rake` — 522 runs, 62191 assertions, 0 failures, 0 errors
- [x] Run benchmarks: `DALLI_VERSION=5.0.0 ruby bin/compare_versions` (baseline) then local patched code — `get_multi` ~11% faster, no regressions (see comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)