### PR TITLE
Minor allocation reduction in the common paths

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -14,7 +14,7 @@ Metrics/AbcSize:
 # Offense count: 9
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 335
+  Max: 350
 
 # Offense count: 4
 # Configuration parameters: CountComments, CountAsOne, AllowedMethods, AllowedPatterns.

--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -651,7 +651,7 @@ module Dalli
     # operation times out.
     ##
     # rubocop:disable Naming/MethodParameterName
-    def perform(op, key, *args)
+    def perform(op, key, ...)
       # rubocop:enable Naming/MethodParameterName
       return yield if block_given?
 
@@ -659,8 +659,14 @@ module Dalli
       key = @key_manager.validate_key(key)
 
       server = ring.server_for_key(key)
-      Instrumentation.trace(op.to_s, trace_attrs(op.to_s, key, server)) do
-        server.request(op, key, *args)
+
+      if Instrumentation.enabled?
+        op_name = op.name
+        Instrumentation.trace(op_name, trace_attrs(op_name, key, server)) do
+          server.request(op, key, ...)
+        end
+      else
+        server.request(op, key, ...)
       end
     rescue RetryableNetworkError => e
       Dalli.logger.debug { e.inspect }

--- a/lib/dalli/options.rb
+++ b/lib/dalli/options.rb
@@ -13,7 +13,7 @@ module Dalli
       obj.init_threadsafe
     end
 
-    def request(opcode, *args)
+    def request(...)
       @lock.synchronize do
         super
       end

--- a/lib/dalli/protocol/key_regularizer.rb
+++ b/lib/dalli/protocol/key_regularizer.rb
@@ -10,10 +10,8 @@ module Dalli
       # memcached supports the use of base64 hashes for keys containing
       # whitespace or non-ASCII characters, provided the 'b' flag is included in the request.
       class KeyRegularizer
-        WHITESPACE = /\s/
-
         def self.encode(key)
-          return [key, false] if key.ascii_only? && !WHITESPACE.match(key)
+          return [key, false] if key.ascii_only? && !/\s/.match?(key)
 
           strict_base64_encoded = [key].pack('m0')
           [strict_base64_encoded, true]


### PR DESCRIPTION
- Reduce allocations in Client#perform
  - Use `Symbol#name` over `Symbol#to_s`.
  - Avoid building trace attributes if tracing is disabled.
  - Use argument forwarding (...) over splatting.
- KeyRegularizer: use match? to avoid MatData allocation
- Dalli::ThreadSafe: use argument forwarding

Measuring with a simple:   `100_000.times { client.get(key) }` (no compression nor serialization).

Before: `507.50 MB (1900036 objects)`
After: `475.50 MB (1400036 objects)`

So -26% objects allocated / -6% memory allocated.

NB:  There some more to squeeze, but here I focused on the simple, non-controversial changes.