### PR TITLE
Bump actions/upload-artifact from v6 to v7

### DIFF
--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -31,7 +31,7 @@ jobs:
     # click to view the run you are interested in (ex https://github.com/petergoldstein/dalli/actions/runs/13296952241)
     # in the artifacts section, download the profile results
     - name: Upload profile results
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: profile-results
         path: |


### PR DESCRIPTION
## Summary

- Bumps `actions/upload-artifact` from v6 to v7 in `.github/workflows/profile.yml`, consolidating Dependabot PR #1087
- Ran `bundle update` — Gemfile.lock was already current on main, no gem version changes needed
- Rubocop passes with no offenses

## Changes

| Dependency | From | To | Type |
|---|---|---|---|
| `actions/upload-artifact` | v6 | v7 | GitHub Actions |

The v7 release adds ESM module support and a new `archive: false` option for direct single-file uploads. Existing multi-file artifact upload usage in this workflow is unaffected.

Closes #1087

## Test plan

- [x] Rubocop passes (`bundle exec rubocop`)
- [ ] Profile workflow runs successfully and uploads artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)