### PR TITLE
Fix client-level string_fastpath: true being silently ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Bug fixes:
   - Adds regression test covering short/long UTF-8, binary, and cross-client read scenarios
   - Thanks to Jean Boussier and Mikael Henriksson for the fix and regression test
 
+- Fix client-level `string_fastpath: true` being silently ignored (#1101)
+  - `Dalli::Client.new(servers, string_fastpath: true)` had no effect; the fast path was only taken when `string_fastpath: true` was passed as a per-request option on each `set` call
+  - Per-request option continues to take precedence over the client-level setting in both directions
+
 5.0.3
 ==========
 

--- a/lib/dalli/protocol/value_serializer.rb
+++ b/lib/dalli/protocol/value_serializer.rb
@@ -10,7 +10,8 @@ module Dalli
     ##
     class ValueSerializer
       DEFAULTS = {
-        serializer: Marshal
+        serializer: Marshal,
+        string_fastpath: false
       }.freeze
 
       OPTIONS = DEFAULTS.keys.freeze
@@ -87,7 +88,9 @@ module Dalli
       end
 
       def use_string_fastpath?(value, req_options)
-        req_options&.dig(:string_fastpath) && value.instance_of?(String)
+        fastpath = req_options&.dig(:string_fastpath)
+        fastpath = @serialization_options[:string_fastpath] if fastpath.nil?
+        fastpath && value.instance_of?(String)
       end
 
       def warn_if_marshal_default(protocol_options)

--- a/test/integration/test_serializer.rb
+++ b/test/integration/test_serializer.rb
@@ -16,7 +16,19 @@ describe 'Serializer configuration' do
 
       it 'skips the serializer for simple strings when string_fastpath is enabled' do
         memcached(p, 29_198) do |_dc, port|
-          memcache = Dalli::Client.new("127.0.0.1:#{port}", string_fastpath: true)
+          dump_calls = 0
+          spy = Module.new do
+            define_singleton_method(:dump) do |v|
+              dump_calls += 1
+              Marshal.dump(v)
+            end
+            define_singleton_method(:load) { |v| Marshal.load(v) } # rubocop:disable Security/MarshalLoad
+          end
+
+          memcache = Dalli::Client.new("127.0.0.1:#{port}",
+                                       string_fastpath: true,
+                                       serializer: spy,
+                                       silence_marshal_warning: true)
           string = 'héllø'
           memcache.set 'utf-8', string
 
@@ -29,22 +41,64 @@ describe 'Serializer configuration' do
           assert_equal binary, memcache.get('binary')
           assert_equal Encoding::BINARY, memcache.get('binary').encoding
 
+          # UTF-8 and binary bypass the serializer; assert the spy was not called.
+          assert_equal 0, dump_calls, 'serializer#dump should not be called for UTF-8 or binary strings'
+
+          # Non-UTF-8/binary encodings still go through the serializer.
           latin1 = string.encode(Encoding::ISO_8859_1)
           memcache.set 'latin1', latin1
 
+          assert_equal 1, dump_calls, 'serializer#dump should be called for non-UTF-8/binary strings'
           assert_equal latin1, memcache.get('latin1')
           assert_equal Encoding::ISO_8859_1, memcache.get('latin1').encoding
 
-          # Ensure strings that went through the fastpath are properly retreived
+          # Ensure strings written via the fastpath are properly retrieved
           # by clients without string_fastpath enabled.
-          memcache = Dalli::Client.new("127.0.0.1:#{port}", string_fastpath: false)
+          plain = Dalli::Client.new("127.0.0.1:#{port}",
+                                    string_fastpath: false,
+                                    serializer: spy,
+                                    silence_marshal_warning: true)
 
-          assert_equal string, memcache.get('utf-8')
-          assert_equal Encoding::UTF_8, memcache.get('utf-8').encoding
-          assert_equal binary, memcache.get('binary')
-          assert_equal Encoding::BINARY, memcache.get('binary').encoding
-          assert_equal latin1, memcache.get('latin1')
-          assert_equal Encoding::ISO_8859_1, memcache.get('latin1').encoding
+          assert_equal string, plain.get('utf-8')
+          assert_equal Encoding::UTF_8, plain.get('utf-8').encoding
+          assert_equal binary, plain.get('binary')
+          assert_equal Encoding::BINARY, plain.get('binary').encoding
+          assert_equal latin1, plain.get('latin1')
+          assert_equal Encoding::ISO_8859_1, plain.get('latin1').encoding
+        end
+      end
+
+      it 'respects per-request string_fastpath overriding the client-level option' do
+        memcached(p, 29_198) do |_dc, port|
+          dump_calls = 0
+          spy = Module.new do
+            define_singleton_method(:dump) do |v|
+              dump_calls += 1
+              Marshal.dump(v)
+            end
+            define_singleton_method(:load) { |v| Marshal.load(v) } # rubocop:disable Security/MarshalLoad
+          end
+
+          # Client-level true, per-request false: serializer must be called.
+          memcache = Dalli::Client.new("127.0.0.1:#{port}",
+                                       string_fastpath: true,
+                                       serializer: spy,
+                                       silence_marshal_warning: true)
+          memcache.set 'key', 'value', nil, string_fastpath: false
+
+          assert_equal 1, dump_calls, 'per-request false should override client-level true'
+          assert_equal 'value', memcache.get('key')
+
+          # Client-level false, per-request true: serializer must not be called.
+          dump_calls = 0
+          plain = Dalli::Client.new("127.0.0.1:#{port}",
+                                    string_fastpath: false,
+                                    serializer: spy,
+                                    silence_marshal_warning: true)
+          plain.set 'key2', 'value2', nil, string_fastpath: true
+
+          assert_equal 0, dump_calls, 'per-request true should override client-level false'
+          assert_equal 'value2', plain.get('key2')
         end
       end
 

--- a/test/protocol/test_value_serializer.rb
+++ b/test/protocol/test_value_serializer.rb
@@ -399,4 +399,56 @@ describe Dalli::Protocol::ValueSerializer do
       end
     end
   end
+
+  describe 'string_fastpath' do
+    let(:utf8_string)   { 'héllø' }
+    let(:binary_string) { "\0\xff".b }
+
+    describe 'client-level option' do
+      it 'is disabled by default' do
+        vs = Dalli::Protocol::ValueSerializer.new(silence_marshal_warning: true)
+        _, flags = vs.store(utf8_string, nil, 0)
+
+        assert flags.anybits?(Dalli::Flags::SERIALIZED), 'expected SERIALIZED flag when fastpath is off'
+        refute flags.anybits?(Dalli::Flags::UTF8), 'expected no UTF8 flag when fastpath is off'
+      end
+
+      it 'bypasses the serializer for UTF-8 strings when enabled' do
+        vs = Dalli::Protocol::ValueSerializer.new(string_fastpath: true, silence_marshal_warning: true)
+        value, flags = vs.store(utf8_string, nil, 0)
+
+        assert_equal utf8_string, value
+        assert flags.anybits?(Dalli::Flags::UTF8), 'expected UTF8 flag'
+        refute flags.anybits?(Dalli::Flags::SERIALIZED), 'expected no SERIALIZED flag'
+      end
+
+      it 'bypasses the serializer for binary strings when enabled' do
+        vs = Dalli::Protocol::ValueSerializer.new(string_fastpath: true, silence_marshal_warning: true)
+        value, flags = vs.store(binary_string, nil, 0)
+
+        assert_equal binary_string, value
+        refute flags.anybits?(Dalli::Flags::UTF8), 'expected no UTF8 flag for binary'
+        refute flags.anybits?(Dalli::Flags::SERIALIZED), 'expected no SERIALIZED flag for binary'
+      end
+    end
+
+    describe 'per-request option overrides client-level option' do
+      it 'per-request true overrides client-level false' do
+        vs = Dalli::Protocol::ValueSerializer.new(string_fastpath: false, silence_marshal_warning: true)
+        value, flags = vs.store(utf8_string, { string_fastpath: true }, 0)
+
+        assert_equal utf8_string, value
+        assert flags.anybits?(Dalli::Flags::UTF8)
+        refute flags.anybits?(Dalli::Flags::SERIALIZED)
+      end
+
+      it 'per-request false overrides client-level true' do
+        vs = Dalli::Protocol::ValueSerializer.new(string_fastpath: true, silence_marshal_warning: true)
+        _, flags = vs.store(utf8_string, { string_fastpath: false }, 0)
+
+        assert flags.anybits?(Dalli::Flags::SERIALIZED)
+        refute flags.anybits?(Dalli::Flags::UTF8)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #1100.

## Problem

`Dalli::Client.new(servers, string_fastpath: true)` had no effect. `use_string_fastpath?` only checked `req_options`, so the fast path was never taken for normal `client.set(key, value)` calls — only when `string_fastpath: true` was passed as a per-request option on each individual `set`.

The existing integration test at line 17 of `test_serializer.rb` didn't catch this because it only verified the round-trip result. Marshal also preserves string encoding, so the test passed whether or not the fast path was actually taken.

## Fix

Add `string_fastpath` to `ValueSerializer::DEFAULTS` and `OPTIONS` so it is stored in `@serialization_options` at init time. In `use_string_fastpath?`, fall back to the client-level value when the per-request option is absent. Per-request still takes full precedence in both directions:

- Per-request `true` overrides client-level `false`
- Per-request `false` overrides client-level `true`

## Tests

- **Existing integration test** strengthened with a serializer spy to prove the fast path is actually taken (not just that the round-trip produces the right value).
- **New integration test** covers per-request override in both directions.
- **New unit tests** cover all four combinations of client-level and per-request option values directly against `ValueSerializer#store`.

## Test plan

- [ ] `bundle exec ruby -Itest test/integration/test_serializer.rb` — 6 runs, 40 assertions, 0 failures
- [ ] `bundle exec ruby -Itest test/protocol/test_value_serializer.rb` — 32 runs, 68 assertions, 0 failures
- [ ] `bundle exec rubocop` — no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)