### PR TITLE
Use kwargs with `resolv-replace` gem version >= 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Performance:
 
 Features:
 
+- Support `connect_timeout:` keyword argument with `resolv-replace` >= 0.2.0, which now correctly forwards keyword arguments through its `TCPSocket` patch (#1096)
+
 - Add `Dalli::Instrumentation.disable!` to allow disabling OpenTelemetry instrumentation at runtime (#1088)
   - Also exposes `Dalli::Instrumentation.tracer=` for setting a custom tracer
 

--- a/lib/dalli/socket.rb
+++ b/lib/dalli/socket.rb
@@ -106,14 +106,19 @@ module Dalli
       end
 
       # Detect and cache whether TCPSocket supports the connect_timeout: keyword argument.
-      # Returns false if TCPSocket#initialize has been monkey-patched by gems like
-      # socksify or resolv-replace, which don't support keyword arguments.
+      # Returns true for an unmodified TCPSocket on Ruby 3.0+, or for resolv-replace >= 0.2.0
+      # which forwards keyword arguments through its patch.
+      # Returns false when monkey-patched by gems like socksify or resolv-replace < 0.2.0.
       # rubocop:disable ThreadSafety/ClassInstanceVariable
       def self.supports_connect_timeout?
         return @supports_connect_timeout if defined?(@supports_connect_timeout)
 
         @supports_connect_timeout = RUBY_ENGINE == 'ruby' && RUBY_VERSION >= '3.0' &&
-                                    ::TCPSocket.instance_method(:initialize).parameters == TCPSOCKET_NATIVE_PARAMETERS
+                                    ::TCPSocket.instance_method(:initialize).parameters.then do |params|
+                                      params == TCPSOCKET_NATIVE_PARAMETERS || params.any? do |type, _|
+                                        type == :keyrest
+                                      end
+                                    end
       end
       # rubocop:enable ThreadSafety/ClassInstanceVariable
 

--- a/test/test_socket.rb
+++ b/test/test_socket.rb
@@ -58,6 +58,7 @@ describe 'Dalli::Socket::TCP' do
 
     it 'returns false for resolv-replace < 0.2.0 which does not forward keyword arguments' do
       skip 'Ruby 3.0+ required' if RUBY_VERSION < '3.0'
+      skip 'MRI-specific test' if RUBY_ENGINE != 'ruby'
 
       # resolv-replace < 0.2.0 uses def initialize(host, serv, *rest) - no kwargs
       params = [%i[req host], %i[req serv], %i[rest rest]]

--- a/test/test_socket.rb
+++ b/test/test_socket.rb
@@ -10,6 +10,12 @@ describe 'Dalli::Socket::TCP' do
         Dalli::Socket::TCP.instance_variable_defined?(:@supports_connect_timeout)
     end
 
+    def with_tcpsocket_parameters(params, &block)
+      fake_method = Object.new
+      fake_method.define_singleton_method(:parameters) { params }
+      TCPSocket.stub(:instance_method, fake_method, &block)
+    end
+
     it 'returns true for unmodified TCPSocket on MRI Ruby 3.0+' do
       skip 'Ruby 3.0+ required' if RUBY_VERSION < '3.0'
       skip 'MRI-specific test' if RUBY_ENGINE != 'ruby'
@@ -38,21 +44,26 @@ describe 'Dalli::Socket::TCP' do
       assert_equal result1, result2
     end
 
-    it 'detects when TCPSocket#initialize parameters have changed' do
+    it 'returns true for resolv-replace >= 0.2.0 which forwards keyword arguments' do
       skip 'Ruby 3.0+ required' if RUBY_VERSION < '3.0'
       skip 'MRI-specific test' if RUBY_ENGINE != 'ruby'
 
-      # Get the expected native parameters
-      native_params = [[:rest]]
-      actual_params = TCPSocket.instance_method(:initialize).parameters
+      # resolv-replace >= 0.2.0 uses def initialize(host, serv, *rest, **kwargs)
+      params = [%i[req host], %i[req serv], %i[rest rest], %i[keyrest kwargs]]
 
-      # This test documents the expected behavior
-      if actual_params == native_params
-        assert_predicate Dalli::Socket::TCP, :supports_connect_timeout?,
-                         'Should support connect_timeout when TCPSocket is unmodified'
-      else
-        refute_predicate Dalli::Socket::TCP, :supports_connect_timeout?,
-                         'Should not support connect_timeout when TCPSocket is modified'
+      with_tcpsocket_parameters(params) do
+        assert_predicate Dalli::Socket::TCP, :supports_connect_timeout?
+      end
+    end
+
+    it 'returns false for resolv-replace < 0.2.0 which does not forward keyword arguments' do
+      skip 'Ruby 3.0+ required' if RUBY_VERSION < '3.0'
+
+      # resolv-replace < 0.2.0 uses def initialize(host, serv, *rest) - no kwargs
+      params = [%i[req host], %i[req serv], %i[rest rest]]
+
+      with_tcpsocket_parameters(params) do
+        refute_predicate Dalli::Socket::TCP, :supports_connect_timeout?
       end
     end
   end


### PR DESCRIPTION
When upgrading from v2 to latest, I hit a lot of errors about `ruby/3.3.0/gems/timeout-0.4.3/lib/timeout.rb:95:in 'new': can't alloc thread (ThreadError)` in a project that is using the resolv-replace bundled gem.

`resolv-replace` [v0.2.0](https://github.com/ruby/resolv-replace/releases/tag/v0.2.0) updated its `TCPSocket#initialize` patch to forward `**kwargs`, which means `connect_timeout:` should now work correctly when that version is loaded. Previously, `supports_connect_timeout?` treated any `resolv-replace`-patched `TCPSocket` as incompatible.

### What changed

`supports_connect_timeout?` now checks the parameter signature of `TCPSocket#initialize` more precisely instead of requiring an exact match against the native `[[:rest]]` signature:

- **Unpatched Ruby 3.0+** – parameters are `[[:rest]]`, returns `true` (unchanged)
- **resolv-replace ≥ 0.2.0** – parameters include `**kwargs` (a `:keyrest` entry), returns `true` (new)
- **resolv-replace < 0.2.0 / socksify / other patchers without kwargs** – no `:keyrest` entry, returns `false` (unchanged)

This PR was generated with the assistance of claude code