### PR TITLE
Make single-server fast path tests actually use a single server

### DIFF
--- a/test/helpers/memcached.rb
+++ b/test/helpers/memcached.rb
@@ -66,6 +66,10 @@ module Memcached
       MemcachedManager.stop(port_or_socket)
     end
 
+    def single_server_client(port, client_options = {})
+      Dalli::Client.new("localhost:#{port}", client_options)
+    end
+
     private
 
     def fork_mock_process(prc, meth, meth_args)

--- a/test/integration/test_pipelined_delete.rb
+++ b/test/integration/test_pipelined_delete.rb
@@ -7,7 +7,8 @@ describe 'Pipelined Delete' do
     describe "using the #{p} protocol" do
       describe 'single-server delete_multi fast path' do
         it 'deletes multiple keys' do
-          memcached_persistent(p) do |dc|
+          memcached_persistent(p) do |_, port|
+            dc = single_server_client(port)
             dc.flush
 
             dc.set('d1', 'v1')
@@ -25,13 +26,15 @@ describe 'Pipelined Delete' do
         end
 
         it 'handles empty array' do
-          memcached_persistent(p) do |dc|
+          memcached_persistent(p) do |_, port|
+            dc = single_server_client(port)
             dc.delete_multi([])
           end
         end
 
         it 'handles non-existent keys' do
-          memcached_persistent(p) do |dc|
+          memcached_persistent(p) do |_, port|
+            dc = single_server_client(port)
             dc.flush
 
             dc.delete_multi(%w[nonexistent1 nonexistent2])
@@ -39,7 +42,8 @@ describe 'Pipelined Delete' do
         end
 
         it 'only deletes specified keys' do
-          memcached_persistent(p) do |dc|
+          memcached_persistent(p) do |_, port|
+            dc = single_server_client(port)
             dc.flush
 
             dc.set('keep', 'keep_val')
@@ -53,7 +57,8 @@ describe 'Pipelined Delete' do
         end
 
         it 'handles Unicode and space keys' do
-          memcached_persistent(p) do |dc|
+          memcached_persistent(p) do |_, port|
+            dc = single_server_client(port)
             dc.flush
 
             dc.set('contains space', 'space_val')
@@ -67,7 +72,8 @@ describe 'Pipelined Delete' do
         end
 
         it 'handles large batch' do
-          memcached_persistent(p) do |dc|
+          memcached_persistent(p) do |_, port|
+            dc = single_server_client(port)
             dc.flush
 
             keys = []

--- a/test/integration/test_pipelined_get.rb
+++ b/test/integration/test_pipelined_get.rb
@@ -105,7 +105,9 @@ describe 'Pipelined Get' do
 
       describe 'single-server get_multi fast path' do
         it 'returns correct results via the fast path' do
-          memcached_persistent(p) do |dc|
+          memcached_persistent(p) do |_, port|
+            dc = single_server_client(port)
+
             dc.flush
 
             dc.set('a', 'foo')
@@ -120,7 +122,9 @@ describe 'Pipelined Get' do
         end
 
         it 'returns correct results with raw mode' do
-          memcached_persistent(p, 21_345, '', raw: true) do |dc|
+          memcached_persistent(p, 21_345, '', raw: true) do |_, port|
+            dc = single_server_client(port)
+
             dc.flush
 
             dc.set('x', 'hello')
@@ -133,7 +137,9 @@ describe 'Pipelined Get' do
         end
 
         it 'returns correct results with namespace' do
-          memcached_persistent(p, 21_345, '', namespace: 'ns') do |dc|
+          memcached_persistent(p, 21_345, '', namespace: 'ns') do |_, port|
+            dc = single_server_client(port)
+
             dc.flush
 
             dc.set('a', 'val_a')
@@ -146,7 +152,9 @@ describe 'Pipelined Get' do
         end
 
         it 'handles all misses' do
-          memcached_persistent(p) do |dc|
+          memcached_persistent(p) do |_, port|
+            dc = single_server_client(port)
+
             dc.flush
 
             resp = dc.get_multi(%w[miss1 miss2 miss3])
@@ -156,7 +164,9 @@ describe 'Pipelined Get' do
         end
 
         it 'handles Unicode and space keys via fast path' do
-          memcached_persistent(p) do |dc|
+          memcached_persistent(p) do |_, port|
+            dc = single_server_client(port)
+
             dc.flush
 
             dc.set('contains space', 'space_val')
@@ -169,7 +179,9 @@ describe 'Pipelined Get' do
         end
 
         it 'still uses block-based get_multi via PipelinedGetter' do
-          memcached_persistent(p) do |dc|
+          memcached_persistent(p) do |_, port|
+            dc = single_server_client(port)
+
             dc.flush
 
             dc.set('a', 'foo')

--- a/test/integration/test_pipelined_set.rb
+++ b/test/integration/test_pipelined_set.rb
@@ -7,7 +7,8 @@ describe 'Pipelined Set' do
     describe "using the #{p} protocol" do
       describe 'single-server set_multi fast path' do
         it 'sets multiple key-value pairs' do
-          memcached_persistent(p) do |dc|
+          memcached_persistent(p) do |_, port|
+            dc = single_server_client(port)
             dc.flush
 
             hash = { 'a' => 'foo', 'b' => 123, 'c' => %w[x y z] }
@@ -20,7 +21,8 @@ describe 'Pipelined Set' do
         end
 
         it 'sets with custom TTL' do
-          memcached_persistent(p) do |dc|
+          memcached_persistent(p) do |_, port|
+            dc = single_server_client(port)
             dc.flush
 
             dc.set_multi({ 'ttl1' => 'val1', 'ttl2' => 'val2' }, 300)
@@ -31,7 +33,8 @@ describe 'Pipelined Set' do
         end
 
         it 'sets with raw mode' do
-          memcached_persistent(p, 21_345, '', raw: true) do |dc|
+          memcached_persistent(p) do |_, port|
+            dc = single_server_client(port, raw: true)
             dc.flush
 
             dc.set_multi({ 'r1' => 'raw_val1', 'r2' => 'raw_val2' }, 300)
@@ -42,13 +45,15 @@ describe 'Pipelined Set' do
         end
 
         it 'handles empty hash' do
-          memcached_persistent(p) do |dc|
+          memcached_persistent(p) do |_, port|
+            dc = single_server_client(port)
             dc.set_multi({})
           end
         end
 
         it 'handles large batch' do
-          memcached_persistent(p) do |dc|
+          memcached_persistent(p) do |_, port|
+            dc = single_server_client(port)
             dc.flush
 
             hash = {}
@@ -61,7 +66,8 @@ describe 'Pipelined Set' do
         end
 
         it 'works with get_multi round-trip' do
-          memcached_persistent(p) do |dc|
+          memcached_persistent(p) do |_, port|
+            dc = single_server_client(port)
             dc.flush
 
             hash = { 'rt1' => 'v1', 'rt2' => 'v2', 'rt3' => 'v3' }


### PR DESCRIPTION
The tests for the single server fast path batch methods used test helpers that build clients with two address aliases for the same memcached process (https://github.com/petergoldstein/dalli/blob/main/test/utils/memcached_manager.rb#L43-L47), so every client got a 2 server ring and batch operations were always going through the pipelined path. 

Add a `single_server_client` test helper that builds a client with a single address, and use it in those tests so they actually hit the fast path.