### PR TITLE
ResponseBuffer#process_single_getk_response avoid one allocation

### DIFF
--- a/lib/dalli/protocol/response_buffer.rb
+++ b/lib/dalli/protocol/response_buffer.rb
@@ -41,9 +41,9 @@ module Dalli
       # Attempts to process a single response from the buffer,
       # advancing the offset past the consumed bytes.
       def process_single_getk_response
-        bytes, status, cas, key, value = @response_processor.getk_response_from_buffer(@buffer, @offset)
-        @offset += bytes
-        [status, cas, key, value]
+        response = @response_processor.getk_response_from_buffer(@buffer, @offset)
+        @offset += response.pop
+        response
       end
 
       # Resets the internal buffer to an empty state,

--- a/lib/dalli/protocol/response_processor.rb
+++ b/lib/dalli/protocol/response_processor.rb
@@ -159,7 +159,7 @@ module Dalli
 
         def full_response_from_buffer(tokens, body, resp_size)
           value = @value_marshaller.retrieve(body, bitflags_from_tokens(tokens))
-          [resp_size, tokens.first == VA, cas_from_tokens(tokens), key_from_tokens(tokens), value]
+          [tokens.first == VA, cas_from_tokens(tokens), key_from_tokens(tokens), value, resp_size]
         end
 
         ##
@@ -175,7 +175,7 @@ module Dalli
         def getk_response_from_buffer(buf, offset = 0)
           # Find the header terminator starting from offset
           term_idx = buf.byteindex(TERMINATOR, offset)
-          return [0, nil, nil, nil, nil] unless term_idx
+          return [0] unless term_idx
 
           header = buf.byteslice(offset, term_idx - offset)
           tokens = header.split
@@ -186,12 +186,12 @@ module Dalli
           # This is either the response to the terminating
           # noop or, if the status is not MN, an intermediate
           # error response that needs to be discarded.
-          return [header_len, true, nil, nil, nil] if body_len.zero?
+          return [true, header_len] if body_len.zero?
 
           resp_size = header_len + body_len + TERMINATOR.length
           # The header is in the buffer, but the body is not.  As we don't have
           # a complete response, don't advance the buffer
-          return [0, nil, nil, nil, nil] unless buf.bytesize >= offset + resp_size
+          return [0] unless buf.bytesize >= offset + resp_size
 
           # The full response is in our buffer, so parse it and return
           # the values

--- a/test/protocol/test_response_buffer.rb
+++ b/test/protocol/test_response_buffer.rb
@@ -41,14 +41,14 @@ describe Dalli::Protocol::ResponseBuffer do
     it 'returns all nils when the buffer is empty' do
       buffer.read
 
-      assert_equal [nil, nil, nil, nil], buffer.process_single_getk_response
+      assert_equal [], buffer.process_single_getk_response
     end
 
     it "returns all nils if the response value hasn't yet been buffered" do
       write_pipe.write("VA 2 s2 t-1 c2 kfoo\r\nHI\r")
       buffer.read
 
-      assert_equal [nil, nil, nil, nil], buffer.process_single_getk_response
+      assert_equal [], buffer.process_single_getk_response
     end
 
     it 'returns the parsed value if it has been fully buffered' do
@@ -71,7 +71,7 @@ describe Dalli::Protocol::ResponseBuffer do
       buffer.read
 
       assert_equal [true, 2, 'foo', 'HI'], buffer.process_single_getk_response
-      assert_equal [true, nil, nil, nil], buffer.process_single_getk_response
+      assert_equal [true], buffer.process_single_getk_response
     end
   end
 end

--- a/test/protocol/test_response_processor.rb
+++ b/test/protocol/test_response_processor.rb
@@ -327,15 +327,15 @@ describe Dalli::Protocol::Meta::ResponseProcessor do
       buf = 'incomplete'
       result = processor.getk_response_from_buffer(buf)
 
-      assert_equal [0, nil, nil, nil, nil], result
+      assert_equal [0], result
     end
 
     it 'returns header info for complete response without body' do
       buf = "MN\r\n"
       result = processor.getk_response_from_buffer(buf)
 
-      assert_equal 4, result[0] # header length
-      assert result[1] # ok status
+      assert_equal 4, result.last # header length
+      assert result[0] # ok status
     end
   end
 end


### PR DESCRIPTION
Instead of allocating an entirely new array, we can just remove the one element we need and return the rest.

To avoid having to shift other elements, the `offset` is now the array's last element.

Also we skip on including trailing nils.