### PR TITLE
Fix string_fastpath flag collision with compression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ Dalli Changelog
 Unreleased
 ==========
 
+Bug fixes:
+
+- Fix `string_fastpath` flag collision with compression (#1099)
+  - `ValueSerializer::FLAG_UTF8` and `ValueCompressor::FLAG_COMPRESSED` were both `0x2`, causing `Dalli::UnmarshalError` on any UTF-8 string written with `string_fastpath: true` when compression is enabled, and silent encoding corruption for binary strings
+  - Introduces `Dalli::Flags` to centralise bit flag constants; UTF8 is reassigned to `0x4`
+  - Adds regression test covering short/long UTF-8, binary, and cross-client read scenarios
+  - Thanks to Jean Boussier and Mikael Henriksson for the fix and regression test
+
 5.0.3
 ==========
 

--- a/lib/dalli.rb
+++ b/lib/dalli.rb
@@ -61,6 +61,7 @@ end
 require_relative 'dalli/version'
 require_relative 'dalli/instrumentation'
 
+require_relative 'dalli/flags'
 require_relative 'dalli/compressor'
 require_relative 'dalli/client'
 require_relative 'dalli/key_manager'

--- a/lib/dalli/flags.rb
+++ b/lib/dalli/flags.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Dalli
+  module Flags
+    # https://www.hjp.at/zettel/m/memcached_flags.rxml
+    # Looks like most clients use bit 0 to indicate native language serialization
+    SERIALIZED = 0x1
+
+    # https://www.hjp.at/zettel/m/memcached_flags.rxml
+    # Looks like most clients use bit 1 to indicate gzip compression.
+    COMPRESSED = 0x2
+
+    UTF8 = 0x4
+  end
+end

--- a/lib/dalli/protocol/value_compressor.rb
+++ b/lib/dalli/protocol/value_compressor.rb
@@ -20,10 +20,6 @@ module Dalli
 
       OPTIONS = DEFAULTS.keys.freeze
 
-      # https://www.hjp.at/zettel/m/memcached_flags.rxml
-      # Looks like most clients use bit 1 to indicate gzip compression.
-      FLAG_COMPRESSED = 0x2
-
       def initialize(client_options)
         @compression_options =
           DEFAULTS.merge(client_options.slice(*OPTIONS))
@@ -32,13 +28,13 @@ module Dalli
       def store(value, req_options, bitflags)
         do_compress = compress_value?(value, req_options)
         store_value = do_compress ? compressor.compress(value) : value
-        bitflags |= FLAG_COMPRESSED if do_compress
+        bitflags |= Flags::COMPRESSED if do_compress
 
         [store_value, bitflags]
       end
 
       def retrieve(value, bitflags)
-        compressed = bitflags.anybits?(FLAG_COMPRESSED)
+        compressed = bitflags.anybits?(Flags::COMPRESSED)
         compressed ? compressor.decompress(value) : value
 
       # TODO: We likely want to move this rescue into the Dalli::Compressor / Dalli::GzipCompressor

--- a/lib/dalli/protocol/value_serializer.rb
+++ b/lib/dalli/protocol/value_serializer.rb
@@ -15,11 +15,6 @@ module Dalli
 
       OPTIONS = DEFAULTS.keys.freeze
 
-      # https://www.hjp.at/zettel/m/memcached_flags.rxml
-      # Looks like most clients use bit 0 to indicate native language serialization
-      FLAG_SERIALIZED = 0x1
-      FLAG_UTF8 = 0x2
-
       # Class variable to track whether the Marshal warning has been logged
       @@marshal_warning_logged = false # rubocop:disable Style/ClassVars
 
@@ -35,18 +30,18 @@ module Dalli
         return store_raw(value, bitflags) if req_options&.dig(:raw)
         return store_string_fastpath(value, bitflags) if use_string_fastpath?(value, req_options)
 
-        [serialize_value(value), bitflags | FLAG_SERIALIZED]
+        [serialize_value(value), bitflags | Flags::SERIALIZED]
       end
 
       def retrieve(value, bitflags)
-        serialized = bitflags.anybits?(FLAG_SERIALIZED)
+        serialized = bitflags.anybits?(Flags::SERIALIZED)
         if serialized
           begin
             serializer.load(value)
           rescue StandardError
             raise UnmarshalError, 'Unable to unmarshal value'
           end
-        elsif bitflags.anybits?(FLAG_UTF8)
+        elsif bitflags.anybits?(Flags::UTF8)
           value.force_encoding(Encoding::UTF_8)
         else
           value
@@ -86,8 +81,8 @@ module Dalli
       def store_string_fastpath(value, bitflags)
         case value.encoding
         when Encoding::BINARY then [value, bitflags]
-        when Encoding::UTF_8 then [value, bitflags | FLAG_UTF8]
-        else [serialize_value(value), bitflags | FLAG_SERIALIZED]
+        when Encoding::UTF_8 then [value, bitflags | Flags::UTF8]
+        else [serialize_value(value), bitflags | Flags::SERIALIZED]
         end
       end
 

--- a/test/integration/test_serializer.rb
+++ b/test/integration/test_serializer.rb
@@ -48,6 +48,61 @@ describe 'Serializer configuration' do
         end
       end
 
+      it 'round-trips fastpath strings when compression is enabled (per-request option)' do
+        # Regression test for the collision between the UTF8 fastpath flag and
+        # the COMPRESSED flag — both occupy bit 0x2 in ValueSerializer and
+        # ValueCompressor respectively. The bug only surfaces when
+        # `string_fastpath: true` is passed as a per-request option on `#set`,
+        # which is the path real callers like Rails' `mem_cache_store` use
+        # (it forwards all per-call options to Dalli except `:compress`).
+        memcached(p, 29_198) do |_dc, port|
+          memcache = Dalli::Client.new("127.0.0.1:#{port}",
+                                       compress: true,
+                                       compression_min_size: 1024)
+
+          # Short UTF-8 — below the compression threshold, but the fastpath
+          # still sets the UTF8 flag bit. Without the fix, the reader's
+          # compressor sees the bit as "compressed" and raises Zlib::DataError
+          # (wrapped as Dalli::UnmarshalError).
+          short_utf8 = 'héllø'
+          memcache.set 'short_utf8', short_utf8, 60, string_fastpath: true
+
+          assert_equal short_utf8, memcache.get('short_utf8')
+          assert_equal Encoding::UTF_8, memcache.get('short_utf8').encoding
+
+          # Long UTF-8 — over the compression threshold. Compressor and
+          # fastpath both want to set their flag bit on the same value.
+          long_utf8 = ('héllo-вселенная-🌍 ' * 600).force_encoding(Encoding::UTF_8).freeze
+          memcache.set 'long_utf8', long_utf8, 60, string_fastpath: true
+
+          assert_equal long_utf8, memcache.get('long_utf8')
+          assert_equal Encoding::UTF_8, memcache.get('long_utf8').encoding
+
+          # Long BINARY — fastpath leaves no encoding flag, compressor adds
+          # the compression flag. Without the fix the reader returns the
+          # decompressed bytes with the wrong encoding.
+          long_binary = ("\xFFpayload" * 2000).b.freeze
+          memcache.set 'long_binary', long_binary, 60, string_fastpath: true
+
+          assert_equal long_binary, memcache.get('long_binary')
+          assert_equal Encoding::BINARY, memcache.get('long_binary').encoding
+
+          # A second client that never opts into fastpath must still read
+          # every entry correctly — covers a rolling-deploy or worker-pool
+          # mismatch where only some processes use the per-request option.
+          plain = Dalli::Client.new("127.0.0.1:#{port}",
+                                    compress: true,
+                                    compression_min_size: 1024)
+
+          assert_equal short_utf8, plain.get('short_utf8')
+          assert_equal Encoding::UTF_8, plain.get('short_utf8').encoding
+          assert_equal long_utf8, plain.get('long_utf8')
+          assert_equal Encoding::UTF_8, plain.get('long_utf8').encoding
+          assert_equal long_binary, plain.get('long_binary')
+          assert_equal Encoding::BINARY, plain.get('long_binary').encoding
+        end
+      end
+
       it 'supports a custom serializer' do
         memcached(p, 29_198) do |_dc, port|
           memcache = Dalli::Client.new("127.0.0.1:#{port}", serializer: JSON)

--- a/test/protocol/test_value_serializer.rb
+++ b/test/protocol/test_value_serializer.rb
@@ -283,7 +283,7 @@ describe Dalli::Protocol::ValueSerializer do
         error = ->(_arg) { raise TypeError, error_message }
         exception = serializer.stub :load, error do
           assert_raises Dalli::UnmarshalError do
-            vs.retrieve(raw_value, Dalli::Protocol::ValueSerializer::FLAG_SERIALIZED)
+            vs.retrieve(raw_value, Dalli::Flags::SERIALIZED)
           end
         end
 
@@ -300,7 +300,7 @@ describe Dalli::Protocol::ValueSerializer do
         error = ->(_arg) { raise TypeError, error_message }
         exception = serializer.stub :load, error do
           assert_raises Dalli::UnmarshalError do
-            vs.retrieve(raw_value, Dalli::Protocol::ValueSerializer::FLAG_SERIALIZED)
+            vs.retrieve(raw_value, Dalli::Flags::SERIALIZED)
           end
         end
 
@@ -315,7 +315,7 @@ describe Dalli::Protocol::ValueSerializer do
 
       it 'raises UnmarshalError on uninitialized constant' do
         exception = assert_raises Dalli::UnmarshalError do
-          vs.retrieve(raw_value, Dalli::Protocol::ValueSerializer::FLAG_SERIALIZED)
+          vs.retrieve(raw_value, Dalli::Flags::SERIALIZED)
         end
 
         assert_equal exception.cause.message, error_message
@@ -329,7 +329,7 @@ describe Dalli::Protocol::ValueSerializer do
 
       it 'raises UnmarshalError on uninitialized constant' do
         exception = assert_raises Dalli::UnmarshalError do
-          vs.retrieve(raw_value, Dalli::Protocol::ValueSerializer::FLAG_SERIALIZED)
+          vs.retrieve(raw_value, Dalli::Flags::SERIALIZED)
         end
 
         assert exception.cause.message.start_with?(error_message)
@@ -345,7 +345,7 @@ describe Dalli::Protocol::ValueSerializer do
         error = ->(_arg) { raise NameError, error_message }
         exception = serializer.stub :load, error do
           assert_raises Dalli::UnmarshalError do
-            vs.retrieve(raw_value, Dalli::Protocol::ValueSerializer::FLAG_SERIALIZED)
+            vs.retrieve(raw_value, Dalli::Flags::SERIALIZED)
           end
         end
 
@@ -360,7 +360,7 @@ describe Dalli::Protocol::ValueSerializer do
 
       it 'raises UnmarshalError on uninitialized constant' do
         exception = assert_raises Dalli::UnmarshalError do
-          vs.retrieve(raw_value, Dalli::Protocol::ValueSerializer::FLAG_SERIALIZED)
+          vs.retrieve(raw_value, Dalli::Flags::SERIALIZED)
         end
 
         assert_equal exception.cause.message, error_message
@@ -374,7 +374,7 @@ describe Dalli::Protocol::ValueSerializer do
 
       it 'raises UnmarshalError on uninitialized constant' do
         exception = assert_raises Dalli::UnmarshalError do
-          vs.retrieve(raw_value, Dalli::Protocol::ValueSerializer::FLAG_SERIALIZED)
+          vs.retrieve(raw_value, Dalli::Flags::SERIALIZED)
         end
 
         assert_equal exception.cause.message, error_message
@@ -388,13 +388,13 @@ describe Dalli::Protocol::ValueSerializer do
       let(:vs) { Dalli::Protocol::ValueSerializer.new(vs_options) }
 
       it 'properly deserializes the serialized value' do
-        assert_equal vs.retrieve(serialized_value, Dalli::Protocol::ValueSerializer::FLAG_SERIALIZED),
+        assert_equal vs.retrieve(serialized_value, Dalli::Flags::SERIALIZED),
                      deserialized_value
       end
 
       it 'raises UnmarshalError for non-serialized data' do
         assert_raises Dalli::UnmarshalError do
-          vs.retrieve(:not_serialized_value, Dalli::Protocol::ValueSerializer::FLAG_SERIALIZED)
+          vs.retrieve(:not_serialized_value, Dalli::Flags::SERIALIZED)
         end
       end
     end


### PR DESCRIPTION
## Summary

Fixes a flag collision introduced in #1041: `ValueSerializer::FLAG_UTF8` and `ValueCompressor::FLAG_COMPRESSED` were both `0x2`. When `string_fastpath: true` is passed as a per-request option on `set`, ambiguous bitflags are written to memcached:

- **UTF-8 input**: fastpath sets bit `0x2` (UTF8). On read, the compressor sees `0x2` set and calls `Zlib.inflate` on raw UTF-8 bytes → `Zlib::DataError` → `Dalli::UnmarshalError`. Every subsequent `get` raises.
- **Binary input**: compressor sets `0x2` (compressed). Reader returns decompressed bytes with the wrong encoding silently.

In Rails, `Dalli::UnmarshalError` is caught by `MemCacheStore#rescue_error_with` and returned as a silent miss, so the application re-runs and re-writes on every request. The symptom is near-equal gets, misses, and sets at high volume with ~80% hit rate — looks healthy at a glance, but every cacheable computation runs twice.

## Fix (from #1086 by @byroot)

Introduces `Dalli::Flags` to centralise the bit flag constants and assigns UTF8 to bit `0x4`, which is unambiguous alongside SERIALIZED (`0x1`) and COMPRESSED (`0x2`). These bit assignments match the de facto convention described at https://www.hjp.at/zettel/m/memcached_flags.rxml.

Note: `ValueSerializer::FLAG_SERIALIZED`, `ValueSerializer::FLAG_UTF8`, and `ValueCompressor::FLAG_COMPRESSED` are removed in favour of `Dalli::Flags::SERIALIZED`, `Dalli::Flags::COMPRESSED`, and `Dalli::Flags::UTF8`. These were internal constants, not documented public API.

## Regression test (from #1098 by @mhenrixon)

Adds an integration test covering the three failure modes that were invisible to the existing test suite (which only tested client-level `string_fastpath` without compression):

- Short UTF-8 string + `string_fastpath: true` per-request + `compress: true` client (below compression threshold — UTF8 flag misread as COMPRESSED)
- Long UTF-8 string (over threshold — both serializer and compressor contend for bit `0x2`)
- Long binary string (wrong encoding on read)
- Cross-client read: a second client without `string_fastpath` must still deserialise all three correctly (covers rolling deploys and worker-pool mismatches)

## Copilot review note

One Copilot comment on #1086 flagged that client-level `string_fastpath: true` is silently ignored — `use_string_fastpath?` only checks `req_options`, not the client's own options. This is a pre-existing gap in the feature (the existing test passes because Marshal also preserves encoding, so it doesn't verify the fast path is actually taken). Left as a separate issue to keep this PR focused on the flag collision fix.

## Test plan

- [ ] `bundle exec ruby -Itest test/integration/test_serializer.rb` — 5 runs, 34 assertions, 0 failures (new test fails on `main`, passes here)
- [ ] `bundle exec ruby -Itest test/protocol/test_value_serializer.rb` — 27 runs, 55 assertions, 0 failures
- [ ] `bundle exec rubocop` — no offenses

Co-authored-by: Jean Boussier <jean.boussier@gmail.com>
Co-authored-by: Mikael Henriksson <mikael@mhenrixon.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)