### PR TITLE
Prepare 5.0.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Dalli Changelog
 Unreleased
 ==========
 
+5.0.4
+==========
+
 Bug fixes:
 
 - Fix `string_fastpath` flag collision with compression (#1099)

--- a/lib/dalli/version.rb
+++ b/lib/dalli/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Dalli
-  VERSION = '5.0.3'
+  VERSION = '5.0.4'
 
   MIN_SUPPORTED_MEMCACHED_VERSION = '1.6'
 end


### PR DESCRIPTION
## Summary

- Bumps version to 5.0.4
- Moves unreleased CHANGELOG entries under the 5.0.4 heading

## Changes in this release

**Bug fixes:**

- Fix `string_fastpath` flag collision with compression (#1099) — `FLAG_UTF8` and `FLAG_COMPRESSED` shared bit `0x2`, causing `Dalli::UnmarshalError` on UTF-8 strings written with `string_fastpath: true` when compression is enabled, and silent encoding corruption for binary strings
- Fix client-level `string_fastpath: true` being silently ignored (#1101) — the fast path was only taken when the option was passed per-request; client-level configuration now works as documented

## Test plan

- [ ] `bundle exec rake` passes
- [ ] `bundle exec rubocop` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)