### PR TITLE
Release Dalli 5.0.1

### DIFF
--- a/lib/dalli/version.rb
+++ b/lib/dalli/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Dalli
-  VERSION = '5.0.0'
+  VERSION = '5.0.1'
 
   MIN_SUPPORTED_MEMCACHED_VERSION = '1.6'
 end


### PR DESCRIPTION
## Summary

Patch release incorporating pipeline performance optimizations from v4.3 and bug fixes since 5.0.0.

Changes since 5.0.0:
- **Performance**: Reduce object allocations in pipelined get response processing (~11% `get_multi` throughput improvement) — forward-ported from v4.3.3 (#1072, #1078)
- **Bug fix**: Rescue `IOError` in connection manager `write`/`flush` methods (#1075)
- **Development**: Add `rubocop-thread_safety` (#1076), CONTRIBUTING.md (#1074)
- **Tooling**: Add `bin/compare_versions` benchmark script

All v4.3 branch changes have been reviewed — everything applicable to 5.0 is already on main.

## Test plan

- [x] `bundle exec rubocop` — 0 offenses
- [x] `bundle exec rake` — 522 runs, 77278 assertions, 0 failures, 0 errors
- [x] Verified all v4.3 changes are forward-ported or inapplicable to 5.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)