### PR TITLE
Add CHANGELOG entries for #1103, #1104, #1106

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ Dalli Changelog
 Unreleased
 ==========
 
+Performance:
+
+- Avoid repeated `RUBY_ENGINE` checks on every socket read (#1103)
+  - Moved the JRuby branch from a runtime `if` inside `ConnectionManager#read` to a class-level conditional method definition, so the check happens once at load time rather than on every read call
+  - Thanks to Jean Boussier for this contribution
+
+- Eliminate per-call array allocations in `ResponseProcessor` (#1104)
+  - Token sets passed to `error_on_unexpected!` (e.g. `[VA, EN, HD]`) were allocated as new arrays on every invocation; replaced with frozen constants defined once at class load time
+  - Thanks to Jean Boussier for this contribution
+
+- Avoid string copies when building request commands in `RequestFormatter` (#1106)
+  - Changed `cmd + TERMINATOR` to `cmd << TERMINATOR`; since `cmd` is always a mutable string, the in-place append avoids copying the entire command string just to append two bytes
+  - Thanks to Jean Boussier for this contribution
+
 5.0.4
 ==========
 


### PR DESCRIPTION
## Summary

- Adds unreleased CHANGELOG entries for three performance PRs from Jean Boussier that were merged without changelog entries
- #1103: avoid repeated `RUBY_ENGINE` checks on every socket read
- #1104: eliminate per-call array allocations in `ResponseProcessor`
- #1106: avoid string copies when building request commands in `RequestFormatter`

## Test plan

- [ ] No code changes; CHANGELOG only

🤖 Generated with [Claude Code](https://claude.com/claude-code)