### PR TITLE
Add regression test for string_fastpath/compression flag collision

### DIFF
--- a/test/integration/test_serializer.rb
+++ b/test/integration/test_serializer.rb
@@ -48,6 +48,61 @@ describe 'Serializer configuration' do
         end
       end
 
+      it 'round-trips fastpath strings when compression is enabled (per-request option)' do
+        # Regression test for the collision between the UTF8 fastpath flag and
+        # the COMPRESSED flag — both occupy bit 0x2 in ValueSerializer and
+        # ValueCompressor respectively. The bug only surfaces when
+        # `string_fastpath: true` is passed as a per-request option on `#set`,
+        # which is the path real callers like Rails' `mem_cache_store` use
+        # (it forwards all per-call options to Dalli except `:compress`).
+        memcached(p, 29_198) do |_dc, port|
+          memcache = Dalli::Client.new("127.0.0.1:#{port}",
+                                       compress: true,
+                                       compression_min_size: 1024)
+
+          # Short UTF-8 — below the compression threshold, but the fastpath
+          # still sets the UTF8 flag bit. Without the fix, the reader's
+          # compressor sees the bit as "compressed" and raises Zlib::DataError
+          # (wrapped as Dalli::UnmarshalError).
+          short_utf8 = 'héllø'
+          memcache.set 'short_utf8', short_utf8, 60, string_fastpath: true
+
+          assert_equal short_utf8, memcache.get('short_utf8')
+          assert_equal Encoding::UTF_8, memcache.get('short_utf8').encoding
+
+          # Long UTF-8 — over the compression threshold. Compressor and
+          # fastpath both want to set their flag bit on the same value.
+          long_utf8 = ('héllo-вселенная-🌍 ' * 600).force_encoding(Encoding::UTF_8).freeze
+          memcache.set 'long_utf8', long_utf8, 60, string_fastpath: true
+
+          assert_equal long_utf8, memcache.get('long_utf8')
+          assert_equal Encoding::UTF_8, memcache.get('long_utf8').encoding
+
+          # Long BINARY — fastpath leaves no encoding flag, compressor adds
+          # the compression flag. Without the fix the reader returns the
+          # decompressed bytes with the wrong encoding.
+          long_binary = ("\xFFpayload" * 2000).b.freeze
+          memcache.set 'long_binary', long_binary, 60, string_fastpath: true
+
+          assert_equal long_binary, memcache.get('long_binary')
+          assert_equal Encoding::BINARY, memcache.get('long_binary').encoding
+
+          # A second client that never opts into fastpath must still read
+          # every entry correctly — covers a rolling-deploy or worker-pool
+          # mismatch where only some processes use the per-request option.
+          plain = Dalli::Client.new("127.0.0.1:#{port}",
+                                    compress: true,
+                                    compression_min_size: 1024)
+
+          assert_equal short_utf8, plain.get('short_utf8')
+          assert_equal Encoding::UTF_8, plain.get('short_utf8').encoding
+          assert_equal long_utf8, plain.get('long_utf8')
+          assert_equal Encoding::UTF_8, plain.get('long_utf8').encoding
+          assert_equal long_binary, plain.get('long_binary')
+          assert_equal Encoding::BINARY, plain.get('long_binary').encoding
+        end
+      end
+
       it 'supports a custom serializer' do
         memcached(p, 29_198) do |_dc, port|
           memcache = Dalli::Client.new("127.0.0.1:#{port}", serializer: JSON)


### PR DESCRIPTION
Adds an integration test covering the collision between `ValueSerializer::FLAG_UTF8` and `ValueCompressor::FLAG_COMPRESSED`. Both constants are `0x2`, so any value written with `string_fastpath: true` as a per-request option produces ambiguous flags on read.

The bug is fixed by #1086, but no test was added there that fails on `main` and passes on the fix — so the regression could re-emerge if the flag handling is refactored again. This PR fills that gap.

### What the test covers

- Short UTF-8 string with `string_fastpath: true` per-request + `compress: true` client-level. Below the compression threshold, but the fastpath still sets bit `0x2`, which the reader's compressor interprets as `FLAG_COMPRESSED` and tries to `Zlib.inflate` on raw UTF-8 bytes.
- Long UTF-8 string (over `compression_min_size`).
- Long BINARY string — fastpath leaves bit `0x2` clear, compressor sets it; without the fix the reader returns the decompressed bytes with the wrong encoding.
- A second client that never opts into `string_fastpath` reading every key — covers a rolling-deploy or worker-pool mismatch where only some processes use the per-request option (mirrors how `ActiveSupport::Cache::MemCacheStore#write_serialized_entry` forwards per-call options to Dalli).

### Why the existing fastpath test didn't catch it

`test/integration/test_serializer.rb#L17` covers `string_fastpath` as a **client-level** option without compression. The new test covers the production-relevant path: `string_fastpath: true` as a **per-request** option on `#set`, with `compress: true` on the client. That's the combination Rails callers naturally produce — Rails strips `:compress` from per-call options (see `active_support/cache/mem_cache_store.rb#L215`) but forwards everything else.

### Verification

On `main` (`1bc7403`, "Prepare 5.0.3 release"):

```
Serializer configuration::using the meta protocol#test_0003_round-trips fastpath strings when compression is enabled (per-request option) = 0.11 s = E

  1) Error:
Serializer configuration::using the meta protocol#test_0003_round-trips fastpath strings when compression is enabled (per-request option):
Dalli::UnmarshalError: Unable to uncompress value: incorrect header check
    lib/dalli/protocol/value_compressor.rb:48:in 'Dalli::Protocol::ValueCompressor#retrieve'
    ...

5 runs, 22 assertions, 0 failures, 1 errors, 0 skips
```

With #1086 applied (cherry-picked locally):

```
5 runs, 34 assertions, 0 failures, 0 errors, 0 skips
```

### Production symptom this corresponds to

When the UTF-8 branch fires inside Rails, `Dalli::UnmarshalError` is caught by `MemCacheStore#rescue_error_with` and returned as a silent cache miss. The application re-runs whatever produced the value and re-writes it; the next read trips the same error. The Memcachier dashboard for an app that hit this shows roughly equal gets, misses, and sets at very high volume with hit rate hovering near 80% — looks healthy at a glance, but every cacheable computation is running twice or more. See https://github.com/petergoldstein/dalli/pull/1086#issuecomment-4467725160 for the full standalone repro and version matrix.

### Notes

- The test runs against memcached 1.6.40 in CI (matches `tests.yml`).
- Will fail on `main` until #1086 (or an equivalent fix) is merged. That's the intended signal.
- Rubocop clean.
