### PR TITLE
Get rid of unused COMPACT_THRESHOLD constant

### DIFF
--- a/lib/dalli/protocol/response_buffer.rb
+++ b/lib/dalli/protocol/response_buffer.rb
@@ -11,10 +11,6 @@ module Dalli
     # when advancing through parsed responses.
     ##
     class ResponseBuffer
-      # Compact the buffer when the consumed portion exceeds this
-      # threshold and represents more than half the buffer
-      COMPACT_THRESHOLD = 4096
-
       def initialize(io_source, response_processor)
         @io_source = io_source
         @response_processor = response_processor


### PR DESCRIPTION
Followup: https://github.com/petergoldstein/dalli/pull/1114

Just noticed I forgot it.