### PR TITLE
Fix and add tests for ResponseBuffer compaction

### DIFF
--- a/lib/dalli/protocol/response_buffer.rb
+++ b/lib/dalli/protocol/response_buffer.rb
@@ -5,6 +5,10 @@ require 'timeout'
 
 module Dalli
   module Protocol
+    # Compact the buffer when the consumed portion exceeds this
+    # threshold and represents more than half the buffer
+    COMPACT_THRESHOLD = 4096
+
     ##
     # Manages the buffer for responses from memcached.
     # Uses an offset-based approach to avoid string allocations
@@ -24,10 +28,8 @@ module Dalli
           @offset = 0
           @buffer = @io_source.read_available(@buffer)
         else
-          if remaining_bytes > COMPACT_THRESHOLD && remaining_bytes < @buffer.bytesize
-            # NB: we're freezing the old buffer before slicing so Ruby doesn't
-            # have to allocate a third hidden string to be the Copy-on-Write onwer.
-            @buffer = @buffer.freeze.byteslice(@offset..)
+          if @offset > COMPACT_THRESHOLD && @offset > (@buffer.bytesize / 2)
+            @buffer.bytesplice(0, @offset, '')
             @offset = 0
           end
           @buffer << @io_source.read_available

--- a/test/protocol/test_response_buffer.rb
+++ b/test/protocol/test_response_buffer.rb
@@ -58,6 +58,36 @@ describe Dalli::Protocol::ResponseBuffer do
       assert_equal [true, 2, 'foo', 'HI'], buffer.process_single_getk_response
     end
 
+    it 'returns the parsed value if it has been fully buffered on a subsequent read' do
+      write_pipe.write("VA 2 s2 t-1 c2 kfoo\r\nHI\r")
+      buffer.read
+
+      assert_equal [nil, nil, nil, nil], buffer.process_single_getk_response
+
+      write_pipe.write("\nVA 2 s5 t-1 c2 kfoo\r\nHELLO\r\ngarbage")
+      buffer.read
+
+      assert_equal [true, 2, 'foo', 'HI'], buffer.process_single_getk_response
+      assert_equal [true, 2, 'foo', 'HELLO'], buffer.process_single_getk_response
+    end
+
+    it 'compacts the buffer when it has largely been read' do
+      long_value = 'A' * 10_000
+      write_pipe.write("VA 2 s#{long_value.bytesize} t-1 c3424234 kfoo\r\n#{long_value}")
+      write_pipe.write("VA 2 s2 t-1 c2 kfoo\r\nHI\r") # missing one byte
+      buffer.read
+
+      assert_equal [true, 3_424_234, 'foo', long_value], buffer.process_single_getk_response
+      assert_equal [nil, nil, nil, nil], buffer.process_single_getk_response
+      write_pipe.write("\n") # add the missing byte
+
+      assert_equal 10_055, buffer.instance_variable_get(:@buffer).bytesize
+      buffer.read
+
+      assert_equal 23, buffer.instance_variable_get(:@buffer).bytesize
+      assert_equal [false, 2, 'foo', 'HI'], buffer.process_single_getk_response
+    end
+
     it 'advances the offset' do
       write_pipe.write("VA 2 s2 t-1 c2 kfoo\r\nHI\r\nVA 2 s5 t-1 c2 kfoo\r\nHELLO\r\ngarbage")
       buffer.read


### PR DESCRIPTION
Fix: https://github.com/petergoldstein/dalli/pull/1116

Removing the constant was a mistake, it was indeed in use just not covered.

I added some tests specifically for it now, and fixed the logic as well as improved the buffer shrinking method using `String#bytesplice` which should translate into a `memmove`.