### PR TITLE
Release 5.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Dalli Changelog
 Unreleased
 ==========
 
+5.0.3
+==========
+
 Performance:
 
 - Eliminate double array allocation in `Client#perform` (#1093)

--- a/lib/dalli/version.rb
+++ b/lib/dalli/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Dalli
-  VERSION = '5.0.2'
+  VERSION = '5.0.3'
 
   MIN_SUPPORTED_MEMCACHED_VERSION = '1.6'
 end


### PR DESCRIPTION
## Summary

- Bumps `Dalli::VERSION` to `5.0.3`
- Promotes the `Unreleased` CHANGELOG block to `5.0.3`

## Changes included

**Performance:**
- Eliminate double array allocation in `Client#perform` — ~39% benchmark improvement across all operations (#1093)

**Features:**
- Support `connect_timeout:` keyword argument with `resolv-replace` >= 0.2.0 (#1096)
- Add `Dalli::Instrumentation.disable!` for disabling OpenTelemetry instrumentation at runtime (#1088)

## Test plan

- [ ] CI passes
- [ ] After merge, tag `v5.0.3` and push the gem to RubyGems

🤖 Generated with [Claude Code](https://claude.com/claude-code)