### PR TITLE
Disable rubocop metrics cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,13 +19,8 @@ AllCops:
     - 'bin/benchmark_*'
     - 'vendor/**/*'
 
-Metrics/BlockLength:
-  Max: 50
-  Exclude:
-    - 'test/**/*'
-
-Metrics/MethodLength:
-  Max: 20
+Metrics:
+  Enabled: false
 
 Style/Documentation:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,29 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 2
-# Configuration parameters: AllowedMethods, AllowedPatterns, CountRepeatedAttributes.
-Metrics/AbcSize:
-  Max: 19
-
-# Offense count: 7
-# Configuration parameters: CountComments, CountAsOne.
-Metrics/ClassLength:
-  Max: 342
-
-# Offense count: 1
-# Configuration parameters: CountComments, Max, CountAsOne, AllowedMethods, AllowedPatterns.
-Metrics/MethodLength:
-  Exclude:
-    - 'lib/dalli/socket.rb'
-
-# Offense count: 2
-# Configuration parameters: CountComments, CountAsOne.
-Metrics/ModuleLength:
-  Max: 128
-
-# Offense count: 1
-# Configuration parameters: AllowedClasses.
 Style/OneClassPerFile:
   Exclude:
     - 'test/helper.rb'

--- a/bin/benchmark
+++ b/bin/benchmark
@@ -121,9 +121,6 @@ class GCSuite
 end
 suite = GCSuite.new
 
-# rubocop:disable Metrics/PerceivedComplexity
-# rubocop:disable Metrics/AbcSize
-# rubocop:disable Metrics/CyclomaticComplexity
 def sock_get_multi(sock, pairs)
   count = pairs.length
   pairs.each_key do |key|

--- a/bin/profile
+++ b/bin/profile
@@ -76,9 +76,6 @@ client.quiet do
   end
 end
 
-# rubocop:disable Metrics/PerceivedComplexity
-# rubocop:disable Metrics/AbcSize
-# rubocop:disable Metrics/CyclomaticComplexity
 def sock_get_multi(sock, pairs)
   count = pairs.length
   pairs.each_key do |key|

--- a/lib/dalli/protocol/base.rb
+++ b/lib/dalli/protocol/base.rb
@@ -95,7 +95,6 @@ module Dalli
       # When a block is given, yields (key, value, cas) for each response,
       # avoiding intermediate Hash allocation. Returns nil.
       # Without a block, returns a Hash of { key => [value, cas] }.
-      # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       def pipeline_next_responses(&block)
         reconnect_on_pipeline_complete!
         values = nil

--- a/lib/dalli/protocol/meta.rb
+++ b/lib/dalli/protocol/meta.rb
@@ -132,7 +132,6 @@ module Dalli
         response_processor.meta_set_with_cas unless quiet?
       end
 
-      # rubocop:disable Metrics/ParameterLists
       def write_storage_req(mode, key, raw_value, ttl = nil, cas = nil, options = {}, quiet: quiet?)
         (value, bitflags) = @value_marshaller.store(key, raw_value, options)
         ttl = TtlSanitizer.sanitize(ttl) if ttl

--- a/lib/dalli/protocol/request_formatter.rb
+++ b/lib/dalli/protocol/request_formatter.rb
@@ -14,9 +14,6 @@ module Dalli
         # Rubocop directives.  We really can't make this construction much simpler,
         # and introducing an intermediate object seems like overkill.
         #
-        # rubocop:disable Metrics/CyclomaticComplexity
-        # rubocop:disable Metrics/ParameterLists
-        # rubocop:disable Metrics/PerceivedComplexity
         #
         # Meta get flags:
         #

--- a/lib/dalli/socket.rb
+++ b/lib/dalli/socket.rb
@@ -48,7 +48,6 @@ module Dalli
       # JRuby doesn't support IO#timeout=, so use custom readfull implementation
       # CRuby 3.3+ has IO#timeout= which makes IO#read work with timeouts
       if RUBY_ENGINE == 'jruby'
-        # rubocop:disable Metrics/AbcSize
         def readfull(count)
           value = String.new(capacity: count + 1)
 

--- a/test/helpers/memcached.rb
+++ b/test/helpers/memcached.rb
@@ -45,7 +45,6 @@ module Memcached
     # Launches a memcached process using the memcached method in this module,
     # but sets terminate_process to false ensuring that the process persists
     # past execution of the block argument.
-    # rubocop:disable Metrics/ParameterLists
     def memcached_persistent(protocol = :meta, port_or_socket = 21_345, args = '', client_options = {}, &)
       memcached(protocol, port_or_socket, args, client_options, terminate_process: false, &)
     end


### PR DESCRIPTION
As discussed in https://github.com/petergoldstein/dalli/pull/1126 they're not really useful, they always end up being disabled or bumped.