### PR TITLE
getk_response_from_buffer: search terminator with byteindex

### DIFF
--- a/lib/dalli/protocol/response_processor.rb
+++ b/lib/dalli/protocol/response_processor.rb
@@ -174,7 +174,7 @@ module Dalli
         ##
         def getk_response_from_buffer(buf, offset = 0)
           # Find the header terminator starting from offset
-          term_idx = buf.index(TERMINATOR, offset)
+          term_idx = buf.byteindex(TERMINATOR, offset)
           return [0, nil, nil, nil, nil] unless term_idx
 
           header = buf.byteslice(offset, term_idx - offset)


### PR DESCRIPTION
Pure nitpick.

In practice it makes no difference because `buf` is always `Encoding::BINARY`, so always treated as single byte.

But since we're using that index with `byteslice` it's less surprising to query it with `byteindex`.