### PR TITLE
Release 5.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 Dalli Changelog
 =====================
 
+5.0.2
+==========
+
+Performance:
+
+- Add single-server fast path for `get_multi`, `set_multi`, and `delete_multi` (#1077)
+  - When only one memcached server is configured, bypass the `Pipelined*` machinery (IO.select, response buffering, server grouping) and issue all quiet meta requests inline followed by a noop terminator
+  - `get_multi` shows ~1.5x improvement at 10 keys and ~1.75x at 100–500 keys compared to the `PipelinedGetter` path
+  - Thanks to Dan Mayer (Shopify) for this contribution
+
+Development:
+
+- Add `bin/benchmark_branch` script for benchmarking against the current branch
+
 5.0.1
 ==========
 

--- a/lib/dalli/version.rb
+++ b/lib/dalli/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Dalli
-  VERSION = '5.0.1'
+  VERSION = '5.0.2'
 
   MIN_SUPPORTED_MEMCACHED_VERSION = '1.6'
 end


### PR DESCRIPTION
## Summary

- Bump version to 5.0.2
- Update CHANGELOG with single-server fast path entries for `get_multi`, `set_multi`, and `delete_multi`
- Remove Claude Code GitHub Actions workflows

## Changes included since 5.0.1

**Performance** (#1077, Dan Mayer / Shopify):
- Single-server fast path for `get_multi`, `set_multi`, and `delete_multi` — bypasses `Pipelined*` machinery when only one server is configured (~1.5x improvement at 10 keys, ~1.75x at 100–500 keys for `get_multi`)

**Development:**
- `bin/benchmark_branch` script for benchmarking against the current branch

## Test plan

- [ ] `bundle exec rubocop` passes
- [ ] `bundle exec rake` passes
- [ ] Tag `v5.0.2` after merge and push gem to RubyGems

🤖 Generated with [Claude Code](https://claude.com/claude-code)