### PR TITLE
Use `IO#gets(chomp: true)`

### DIFF
--- a/lib/dalli/protocol/connection_manager.rb
+++ b/lib/dalli/protocol/connection_manager.rb
@@ -148,7 +148,7 @@ module Dalli
       end
 
       def read_line
-        data = @sock.gets("\r\n")
+        data = @sock.gets("\r\n", chomp: true)
         error_on_request!('EOF in read_line') if data.nil?
         data
       rescue SystemCallError, *TIMEOUT_ERRORS, *SSL_ERRORS, EOFError => e

--- a/lib/dalli/protocol/meta.rb
+++ b/lib/dalli/protocol/meta.rb
@@ -290,7 +290,7 @@ module Dalli
       end
 
       def parse_multi_get_value(line, key_index, is_raw)
-        tokens = line.chomp!(TERMINATOR).split
+        tokens = line.split
         value = @connection_manager.read(tokens[1].to_i + TERMINATOR.bytesize)&.chomp!(TERMINATOR)
         raw_key = tokens[key_index]
         return unless raw_key

--- a/lib/dalli/protocol/response_processor.rb
+++ b/lib/dalli/protocol/response_processor.rb
@@ -110,7 +110,7 @@ module Dalli
           return false if [NS, EX].include?(tokens.first)
           return nil if tokens.first == NF
 
-          read_line.to_i
+          @io_source.read_line.to_i
         end
 
         def stats
@@ -239,12 +239,8 @@ module Dalli
           bitflags_token[1..]
         end
 
-        def read_line
-          @io_source.read_line&.chomp!(TERMINATOR)
-        end
-
         def next_line_to_tokens
-          line = read_line
+          line = @io_source.read_line
           line&.split || []
         end
 


### PR DESCRIPTION
Saves on chomping it ourselves later:

```ruby
>> StringIO.new("fooo\r\nbar").gets("\r\n", chomp: true)
=> "fooo"
```