### PR TITLE
Return the number of keys deleted from `delete_multi`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -14,7 +14,7 @@ Metrics/AbcSize:
 # Offense count: 7
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 338
+  Max: 342
 
 # Offense count: 1
 # Configuration parameters: CountComments, Max, CountAsOne, AllowedMethods, AllowedPatterns.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,14 @@ Performance:
   - Accompanied by new unit tests for `ResponseBuffer` (#1115)
   - Thanks to Jean Boussier for this contribution
 
+Features:
+
+- `delete_multi` now returns the number of keys found and deleted (#1126)
+  - Previously the return value was unspecified; callers (e.g. Rails, see rails/rails#58071) had no way to tell how many keys were actually removed
+  - The count is derived from the meta protocol's quiet-mode delete responses with no extra round-trips: successful deletes are suppressed while misses report `NF`, so any response received before the terminator is a key that was not deleted
+  - The single-server fast path now shares the pipelined path's bounded retry on transient (`RetryableNetworkError`) network errors, so both paths behave consistently; the returned count is best-effort and may under-report if a network error triggers a retry, since keys deleted before the error are not recounted
+  - Thanks to Iliana Hadzhiatanasova for this contribution
+
 Bug Fixes:
 
 - Fix `ResponseBuffer` compaction logic (#1119)
@@ -62,6 +70,11 @@ Maintenance:
 - Use `String#byteindex` instead of `String#index` when searching for the response terminator in `getk_response_from_buffer` (#1112)
   - The result feeds directly into `byteslice`; `byteindex` makes the intent explicit, though both return the same value since the buffer encoding is always `BINARY`
   - Thanks to Jean Boussier for this contribution
+
+- Make single-server fast path tests actually exercise the fast path (#1127)
+  - The batch-operation tests built clients through a helper that registers two address aliases for the same memcached process, so every client had a 2-server ring and the tests always ran through the pipelined path instead of the single-server fast path
+  - Adds a `single_server_client` test helper that builds a client with a single address, and uses it in the affected `get_multi`, `set_multi`, and `delete_multi` tests
+  - Thanks to Iliana Hadzhiatanasova for this contribution
 
 5.0.5
 ==========

--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -364,7 +364,10 @@ module Dalli
     # it batches requests by server and uses quiet mode.
     #
     # @param keys [Array<String>] keys to delete
-    # @return [Integer] the number of keys that were found and deleted
+    # @return [Integer] the number of keys that were found and deleted. This is
+    #   best-effort: on a network error the operation is retried, and keys
+    #   deleted before the error are not recounted, so the result may
+    #   under-report the number actually removed when a failure occurs.
     #
     # Example:
     #   client.delete_multi(['key1', 'key2', 'key3'])
@@ -572,6 +575,13 @@ module Dalli
       return 0 unless (server = single_server)
 
       server.request(:delete_multi_req, validated_keys)
+    rescue Dalli::RetryableNetworkError => e
+      # Mirror the pipelined path: retry transient errors so a momentary blip
+      # still yields a real count. Bounded by the server's socket_max_failures,
+      # after which a hard NetworkError is raised and handled below.
+      Dalli.logger.debug { e.inspect }
+      Dalli.logger.debug { 'retrying single-server delete_multi because of network error' }
+      retry
     rescue Dalli::NetworkError
       0
     end

--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -364,12 +364,12 @@ module Dalli
     # it batches requests by server and uses quiet mode.
     #
     # @param keys [Array<String>] keys to delete
-    # @return [void]
+    # @return [Integer] the number of keys that were found and deleted
     #
     # Example:
     #   client.delete_multi(['key1', 'key2', 'key3'])
     def delete_multi(keys)
-      return if keys.empty?
+      return 0 if keys.empty?
 
       Instrumentation.trace('delete_multi', multi_trace_attrs('delete_multi', keys.size, keys)) do
         if ring.servers.size == 1
@@ -569,11 +569,11 @@ module Dalli
 
     def single_server_delete_multi(keys)
       validated_keys = keys.map { |k| @key_manager.validate_key(k.to_s) }
-      return unless (server = single_server)
+      return 0 unless (server = single_server)
 
       server.request(:delete_multi_req, validated_keys)
     rescue Dalli::NetworkError
-      nil
+      0
     end
 
     def get_multi_attributes(keys)

--- a/lib/dalli/pipelined_deleter.rb
+++ b/lib/dalli/pipelined_deleter.rb
@@ -16,7 +16,10 @@ module Dalli
     # Deletes multiple keys from memcached.
     #
     # @param keys [Array<String>] keys to delete
-    # @return [Integer] the number of keys that were deleted
+    # @return [Integer] the number of keys that were deleted. This is
+    #   best-effort: on a network error the operation is retried, and keys
+    #   deleted before the error are not recounted, so the result may
+    #   under-report the number actually removed when a failure occurs.
     ##
     def process(keys)
       return 0 if keys.empty?
@@ -25,7 +28,7 @@ module Dalli
         groups = setup_requests(keys)
         finish_requests(groups)
       end
-    rescue NetworkError => e
+    rescue Dalli::RetryableNetworkError => e
       Dalli.logger.debug { e.inspect }
       Dalli.logger.debug { 'retrying pipelined deletes because of network error' }
       retry

--- a/lib/dalli/pipelined_deleter.rb
+++ b/lib/dalli/pipelined_deleter.rb
@@ -16,14 +16,14 @@ module Dalli
     # Deletes multiple keys from memcached.
     #
     # @param keys [Array<String>] keys to delete
-    # @return [void]
+    # @return [Integer] the number of keys that were deleted
     ##
     def process(keys)
-      return if keys.empty?
+      return 0 if keys.empty?
 
       @ring.lock do
-        servers = setup_requests(keys)
-        finish_requests(servers)
+        groups = setup_requests(keys)
+        finish_requests(groups)
       end
     rescue NetworkError => e
       Dalli.logger.debug { e.inspect }
@@ -36,7 +36,7 @@ module Dalli
     def setup_requests(keys)
       groups = groups_for_keys(keys)
       make_delete_requests(groups)
-      groups.keys
+      groups
     end
 
     ##
@@ -45,24 +45,28 @@ module Dalli
     ##
     def make_delete_requests(groups)
       groups.each do |server, keys_for_server|
-        keys_for_server.each do |key|
+        keys_for_server.select! do |key|
           server.request(:pipelined_delete, key)
+          true
         rescue DalliError, NetworkError => e
           Dalli.logger.debug { e.inspect }
           Dalli.logger.debug { "unable to delete key #{key} for server #{server.name}" }
+          false
         end
       end
     end
 
     ##
     # Sends noop to each server to flush responses and ensure all deletes complete.
+    # Returns the total successful deletes across servers.
     ##
-    def finish_requests(servers)
-      servers.each do |server|
-        server.request(:noop)
+    def finish_requests(groups)
+      groups.sum do |server, keys_for_server|
+        server.request(:finish_pipelined_delete, keys_for_server.size)
       rescue DalliError, NetworkError => e
         Dalli.logger.debug { e.inspect }
         Dalli.logger.debug { "unable to complete pipelined delete on server #{server.name}" }
+        0
       end
     end
 

--- a/lib/dalli/protocol/meta.rb
+++ b/lib/dalli/protocol/meta.rb
@@ -181,7 +181,7 @@ module Dalli
 
       def finish_pipelined_delete(sent)
         write_noop
-        sent - response_processor.pipelined_delete_misses
+        sent - response_processor.pipelined_delete_non_deletions
       end
 
       # Arithmetic Commands
@@ -290,7 +290,7 @@ module Dalli
         buffer = RequestFormatter.multi_meta_delete(keys)
         flushed_write(buffer)
         buffer.clear
-        keys.size - response_processor.pipelined_delete_misses
+        keys.size - response_processor.pipelined_delete_non_deletions
       end
 
       require_relative 'key_regularizer'

--- a/lib/dalli/protocol/meta.rb
+++ b/lib/dalli/protocol/meta.rb
@@ -179,6 +179,11 @@ module Dalli
         write(req)
       end
 
+      def finish_pipelined_delete(sent)
+        write_noop
+        sent - response_processor.pipelined_delete_misses
+      end
+
       # Arithmetic Commands
       def decr(key, count, ttl, initial)
         decr_incr false, key, count, ttl, initial
@@ -285,7 +290,7 @@ module Dalli
         buffer = RequestFormatter.multi_meta_delete(keys)
         flushed_write(buffer)
         buffer.clear
-        response_processor.consume_all_responses_until_mn
+        keys.size - response_processor.pipelined_delete_misses
       end
 
       require_relative 'key_regularizer'

--- a/lib/dalli/protocol/response_processor.rb
+++ b/lib/dalli/protocol/response_processor.rb
@@ -157,6 +157,16 @@ module Dalli
           true
         end
 
+        def pipelined_delete_misses
+          misses = 0
+          tokens = next_line_to_tokens
+          until tokens.first == MN
+            misses += 1 if tokens.first == NF
+            tokens = next_line_to_tokens
+          end
+          misses
+        end
+
         def full_response_from_buffer(tokens, body, resp_size)
           value = @value_marshaller.retrieve(body, bitflags_from_tokens(tokens))
           [tokens.first == VA, cas_from_tokens(tokens), key_from_tokens(tokens), value, resp_size]

--- a/lib/dalli/protocol/response_processor.rb
+++ b/lib/dalli/protocol/response_processor.rb
@@ -157,14 +157,21 @@ module Dalli
           true
         end
 
-        def pipelined_delete_misses
-          misses = 0
+        # Consumes the responses to a batch of quiet (pipelined) delete
+        # requests, which are terminated by a noop (MN). In quiet mode
+        # memcached suppresses the success response for each deleted key, so
+        # every line received before the terminator corresponds to a key that
+        # was NOT deleted -- a miss (NF) or an error. Returns that count so
+        # callers can derive the number of successful deletes as
+        # (keys_sent - non_deletions).
+        def pipelined_delete_non_deletions
+          non_deletions = 0
           tokens = next_line_to_tokens
           until tokens.first == MN
-            misses += 1 if tokens.first == NF
+            non_deletions += 1
             tokens = next_line_to_tokens
           end
-          misses
+          non_deletions
         end
 
         def full_response_from_buffer(tokens, body, resp_size)

--- a/test/integration/test_pipelined_delete.rb
+++ b/test/integration/test_pipelined_delete.rb
@@ -112,6 +112,54 @@ describe 'Pipelined Delete' do
             assert_equal 1, dc.delete_multi(%w[del_key1 missing_key])
           end
         end
+
+        it 'retries on a transient (retryable) network error and returns the real count' do
+          memcached_persistent(p) do |_, port|
+            dc = single_server_client(port)
+            dc.flush
+
+            dc.set('del_key1', 'value1')
+            dc.set('del_key2', 'value2')
+
+            server = dc.send(:ring).servers.first
+            original_request = server.method(:request)
+            attempts = 0
+            flaky_request = lambda do |opkey, *args|
+              if opkey == :delete_multi_req
+                attempts += 1
+                raise Dalli::RetryableNetworkError, 'transient blip' if attempts == 1
+              end
+
+              original_request.call(opkey, *args)
+            end
+
+            server.stub(:request, flaky_request) do
+              assert_equal 2, dc.delete_multi(%w[del_key1 del_key2])
+            end
+
+            assert_equal 2, attempts
+          end
+        end
+
+        it 'returns 0 on a terminal (non-retryable) network error' do
+          memcached_persistent(p) do |_, port|
+            dc = single_server_client(port)
+            dc.flush
+
+            dc.set('del_key1', 'value1')
+
+            server = dc.send(:ring).servers.first
+            failing_request = lambda do |opkey, *args|
+              raise Dalli::NetworkError, 'localhost is down' if opkey == :delete_multi_req
+
+              raise "unexpected request: #{opkey}, #{args.inspect}"
+            end
+
+            server.stub(:request, failing_request) do
+              assert_equal 0, dc.delete_multi(%w[del_key1])
+            end
+          end
+        end
       end
 
       describe 'multi-server delete_multi pipelined path' do

--- a/test/integration/test_pipelined_delete.rb
+++ b/test/integration/test_pipelined_delete.rb
@@ -89,6 +89,91 @@ describe 'Pipelined Delete' do
             assert_nil dc.get('del_bulk_99')
           end
         end
+
+        it 'returns the number of keys that were deleted' do
+          memcached_persistent(p) do |_, port|
+            dc = single_server_client(port)
+            dc.flush
+
+            dc.set('del_key1', 'value1')
+            dc.set('del_key2', 'value2')
+
+            assert_equal 2, dc.delete_multi(%w[del_key1 del_key2])
+          end
+        end
+
+        it 'does not count keys that were not found' do
+          memcached_persistent(p) do |_, port|
+            dc = single_server_client(port)
+            dc.flush
+
+            dc.set('del_key1', 'value1')
+
+            assert_equal 1, dc.delete_multi(%w[del_key1 missing_key])
+          end
+        end
+      end
+
+      describe 'multi-server delete_multi pipelined path' do
+        it 'aggregates the number of keys deleted per server' do
+          memcached_persistent(p) do |dc|
+            ring = dc.send(:ring)
+
+            assert_equal 2, ring.servers.size
+
+            dc.flush
+
+            keys = (0...6).map { |i| "multi_del_#{i}" }
+            keys.each { |k| dc.set(k, 'value') }
+
+            assert_equal 2, keys.map { |k| ring.server_for_key(k) }.uniq.size
+            assert_equal 6, dc.delete_multi(keys)
+          end
+        end
+
+        it 'does not count keys that were not found' do
+          memcached_persistent(p) do |dc|
+            ring = dc.send(:ring)
+
+            assert_equal 2, ring.servers.size
+
+            dc.flush
+
+            keys = (0...6).map { |i| "multi_del_#{i}" }
+            keys.each { |k| dc.set(k, 'value') }
+
+            assert_equal 2, keys.map { |k| ring.server_for_key(k) }.uniq.size
+            assert_equal 6, dc.delete_multi(keys + ['missing_key'])
+          end
+        end
+
+        it 'does not count keys that fail to enqueue' do
+          memcached_persistent(p) do |dc|
+            ring = dc.send(:ring)
+            dc.flush
+
+            dc.set('successful_key', 'value1')
+            dc.set('failing_key', 'value2')
+
+            failing_key_server = ring.server_for_key('failing_key')
+
+            original_request = failing_key_server.method(:request)
+            failing_request = lambda do |opkey, *args|
+              if opkey == :pipelined_delete && args.first == 'failing_key'
+                raise Dalli::DalliError,
+                      'error writing request'
+              end
+
+              original_request.call(opkey, *args)
+            end
+
+            failing_key_server.stub(:request, failing_request) do
+              assert_equal 1, dc.delete_multi(%w[successful_key failing_key])
+            end
+
+            assert_equal 'value2', dc.get('failing_key')
+          end
+        end
       end
     end
   end

--- a/test/protocol/test_response_processor.rb
+++ b/test/protocol/test_response_processor.rb
@@ -300,6 +300,33 @@ describe Dalli::Protocol::Meta::ResponseProcessor do
     end
   end
 
+  describe '#pipelined_delete_non_deletions' do
+    it 'returns 0 when every delete succeeded (all responses suppressed)' do
+      expect_read_line('MN')
+
+      assert_equal 0, processor.pipelined_delete_non_deletions
+      io_source.verify
+    end
+
+    it 'counts NF misses' do
+      expect_read_line('NF')
+      expect_read_line('NF')
+      expect_read_line('MN')
+
+      assert_equal 2, processor.pipelined_delete_non_deletions
+      io_source.verify
+    end
+
+    it 'counts error responses as non-deletions, not just NF misses' do
+      expect_read_line('NF')
+      expect_read_line('CLIENT_ERROR bad command line format')
+      expect_read_line('MN')
+
+      assert_equal 2, processor.pipelined_delete_non_deletions
+      io_source.verify
+    end
+  end
+
   describe 'error handling' do
     it 'raises DalliError for unexpected response' do
       expect_read_line('UNEXPECTED')


### PR DESCRIPTION
`delete_multi` currently returns nothing so callers can't tell how many keys were actually deleted. 
This came up while adding `delete_multi` support to Rails (https://github.com/rails/rails/pull/58071)

`delete_multi` uses quiet mode which suppresses success responses per key, but a miss is still reported as
`NF`, so the deleted count is available without any extra round-trips. 

 This PR changes `delete_multi` to return the number of keys found and deleted.