### PR TITLE
Fix the `string_fastpath` option to not comflict with compression

### DIFF
--- a/lib/dalli.rb
+++ b/lib/dalli.rb
@@ -61,6 +61,7 @@ end
 require_relative 'dalli/version'
 require_relative 'dalli/instrumentation'
 
+require_relative 'dalli/flags'
 require_relative 'dalli/compressor'
 require_relative 'dalli/client'
 require_relative 'dalli/key_manager'

--- a/lib/dalli/flags.rb
+++ b/lib/dalli/flags.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Dalli
+  module Flags
+    # https://www.hjp.at/zettel/m/memcached_flags.rxml
+    # Looks like most clients use bit 0 to indicate native language serialization
+    SERIALIZED = 0x1
+
+    # https://www.hjp.at/zettel/m/memcached_flags.rxml
+    # Looks like most clients use bit 1 to indicate gzip compression.
+    COMPRESSED = 0x2
+
+    UTF8 = 0x4
+  end
+end

--- a/lib/dalli/protocol/value_compressor.rb
+++ b/lib/dalli/protocol/value_compressor.rb
@@ -20,10 +20,6 @@ module Dalli
 
       OPTIONS = DEFAULTS.keys.freeze
 
-      # https://www.hjp.at/zettel/m/memcached_flags.rxml
-      # Looks like most clients use bit 1 to indicate gzip compression.
-      FLAG_COMPRESSED = 0x2
-
       def initialize(client_options)
         @compression_options =
           DEFAULTS.merge(client_options.slice(*OPTIONS))
@@ -32,13 +28,13 @@ module Dalli
       def store(value, req_options, bitflags)
         do_compress = compress_value?(value, req_options)
         store_value = do_compress ? compressor.compress(value) : value
-        bitflags |= FLAG_COMPRESSED if do_compress
+        bitflags |= Flags::COMPRESSED if do_compress
 
         [store_value, bitflags]
       end
 
       def retrieve(value, bitflags)
-        compressed = bitflags.anybits?(FLAG_COMPRESSED)
+        compressed = bitflags.anybits?(Flags::COMPRESSED)
         compressed ? compressor.decompress(value) : value
 
       # TODO: We likely want to move this rescue into the Dalli::Compressor / Dalli::GzipCompressor

--- a/lib/dalli/protocol/value_serializer.rb
+++ b/lib/dalli/protocol/value_serializer.rb
@@ -15,11 +15,6 @@ module Dalli
 
       OPTIONS = DEFAULTS.keys.freeze
 
-      # https://www.hjp.at/zettel/m/memcached_flags.rxml
-      # Looks like most clients use bit 0 to indicate native language serialization
-      FLAG_SERIALIZED = 0x1
-      FLAG_UTF8 = 0x2
-
       # Class variable to track whether the Marshal warning has been logged
       @@marshal_warning_logged = false # rubocop:disable Style/ClassVars
 
@@ -35,18 +30,18 @@ module Dalli
         return store_raw(value, bitflags) if req_options&.dig(:raw)
         return store_string_fastpath(value, bitflags) if use_string_fastpath?(value, req_options)
 
-        [serialize_value(value), bitflags | FLAG_SERIALIZED]
+        [serialize_value(value), bitflags | Flags::SERIALIZED]
       end
 
       def retrieve(value, bitflags)
-        serialized = bitflags.anybits?(FLAG_SERIALIZED)
+        serialized = bitflags.anybits?(Flags::SERIALIZED)
         if serialized
           begin
             serializer.load(value)
           rescue StandardError
             raise UnmarshalError, 'Unable to unmarshal value'
           end
-        elsif bitflags.anybits?(FLAG_UTF8)
+        elsif bitflags.anybits?(Flags::UTF8)
           value.force_encoding(Encoding::UTF_8)
         else
           value
@@ -86,8 +81,8 @@ module Dalli
       def store_string_fastpath(value, bitflags)
         case value.encoding
         when Encoding::BINARY then [value, bitflags]
-        when Encoding::UTF_8 then [value, bitflags | FLAG_UTF8]
-        else [serialize_value(value), bitflags | FLAG_SERIALIZED]
+        when Encoding::UTF_8 then [value, bitflags | Flags::UTF8]
+        else [serialize_value(value), bitflags | Flags::SERIALIZED]
         end
       end
 

--- a/test/protocol/test_value_serializer.rb
+++ b/test/protocol/test_value_serializer.rb
@@ -283,7 +283,7 @@ describe Dalli::Protocol::ValueSerializer do
         error = ->(_arg) { raise TypeError, error_message }
         exception = serializer.stub :load, error do
           assert_raises Dalli::UnmarshalError do
-            vs.retrieve(raw_value, Dalli::Protocol::ValueSerializer::FLAG_SERIALIZED)
+            vs.retrieve(raw_value, Dalli::Flags::SERIALIZED)
           end
         end
 
@@ -300,7 +300,7 @@ describe Dalli::Protocol::ValueSerializer do
         error = ->(_arg) { raise TypeError, error_message }
         exception = serializer.stub :load, error do
           assert_raises Dalli::UnmarshalError do
-            vs.retrieve(raw_value, Dalli::Protocol::ValueSerializer::FLAG_SERIALIZED)
+            vs.retrieve(raw_value, Dalli::Flags::SERIALIZED)
           end
         end
 
@@ -315,7 +315,7 @@ describe Dalli::Protocol::ValueSerializer do
 
       it 'raises UnmarshalError on uninitialized constant' do
         exception = assert_raises Dalli::UnmarshalError do
-          vs.retrieve(raw_value, Dalli::Protocol::ValueSerializer::FLAG_SERIALIZED)
+          vs.retrieve(raw_value, Dalli::Flags::SERIALIZED)
         end
 
         assert_equal exception.cause.message, error_message
@@ -329,7 +329,7 @@ describe Dalli::Protocol::ValueSerializer do
 
       it 'raises UnmarshalError on uninitialized constant' do
         exception = assert_raises Dalli::UnmarshalError do
-          vs.retrieve(raw_value, Dalli::Protocol::ValueSerializer::FLAG_SERIALIZED)
+          vs.retrieve(raw_value, Dalli::Flags::SERIALIZED)
         end
 
         assert exception.cause.message.start_with?(error_message)
@@ -345,7 +345,7 @@ describe Dalli::Protocol::ValueSerializer do
         error = ->(_arg) { raise NameError, error_message }
         exception = serializer.stub :load, error do
           assert_raises Dalli::UnmarshalError do
-            vs.retrieve(raw_value, Dalli::Protocol::ValueSerializer::FLAG_SERIALIZED)
+            vs.retrieve(raw_value, Dalli::Flags::SERIALIZED)
           end
         end
 
@@ -360,7 +360,7 @@ describe Dalli::Protocol::ValueSerializer do
 
       it 'raises UnmarshalError on uninitialized constant' do
         exception = assert_raises Dalli::UnmarshalError do
-          vs.retrieve(raw_value, Dalli::Protocol::ValueSerializer::FLAG_SERIALIZED)
+          vs.retrieve(raw_value, Dalli::Flags::SERIALIZED)
         end
 
         assert_equal exception.cause.message, error_message
@@ -374,7 +374,7 @@ describe Dalli::Protocol::ValueSerializer do
 
       it 'raises UnmarshalError on uninitialized constant' do
         exception = assert_raises Dalli::UnmarshalError do
-          vs.retrieve(raw_value, Dalli::Protocol::ValueSerializer::FLAG_SERIALIZED)
+          vs.retrieve(raw_value, Dalli::Flags::SERIALIZED)
         end
 
         assert_equal exception.cause.message, error_message
@@ -388,13 +388,13 @@ describe Dalli::Protocol::ValueSerializer do
       let(:vs) { Dalli::Protocol::ValueSerializer.new(vs_options) }
 
       it 'properly deserializes the serialized value' do
-        assert_equal vs.retrieve(serialized_value, Dalli::Protocol::ValueSerializer::FLAG_SERIALIZED),
+        assert_equal vs.retrieve(serialized_value, Dalli::Flags::SERIALIZED),
                      deserialized_value
       end
 
       it 'raises UnmarshalError for non-serialized data' do
         assert_raises Dalli::UnmarshalError do
-          vs.retrieve(:not_serialized_value, Dalli::Protocol::ValueSerializer::FLAG_SERIALIZED)
+          vs.retrieve(:not_serialized_value, Dalli::Flags::SERIALIZED)
         end
       end
     end


### PR DESCRIPTION
Ref: https://github.com/petergoldstein/dalli/pull/1041

Both feature ended up using the same bit, causing Dalli to confuse raw strings with compressed ones.

I however don't understand why it's not reproducing the failure in the test suite.

I'm currently working around the problem by using a noop compressor (as we don't use compression anyway, at least not at the dalli level)

```ruby
  module NoopCompressor

    def self.compress(data)
      data
    end

    def self.decompress(data)
      data
    end

  end
```