### PR TITLE
RequestFormatter: use frozen string literals

### DIFF
--- a/lib/dalli/protocol/request_formatter.rb
+++ b/lib/dalli/protocol/request_formatter.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 module Dalli
   module Protocol


### PR DESCRIPTION
It's unclear why they were disabled, it actually took me a long time to understand why `heap-profiler` was reporting allocations.

Looking at commit 5588d98f which introduced it, it seems the intent was to set it to `true` because the `+''` pattern was used.

Using the benchmark from: https://github.com/petergoldstein/dalli/pull/1114

Before: `Total allocated: 562.42 MB (2430020 objects)`
After :  `Total allocated: 550.42 MB (2130020 objects)`