### PR TITLE
ResponseProcessor: constantize token sets

### DIFF
--- a/lib/dalli/protocol/response_processor.rb
+++ b/lib/dalli/protocol/response_processor.rb
@@ -23,13 +23,23 @@ module Dalli
         VERSION = 'VERSION'
         SERVER_ERROR = 'SERVER_ERROR'
 
+        T_OK = [OK].freeze
+        T_RESET = [RESET].freeze
+        T_EN_HD = [EN, HD].freeze
+        T_VERSION = [VERSION].freeze
+        T_VA_EN_HD = [VA, EN, HD].freeze
+        T_HD_NF_EX = [HD, NF, EX].freeze
+        T_HD_NS_NF_EX = [HD, NS, NF, EX].freeze
+        T_VA_NF_NS_EX = [VA, NF, NS, EX].freeze
+        T_END_TOKEN_STAT = [END_TOKEN, STAT].freeze
+
         def initialize(io_source, value_marshaller)
           @io_source = io_source
           @value_marshaller = value_marshaller
         end
 
         def meta_get_with_value(cache_nils: false)
-          tokens = error_on_unexpected!([VA, EN, HD])
+          tokens = error_on_unexpected!(T_VA_EN_HD)
           return cache_nils ? ::Dalli::NOT_FOUND : nil if tokens.first == EN
           return true unless tokens.first == VA
 
@@ -37,7 +47,7 @@ module Dalli
         end
 
         def meta_get_with_value_and_cas
-          tokens = error_on_unexpected!([VA, EN, HD])
+          tokens = error_on_unexpected!(T_VA_EN_HD)
           return [nil, 0] if tokens.first == EN
 
           cas = cas_from_tokens(tokens)
@@ -47,7 +57,7 @@ module Dalli
         end
 
         def meta_get_without_value
-          tokens = error_on_unexpected!([EN, HD])
+          tokens = error_on_unexpected!(T_EN_HD)
           tokens.first == EN ? nil : true
         end
 
@@ -63,7 +73,7 @@ module Dalli
         # Used by meta_get for comprehensive metadata retrieval.
         # Supports thundering herd protection (N/R flags) and metadata flags (h/l/u).
         def meta_get_with_metadata(cache_nils: false, return_hit_status: false, return_last_access: false)
-          tokens = error_on_unexpected!([VA, EN, HD])
+          tokens = error_on_unexpected!(T_VA_EN_HD)
           result = build_metadata_result(tokens)
           result[:hit_before] = hit_status_from_tokens(tokens) if return_hit_status
           result[:last_access] = last_access_from_tokens(tokens) if return_last_access
@@ -87,26 +97,26 @@ module Dalli
         end
 
         def meta_set_with_cas
-          tokens = error_on_unexpected!([HD, NS, NF, EX])
+          tokens = error_on_unexpected!(T_HD_NS_NF_EX)
           return false unless tokens.first == HD
 
           cas_from_tokens(tokens)
         end
 
         def meta_set_append_prepend
-          tokens = error_on_unexpected!([HD, NS, NF, EX])
+          tokens = error_on_unexpected!(T_HD_NS_NF_EX)
           return false unless tokens.first == HD
 
           true
         end
 
         def meta_delete
-          tokens = error_on_unexpected!([HD, NF, EX])
+          tokens = error_on_unexpected!(T_HD_NF_EX)
           tokens.first == HD
         end
 
         def decr_incr
-          tokens = error_on_unexpected!([VA, NF, NS, EX])
+          tokens = error_on_unexpected!(T_VA_NF_NS_EX)
           return false if [NS, EX].include?(tokens.first)
           return nil if tokens.first == NF
 
@@ -114,7 +124,7 @@ module Dalli
         end
 
         def stats
-          tokens = error_on_unexpected!([END_TOKEN, STAT])
+          tokens = error_on_unexpected!(T_END_TOKEN_STAT)
           values = {}
           while tokens.first != END_TOKEN
             values[tokens[1]] = tokens[2]
@@ -124,19 +134,19 @@ module Dalli
         end
 
         def flush
-          error_on_unexpected!([OK])
+          error_on_unexpected!(T_OK)
 
           true
         end
 
         def reset
-          error_on_unexpected!([RESET])
+          error_on_unexpected!(T_RESET)
 
           true
         end
 
         def version
-          tokens = error_on_unexpected!([VERSION])
+          tokens = error_on_unexpected!(T_VERSION)
           tokens.last
         end
 


### PR DESCRIPTION
`error_on_unexpected!([VA, EN, HD])` end up allocating the same array on every single call, which is a bit wasteful.

Instead we can avoid this allocation by using a precomputed constant. I did it for all methods for consistency, but it's also possible to only do it for the hot ones.

Also if you don't like the resulting code, one alternative is to use literal frozen arrays:

```ruby
error_on_unexpected!(['VA', 'EN', 'HD'].freeze)
```

Which on Ruby 3.4+ is allocation free: https://bugs.ruby-lang.org/issues/20684