### PR TITLE
Apply Shopify changes on top of upstream Dalli 5

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -3,6 +3,7 @@ name: Benchmarks
 on:
   push:
     branches: [main]
+  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -12,10 +13,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v7
-    - name: Install Memcached 1.6.23
+    - name: Install Memcached 1.6.41
       working-directory: scripts
       env:
-        MEMCACHED_VERSION: 1.6.23
+        MEMCACHED_VERSION: 1.6.41
       run: |
         chmod +x ./install_memcached.sh
         ./install_memcached.sh

--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v7
-    - name: Install Memcached 1.6.23
+    - name: Install Memcached 1.6.41
       working-directory: scripts
       env:
-        MEMCACHED_VERSION: 1.6.23
+        MEMCACHED_VERSION: 1.6.41
       run: |
         chmod +x ./install_memcached.sh
         ./install_memcached.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
           - '3.3'
           - jruby-10
           - truffleruby
-        memcached-version: ['1.6.40']
+        memcached-version: ['1.6.41']
 
     name: "Ruby ${{ matrix.ruby-version }} / Memcached ${{ matrix.memcached-version }}"
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ profile.html
 ## Environment normalisation:
 /.bundle/
 /lib/bundler/man/
+dev.yml
 
 # for a library or gem, you might want to ignore these files since the code is
 # intended to run in multiple environments; otherwise, check them in:

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,6 +1,6 @@
 fix: false               # default: false
 parallel: true          # default: false
-ruby_version: 3.1       # default: RUBY_VERSION
+ruby_version: 3.3.0     # default: RUBY_VERSION
 default_ignores: false  # default: true
 
 ignore:                 # default: []

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,46 @@
 Dalli Changelog
 =====================
 
+Shopify fork (on top of upstream 5.0.5)
+==========
+
+Features:
+
+- Add opaque routing tokens `:p_token` / `:l_token` as per-request options on all
+  operations (get, gat, get_cas, get_with_metadata, fetch_with_lock, set, add,
+  replace, append, prepend, delete, incr, decr, and all multi/pipelined paths).
+  Tokens are appended to the wire as `P<token>` / `L<token>` for consumption by
+  intermediate proxies. CRLF/NUL bytes are rejected to prevent wire-protocol
+  injection; empty tokens are treated as no-ops. (Shopify#70, Shopify#72)
+- Add tombstone (mark-stale) support to `delete` / `delete_cas` / `delete_multi`
+  via the `:invalidate`, `:tombstone_ttl` and `:drop_value` request options
+  (meta-protocol `I`, `T` and `x` flags on `md`). A tombstoned item lives in a
+  stale window so concurrent readers can tell a racing repopulate apart from a
+  true miss. (Shopify#73)
+- `get_with_metadata` now returns an explicit `:miss` marker, accepts routing
+  tokens, and supports `return_ttl_remaining:` to fetch the item's remaining TTL
+  (`:ttl_remaining`, `-1` when the item has no expiry). (Shopify#73)
+- Add `get_multi_with_metadata` for stale-aware bulk reads. Returns a metadata
+  Hash (`:value`, `:cas`, `:stale`, `:miss`) for every requested key, including
+  misses, so callers can distinguish a true miss from a tombstone per key.
+  (Shopify#73)
+
+Bug Fixes:
+
+- Ensure fixed-length response reads consume exactly the requested number of
+  bytes or fail. A peer closing the connection mid-response now raises and
+  closes the dirty socket for a retry instead of surfacing a truncated value.
+  (Shopify#77)
+- Tear down the connection when a non-StandardError (e.g. `Async::Stop`,
+  `Thread#kill`) escapes a request or interrupts `ConnectionManager#close`, so
+  a half-used connection is never returned to the pool. (Shopify#68, Shopify#69,
+  Shopify#71)
+
+Performance:
+
+- Quiet-mode `ms` requests no longer include the cas-return flag, saving two
+  bytes per pipelined set.
+
 Unreleased
 ==========
 

--- a/bin/benchmark
+++ b/bin/benchmark
@@ -248,10 +248,9 @@ if %w[all set_multi].include?(bench_target)
         end
       end
     end
-    # TODO: uncomment this once we add PR adding set_multi
-    # x.report('multi client set_multi 100') do
-    #   multi_client.set_multi(pairs, 3600, raw: true)
-    # end
+    x.report('multi client set_multi 100') do
+      multi_client.set_multi(pairs, 3600, raw: true)
+    end
     x.report('write 100 keys rawsock') do
       count = pairs.length
       tail = ''
@@ -267,7 +266,16 @@ if %w[all set_multi].include?(bench_target)
       sock.flush
       sock.gets(TERMINATOR) # clear the buffer
     end
-    # x.report('write_mutli 100 keys') { client.set_multi(pairs, 3600, raw: true) }
+    x.report('write_multi 100 keys') { client.set_multi(pairs, 3600, raw: true) }
+    x.compare!
+  end
+end
+
+if %w[all delete_multi].include?(bench_target)
+  Benchmark.ips do |x|
+    x.config(warmup: bench_warmup, time: bench_time, suite: suite)
+    x.report('delete_multi 100 keys') { client.delete_multi(pairs.keys) }
+    x.report('delete 100 keys') { pairs.each_key { |key| client.delete(key) } }
     x.compare!
   end
 end

--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -75,8 +75,8 @@ module Dalli
     # Gat (get and touch) fetch an item and simultaneously update its expiration time.
     #
     # If a value is not found, then +nil+ is returned.
-    def gat(key, ttl = nil)
-      perform(:gat, key, ttl_or_default(ttl))
+    def gat(key, ttl = nil, req_options = nil)
+      perform(:gat, key, ttl_or_default(ttl), req_options)
     end
 
     ##
@@ -91,8 +91,8 @@ module Dalli
     ##
     # Get the value and CAS ID associated with the key.  If a block is provided,
     # value and CAS will be passed to the block.
-    def get_cas(key)
-      (value, cas) = perform(:cas, key)
+    def get_cas(key, req_options = nil)
+      (value, cas) = perform(:cas, key, req_options)
       return [value, cas] unless block_given?
 
       yield value, cas
@@ -106,25 +106,36 @@ module Dalli
     #   - :return_cas [Boolean] return the CAS value (default: true)
     #   - :return_hit_status [Boolean] return whether item was previously accessed
     #   - :return_last_access [Boolean] return seconds since last access
+    #   - :return_ttl_remaining [Boolean] return seconds of TTL remaining (-1 if no TTL)
     #   - :skip_lru_bump [Boolean] don't bump LRU or update access stats
+    #   - :p_token / :l_token [String] opaque routing tokens appended to the wire request
     #
     # @return [Hash] containing:
     #   - :value - the cached value (or nil on miss)
     #   - :cas - the CAS value
+    #   - :miss - true if the key does not exist. A tombstoned item (see
+    #     `#delete` with `invalidate: true`) is NOT a miss: it is returned with
+    #     `stale: true` and its value may be an empty string when the tombstone
+    #     was created with `drop_value: true`.
+    #   - :stale - true if item is stale (X flag)
+    #   - :won_recache - true if client won the recache race (W flag)
+    #   - :lost_recache - true if another client is recaching (Z flag)
     #   - :hit_before - true/false if previously accessed (only if return_hit_status: true)
     #   - :last_access - seconds since last access (only if return_last_access: true)
+    #   - :ttl_remaining - seconds of TTL remaining (only if return_ttl_remaining: true)
     #
     # @example Get with hit status
     #   result = client.get_with_metadata('key', return_hit_status: true)
-    #   # => { value: "data", cas: 123, hit_before: true }
+    #   # => { value: "data", cas: 123, miss: false, stale: false, ..., hit_before: true }
     #
     # @example Get with all metadata without affecting LRU
     #   result = client.get_with_metadata('key',
     #     return_hit_status: true,
     #     return_last_access: true,
+    #     return_ttl_remaining: true,
     #     skip_lru_bump: true
     #   )
-    #   # => { value: "data", cas: 123, hit_before: true, last_access: 42 }
+    #   # => { value: "data", cas: 123, ..., hit_before: true, last_access: 42, ttl_remaining: 300 }
     #
     def get_with_metadata(key, options = {})
       key = key.to_s
@@ -144,19 +155,69 @@ module Dalli
     # Fetch multiple keys efficiently.
     # If a block is given, yields key/value pairs one at a time.
     # Otherwise returns a hash of { 'key' => 'value', 'key2' => 'value1' }
+    # An optional trailing keyword arg hash (`req_options`) is applied to every
+    # request issued in the pipeline. Recognized entries include the opaque
+    # routing tokens `:p_token` and `:l_token`, which are appended to every
+    # `mg` line as `P<token>` / `L<token>`. The same value is applied to every
+    # key in the pipeline; per-key tokens are not supported.
+    #
+    # NOTE: `req_options` is supplied as keyword arguments here (e.g.
+    # `dc.get_multi('a', 'b', p_token: 'foo')`) because the variadic
+    # `*keys` parameter precludes a trailing positional options hash.
     # rubocop:disable Style/ExplicitBlockArgument
-    def get_multi(*keys)
+    def get_multi(*keys, **req_options)
       keys.flatten!
       keys.compact!
       return {} if keys.empty?
 
+      req_options = nil if req_options.empty?
+
       if block_given?
-        get_multi_yielding(keys) { |k, v| yield k, v }
+        get_multi_yielding(keys, req_options) { |k, v| yield k, v }
       else
-        get_multi_hash(keys)
+        get_multi_hash(keys, req_options)
       end
     end
     # rubocop:enable Style/ExplicitBlockArgument
+
+    ##
+    # Fetch multiple keys efficiently and return a stale-aware metadata Hash
+    # for every requested key.
+    #
+    # Unlike `#get_multi`, the returned hash includes misses so callers can
+    # distinguish a true miss from a tombstoned/stale item for each key. Each
+    # entry is a Hash with `:value`, `:cas`, `:stale` and `:miss` — a subset
+    # of the keys returned by the single-key `#get_with_metadata`:
+    #   { 'key' => { value: 'v', cas: 123, stale: false, miss: false },
+    #     'missing' => { value: nil, cas: 0, stale: false, miss: true } }
+    #
+    # A tombstoned item (see `#delete` with `invalidate: true`) is returned
+    # with `stale: true` and `miss: false`; its value may be an empty string
+    # when the tombstone was created with `drop_value: true`.
+    #
+    # If a block is given, yields key/result pairs one at a time for every
+    # requested key.
+    #
+    # See `#get_multi` for documentation on the `req_options` trailing keyword
+    # arguments (e.g. `p_token:` / `l_token:`).
+    def get_multi_with_metadata(*keys, **req_options, &block)
+      keys.flatten!
+      keys.compact!
+      return {} if keys.empty?
+
+      req_options = nil if req_options.empty?
+
+      results = Instrumentation.trace('get_multi_with_metadata',
+                                      multi_trace_attrs('get_multi_with_metadata', keys.size, keys)) do
+        if ring.servers.size == 1
+          single_server_get_multi_with_metadata(keys, req_options)
+        else
+          pipelined_getter.process_with_metadata(keys, req_options)
+        end
+      end
+
+      block ? results.each(&block) : results
+    end
 
     ##
     # Fetch multiple keys efficiently, including available metadata such as CAS.
@@ -164,12 +225,14 @@ module Dalli
     # [value, cas_id]
     # If no block is given, returns a hash of
     #   { 'key' => [value, cas_id] }
-    def get_multi_cas(*keys)
+    def get_multi_cas(*keys, **req_options)
+      req_options = nil if req_options.empty?
+
       if block_given?
-        pipelined_getter.process(keys) { |*args| yield(*args) }
+        pipelined_getter.process(keys, req_options) { |*args| yield(*args) }
       else
         {}.tap do |hash|
-          pipelined_getter.process(keys) { |k, data| hash[k] = data }
+          pipelined_getter.process(keys, req_options) { |k, data| hash[k] = data }
         end
       end
     end
@@ -350,12 +413,30 @@ module Dalli
 
     # Delete a key/value pair, verifying existing CAS.
     # Returns true if succeeded, and falsy otherwise.
-    def delete_cas(key, cas = 0)
-      perform(:delete, key, cas)
+    #
+    # `req_options` recognizes the same meta-delete keys as `#delete`:
+    # `:invalidate`, `:tombstone_ttl`, `:drop_value`.
+    def delete_cas(key, cas = 0, req_options = nil)
+      perform(:delete, key, cas, req_options)
     end
 
-    def delete(key)
-      delete_cas(key, 0)
+    ##
+    # Delete a key.
+    #
+    # `req_options` may include memcached meta-delete options:
+    # - `:invalidate` (Boolean) — mark the item stale instead of removing it.
+    #   This is the tombstone marker: `#get_with_metadata` returns `stale: true`, and
+    #   the existing value remains readable unless `:drop_value` is also set.
+    # - `:drop_value` (Boolean) — remove the item value but leave the item.
+    #   Alone this is not a tombstone: reads are a non-stale hit with an empty
+    #   string value.
+    # - `:invalidate` + `:drop_value` — leave a stale tombstone marker with an
+    #   empty value, so readers can distinguish it from a miss without retaining
+    #   the previous value.
+    # - `:tombstone_ttl` (Integer seconds) — how long the stale tombstone lives;
+    #   requires `:invalidate`. After this elapses, reads see `miss?`.
+    def delete(key, req_options = nil)
+      delete_cas(key, 0, req_options)
     end
 
     ##
@@ -369,16 +450,20 @@ module Dalli
     #   deleted before the error are not recounted, so the result may
     #   under-report the number actually removed when a failure occurs.
     #
+    # `req_options` is applied to every delete in the pipeline. Recognized
+    # meta-delete keys (`:invalidate`, `:tombstone_ttl`, `:drop_value`) are
+    # applied uniformly to every key in the batch — see `#delete`.
+    #
     # Example:
     #   client.delete_multi(['key1', 'key2', 'key3'])
-    def delete_multi(keys)
+    def delete_multi(keys, req_options = nil)
       return 0 if keys.empty?
 
       Instrumentation.trace('delete_multi', multi_trace_attrs('delete_multi', keys.size, keys)) do
         if ring.servers.size == 1
-          single_server_delete_multi(keys)
+          single_server_delete_multi(keys, req_options)
         else
-          pipelined_deleter.process(keys)
+          pipelined_deleter.process(keys, req_options)
         end
       end
     end
@@ -386,15 +471,15 @@ module Dalli
     ##
     # Append value to the value already stored on the server for 'key'.
     # Appending only works for values stored with :raw => true.
-    def append(key, value)
-      perform(:append, key, value.to_s)
+    def append(key, value, req_options = nil)
+      perform(:append, key, value.to_s, req_options)
     end
 
     ##
     # Prepend value to the value already stored on the server for 'key'.
     # Prepending only works for values stored with :raw => true.
-    def prepend(key, value)
-      perform(:prepend, key, value.to_s)
+    def prepend(key, value, req_options = nil)
+      perform(:prepend, key, value.to_s, req_options)
     end
 
     ##
@@ -410,10 +495,10 @@ module Dalli
     # #cas.
     #
     # If the value already exists, it must have been set with raw: true
-    def incr(key, amt = 1, ttl = nil, default = nil)
+    def incr(key, amt = 1, ttl = nil, default = nil, req_options = nil)
       check_positive!(amt)
 
-      perform(:incr, key, amt.to_i, ttl_or_default(ttl), default)
+      perform(:incr, key, amt.to_i, ttl_or_default(ttl), default, req_options)
     end
 
     ##
@@ -432,10 +517,10 @@ module Dalli
     # #cas.
     #
     # If the value already exists, it must have been set with raw: true
-    def decr(key, amt = 1, ttl = nil, default = nil)
+    def decr(key, amt = 1, ttl = nil, default = nil, req_options = nil)
       check_positive!(amt)
 
-      perform(:decr, key, amt.to_i, ttl_or_default(ttl), default)
+      perform(:decr, key, amt.to_i, ttl_or_default(ttl), default, req_options)
     end
 
     ##
@@ -519,10 +604,10 @@ module Dalli
                           'db.memcached.miss_count' => key_count - hit_count)
     end
 
-    def get_multi_yielding(keys)
+    def get_multi_yielding(keys, req_options = nil)
       Instrumentation.trace_with_result('get_multi', get_multi_attributes(keys)) do |span|
         hit_count = 0
-        pipelined_getter.process(keys) do |k, data|
+        pipelined_getter.process(keys, req_options) do |k, data|
           hit_count += 1
           yield k, data.first
         end
@@ -531,13 +616,13 @@ module Dalli
       end
     end
 
-    def get_multi_hash(keys)
+    def get_multi_hash(keys, req_options = nil)
       Instrumentation.trace_with_result('get_multi', get_multi_attributes(keys)) do |span|
         hash = if ring.servers.size == 1
-                 single_server_get_multi(keys)
+                 single_server_get_multi(keys, req_options)
                else
                  {}.tap do |h|
-                   pipelined_getter.process(keys) { |k, data| h[k] = data.first }
+                   pipelined_getter.process(keys, req_options) { |k, data| h[k] = data.first }
                  end
                end
         record_hit_miss_metrics(span, keys.size, hash.size)
@@ -550,11 +635,22 @@ module Dalli
       server if server&.alive?
     end
 
-    def single_server_get_multi(keys)
+    def single_server_get_multi(keys, req_options = nil)
       keys.map! { |k| @key_manager.validate_key(k.to_s) }
       return {} unless (server = single_server)
 
-      result = server.request(:read_multi_req, keys)
+      result = server.request(:read_multi_req, keys, req_options)
+      result.transform_keys! { |k| @key_manager.key_without_namespace(k) }
+      result
+    rescue Dalli::NetworkError
+      {}
+    end
+
+    def single_server_get_multi_with_metadata(keys, req_options = nil)
+      keys.map! { |k| @key_manager.validate_key(k.to_s) }
+      return {} unless (server = single_server)
+
+      result = server.request(:read_multi_with_metadata_req, keys, req_options)
       result.transform_keys! { |k| @key_manager.key_without_namespace(k) }
       result
     rescue Dalli::NetworkError
@@ -570,11 +666,11 @@ module Dalli
       nil
     end
 
-    def single_server_delete_multi(keys)
+    def single_server_delete_multi(keys, req_options = nil)
       validated_keys = keys.map { |k| @key_manager.validate_key(k.to_s) }
       return 0 unless (server = single_server)
 
-      server.request(:delete_multi_req, validated_keys)
+      server.request(:delete_multi_req, validated_keys, req_options)
     rescue Dalli::RetryableNetworkError => e
       # Mirror the pipelined path: retry transient errors so a momentary blip
       # still yields a real count. Bounded by the server's socket_max_failures,
@@ -618,7 +714,7 @@ module Dalli
     end
 
     def cas_core(key, always_set, ttl = nil, req_options = nil)
-      (value, cas) = perform(:cas, key)
+      (value, cas) = perform(:cas, key, req_options)
       return if value.nil? && !always_set
 
       newvalue = yield(value)

--- a/lib/dalli/pipelined_deleter.rb
+++ b/lib/dalli/pipelined_deleter.rb
@@ -21,11 +21,14 @@ module Dalli
     #   deleted before the error are not recounted, so the result may
     #   under-report the number actually removed when a failure occurs.
     ##
-    def process(keys)
+    # `req_options` is applied to every delete in the pipeline. Recognized
+    # meta-delete keys (:invalidate, :tombstone_ttl, :drop_value) and routing
+    # tokens (:p_token, :l_token) are applied uniformly to every key.
+    def process(keys, req_options = nil)
       return 0 if keys.empty?
 
       @ring.lock do
-        groups = setup_requests(keys)
+        groups = setup_requests(keys, req_options)
         finish_requests(groups)
       end
     rescue Dalli::RetryableNetworkError => e
@@ -36,9 +39,9 @@ module Dalli
 
     private
 
-    def setup_requests(keys)
+    def setup_requests(keys, req_options = nil)
       groups = groups_for_keys(keys)
-      make_delete_requests(groups)
+      make_delete_requests(groups, req_options)
       groups
     end
 
@@ -46,10 +49,10 @@ module Dalli
     # Loop through the server-grouped sets of keys, writing
     # the corresponding quiet delete requests to the appropriate servers
     ##
-    def make_delete_requests(groups)
+    def make_delete_requests(groups, req_options = nil)
       groups.each do |server, keys_for_server|
         keys_for_server.select! do |key|
-          server.request(:pipelined_delete, key)
+          server.request(:pipelined_delete, key, req_options)
           true
         rescue DalliError, NetworkError => e
           Dalli.logger.debug { e.inspect }

--- a/lib/dalli/pipelined_getter.rb
+++ b/lib/dalli/pipelined_getter.rb
@@ -20,13 +20,16 @@ module Dalli
     ##
     # Yields, one at a time, keys and their values+attributes.
     #
-    def process(keys, &block)
+    # `req_options` is an optional hash of options applied to every request
+    # in the pipeline (e.g. routing tokens `:p_token` / `:l_token`).
+    #
+    def process(keys, req_options = nil, &block)
       return {} if keys.empty?
 
       @ring.lock do
         # Stores partial results collected during interleaved send phase
         @partial_results = {}
-        servers = setup_requests(keys)
+        servers = setup_requests(keys, req_options)
         start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
         # First yield any partial results collected during interleaved send
@@ -40,6 +43,33 @@ module Dalli
       retry
     end
 
+    ##
+    # Stale-aware bulk get. Returns { key => metadata Hash } including
+    # misses, so callers can distinguish a true miss from a tombstoned/stale
+    # item for every requested key.
+    #
+    def process_with_metadata(keys, req_options = nil)
+      return {} if keys.empty?
+
+      @ring.lock do
+        results = {}
+        groups_for_keys(keys).each do |server, keys_for_server|
+          results.merge!(server.request(:read_multi_with_metadata_req, keys_for_server, req_options))
+        rescue Dalli::RetryableNetworkError
+          raise
+        rescue DalliError, NetworkError => e
+          Dalli.logger.debug { e.inspect }
+          Dalli.logger.debug { "unable to get keys for server #{server.name}" }
+        end
+        results.transform_keys! { |key| @key_manager.key_without_namespace(key) }
+        results
+      end
+    rescue Dalli::RetryableNetworkError => e
+      Dalli.logger.debug { e.inspect }
+      Dalli.logger.debug { 'retrying pipelined get with metadata because of network error' }
+      retry
+    end
+
     private
 
     def yield_partial_results
@@ -49,9 +79,9 @@ module Dalli
       @partial_results.clear
     end
 
-    def setup_requests(keys)
+    def setup_requests(keys, req_options = nil)
       groups = groups_for_keys(keys)
-      make_getkq_requests(groups)
+      make_getkq_requests(groups, req_options)
 
       # TODO: How does this exit on a NetworkError
       finish_queries(groups.keys)
@@ -65,15 +95,15 @@ module Dalli
     # on the wire by switching from getkq to getq, and using
     # the opaque value to match requests to responses.
     ##
-    def make_getkq_requests(groups)
+    def make_getkq_requests(groups, req_options = nil)
       groups.each do |server, keys_for_server|
         if keys_for_server.size <= INTERLEAVE_THRESHOLD
           # Small batch - send all at once (existing behavior)
-          server.request(:pipelined_get, keys_for_server)
+          server.request(:pipelined_get, keys_for_server, req_options)
         else
           # Large batch - interleave sends with response draining
           # Pass @partial_results directly to avoid hash allocation/merge overhead
-          server.request(:pipelined_get_interleaved, keys_for_server, CHUNK_SIZE, @partial_results)
+          server.request(:pipelined_get_interleaved, keys_for_server, CHUNK_SIZE, @partial_results, req_options)
         end
       rescue DalliError, NetworkError => e
         Dalli.logger.debug { e.inspect }

--- a/lib/dalli/protocol/base.rb
+++ b/lib/dalli/protocol/base.rb
@@ -40,12 +40,14 @@ module Dalli
         verify_state(opkey)
 
         begin
+          request_local_completed = false
           @connection_manager.start_request!
           response = send(opkey, *args)
 
           # pipelined_get/pipelined_get_interleaved emit query but don't read the response(s)
           @connection_manager.finish_request! unless %i[pipelined_get pipelined_get_interleaved].include?(opkey)
 
+          request_local_completed = true
           response
         rescue Dalli::MarshalError => e
           log_marshal_err(args.first, e)
@@ -56,6 +58,16 @@ module Dalli
           log_unexpected_err(e)
           close
           raise
+        ensure
+          # If the begin block didn't complete — any exception, including
+          # non-StandardError like Async::Stop — tear down the connection
+          # so we don't return a half-used client to the pool.  The local
+          # flag avoids reading $ERROR_INFO, which leaks state when
+          # `request` is called from inside a rescue clause: $! is preserved
+          # there and would falsely trigger close on the pipelined get
+          # happy path (which intentionally leaves @request_in_progress
+          # true until the caller drains the responses).
+          close unless request_local_completed
         end
       end
 
@@ -217,6 +229,48 @@ module Dalli
         connected?
       end
 
+      # Extracts opaque routing-token kwargs (`p_token`, `l_token`) from a
+      # request-options Hash so they can be splatted into a RequestFormatter
+      # call. Empty-string tokens are normalized to `nil` (no-op) so they do
+      # not produce orphan `P`/`L` tokens on the wire (proxies may parse
+      # those inconsistently). CRLF / null-byte injection is rejected later,
+      # at the wire-formatter level, where it can ArgumentError uniformly
+      # regardless of how the token reached the formatter.
+      def routing_token_kwargs(opts)
+        return {} unless opts.is_a?(Hash)
+
+        p = blank_token?(opts[:p_token]) ? nil : opts[:p_token]
+        l = blank_token?(opts[:l_token]) ? nil : opts[:l_token]
+        return {} unless p || l
+
+        { p_token: p, l_token: l }
+      end
+
+      # Extracts meta-delete kwargs (`invalidate`, `tombstone_ttl`,
+      # `drop_value`) from a request-options Hash so they can be splatted
+      # into a RequestFormatter.meta_delete call. Returns `{}` when none
+      # of the keys are set, so the splat is a no-op for the common path.
+      # Tombstone TTL uses the same memcached expiration semantics as other
+      # TTL-bearing operations, so sanitize it before formatting the request.
+      # Validation (e.g. `tombstone_ttl` requiring `invalidate`) happens at
+      # the wire-formatter level, where it can ArgumentError uniformly.
+      def tombstone_kwargs(opts)
+        return {} unless opts.is_a?(Hash)
+
+        invalidate    = opts[:invalidate]
+        tombstone_ttl = opts[:tombstone_ttl]
+        drop_value    = opts[:drop_value]
+        return {} unless invalidate || tombstone_ttl || drop_value
+
+        tombstone_ttl = TtlSanitizer.sanitize(Integer(tombstone_ttl)) if tombstone_ttl
+
+        { invalidate: invalidate, tombstone_ttl: tombstone_ttl, drop_value: drop_value }.compact
+      end
+
+      def blank_token?(value)
+        value.nil? || (value.respond_to?(:empty?) && value.empty?)
+      end
+
       def cache_nils?(opts)
         return false unless opts.is_a?(Hash)
 
@@ -229,7 +283,7 @@ module Dalli
         up!
       end
 
-      def pipelined_get(keys)
+      def pipelined_get(keys, req_options = nil)
         # Clear buffer to remove any stale data from interrupted operations.
         # Use clear (not reset) to keep pipeline_complete? = true, which is
         # the expected state before pipeline_response_setup is called.
@@ -237,7 +291,7 @@ module Dalli
 
         req = +''
         keys.each do |key|
-          req << quiet_get_request(key)
+          req << quiet_get_request(key, req_options)
         end
         # Could send noop here instead of in pipeline_response_setup
         write(req)
@@ -246,7 +300,7 @@ module Dalli
       # For large batches, interleave writing requests with draining responses.
       # This prevents socket buffer deadlock when sending many keys.
       # Populates the provided results hash with any responses drained during send.
-      def pipelined_get_interleaved(keys, chunk_size, results)
+      def pipelined_get_interleaved(keys, chunk_size, results, req_options = nil)
         # Initialize the response buffer for draining during send phase
         response_buffer.ensure_ready
 
@@ -254,7 +308,7 @@ module Dalli
           # Build and write this chunk of requests
           req = +''
           chunk.each do |key|
-            req << quiet_get_request(key)
+            req << quiet_get_request(key, req_options)
           end
           write(req)
           @connection_manager.flush

--- a/lib/dalli/protocol/connection_manager.rb
+++ b/lib/dalli/protocol/connection_manager.rb
@@ -115,10 +115,16 @@ module Dalli
           @sock.close
         rescue StandardError
           nil
+        ensure
+          # A non-StandardError (e.g. a second Async::Stop fired into the
+          # fiber while it's already inside ensure-cleanup) can escape
+          # @sock.close; run the state cleanup unconditionally so the client
+          # isn't returned to the pool with a half-closed socket and
+          # @request_in_progress == true.
+          @sock = nil
+          @pid = nil
+          abort_request!
         end
-        @sock = nil
-        @pid = nil
-        abort_request!
       end
 
       def connected?
@@ -163,11 +169,15 @@ module Dalli
         end
       else
         def read(count)
-          @sock.read(count)
+          read_bytes(count)
         rescue SystemCallError, *TIMEOUT_ERRORS, *SSL_ERRORS, EOFError => e
           error_on_request!(e)
         end
       end
+
+      # Reads exactly `count` bytes or raises; alias kept for callers that
+      # want to make the exact-length contract explicit at the call site.
+      alias read_exact read
 
       def write(bytes)
         @sock.write(bytes)
@@ -270,6 +280,22 @@ module Dalli
 
         time = Time.now - @down_at
         Dalli.logger.warn { format('%<name>s is back (downtime was %<time>.3f seconds)', name: name, time: time) }
+      end
+
+      private
+
+      # Reads exactly `count` bytes. IO#read(count) on a blocking socket blocks
+      # until it has `count` bytes, accumulating across TCP chunks internally,
+      # and only hands back a shorter (or nil) buffer when the stream hits EOF.
+      # So a short read means the peer closed mid-response: raise EOFError and
+      # let read's existing `rescue EOFError` route it through
+      # error_on_request!, which closes the dirty socket for a retry on a fresh
+      # connection (and preserves the $ERROR_INFO context down! relies on).
+      def read_bytes(count)
+        buffer = @sock.read(count)
+        return buffer if buffer && buffer.bytesize == count
+
+        raise EOFError, "EOF reading #{count} bytes; received #{buffer ? buffer.bytesize : 0}"
       end
     end
   end

--- a/lib/dalli/protocol/meta.rb
+++ b/lib/dalli/protocol/meta.rb
@@ -26,20 +26,22 @@ module Dalli
       def get(key, options = nil)
         # Skip bitflags in raw mode - saves 2 bytes per request and skips parsing
         skip_flags = raw_mode? || (options && options[:raw])
-        req = RequestFormatter.meta_get(key: key, skip_flags: skip_flags)
+        req = RequestFormatter.meta_get(key: key, skip_flags: skip_flags, **routing_token_kwargs(options))
         flushed_write(req)
         response_processor.meta_get_with_value(cache_nils: cache_nils?(options))
       end
 
-      def quiet_get_request(key)
+      def quiet_get_request(key, req_options = nil)
         # Skip bitflags in raw mode - saves 2 bytes per request and skips parsing
-        RequestFormatter.meta_get(key: key, return_cas: true, quiet: true, skip_flags: raw_mode?)
+        RequestFormatter.meta_get(key: key, return_cas: true, quiet: true, skip_flags: raw_mode?,
+                                  **routing_token_kwargs(req_options))
       end
 
       def gat(key, ttl, options = nil)
         ttl = TtlSanitizer.sanitize(ttl)
         skip_flags = raw_mode? || (options && options[:raw])
-        req = RequestFormatter.meta_get(key: key, ttl: ttl, skip_flags: skip_flags)
+        req = RequestFormatter.meta_get(key: key, ttl: ttl, skip_flags: skip_flags,
+                                        **routing_token_kwargs(options))
         flushed_write(req)
         response_processor.meta_get_with_value(cache_nils: cache_nils?(options))
       end
@@ -53,8 +55,9 @@ module Dalli
 
       # TODO: This is confusing, as there's a cas command in memcached
       # and this isn't it.  Maybe rename?  Maybe eliminate?
-      def cas(key)
-        req = RequestFormatter.meta_get(key: key, value: true, return_cas: true)
+      def cas(key, options = nil)
+        req = RequestFormatter.meta_get(key: key, value: true, return_cas: true,
+                                        **routing_token_kwargs(options))
         flushed_write(req)
         response_processor.meta_get_with_value_and_cas
       end
@@ -73,27 +76,35 @@ module Dalli
       #   - :recache_ttl [Integer] wins recache race if remaining TTL is below this (R flag)
       #   - :return_hit_status [Boolean] return whether item was previously accessed (h flag)
       #   - :return_last_access [Boolean] return seconds since last access (l flag)
+      #   - :return_ttl_remaining [Boolean] return seconds of TTL remaining, -1 if no TTL (t flag)
       #   - :skip_lru_bump [Boolean] don't bump LRU or update access stats (u flag)
       #   - :cache_nils [Boolean] whether to cache nil values
+      #   - :p_token / :l_token [String] opaque routing tokens (P / L)
       # @return [Hash] containing:
       #   - :value - the cached value (or nil on miss)
       #   - :cas - the CAS value
+      #   - :miss - true if the key does not exist (EN response)
       #   - :won_recache - true if client won recache race (W flag)
       #   - :stale - true if item is stale (X flag)
       #   - :lost_recache - true if another client is recaching (Z flag)
       #   - :hit_before - true/false if previously accessed (only if return_hit_status: true)
       #   - :last_access - seconds since last access (only if return_last_access: true)
+      #   - :ttl_remaining - seconds of TTL remaining (only if return_ttl_remaining: true)
       def meta_get(key, options = {})
         req = RequestFormatter.meta_get(
           key: key, value: true, return_cas: true,
           vivify_ttl: options[:vivify_ttl], recache_ttl: options[:recache_ttl],
           return_hit_status: options[:return_hit_status],
-          return_last_access: options[:return_last_access], skip_lru_bump: options[:skip_lru_bump]
+          return_last_access: options[:return_last_access],
+          return_ttl_remaining: options[:return_ttl_remaining],
+          skip_lru_bump: options[:skip_lru_bump],
+          **routing_token_kwargs(options)
         )
         flushed_write(req)
         response_processor.meta_get_with_metadata(
           cache_nils: cache_nils?(options), return_hit_status: options[:return_hit_status],
-          return_last_access: options[:return_last_access]
+          return_last_access: options[:return_last_access],
+          return_ttl_remaining: options[:return_ttl_remaining]
         )
       end
 
@@ -137,35 +148,41 @@ module Dalli
         ttl = TtlSanitizer.sanitize(ttl) if ttl
         req = RequestFormatter.meta_set(key: key, value: value,
                                         bitflags: bitflags, cas: cas,
-                                        ttl: ttl, mode: mode, quiet: quiet)
+                                        ttl: ttl, mode: mode, quiet: quiet,
+                                        **routing_token_kwargs(options))
         write("#{req}#{value}#{TERMINATOR}")
         @connection_manager.flush unless quiet
       end
       # rubocop:enable Metrics/ParameterLists
 
-      def append(key, value)
-        write_append_prepend_req(:append, key, value)
+      def append(key, value, options = nil)
+        write_append_prepend_req(:append, key, value, nil, nil, options)
         response_processor.meta_set_append_prepend unless quiet?
       end
 
-      def prepend(key, value)
-        write_append_prepend_req(:prepend, key, value)
+      def prepend(key, value, options = nil)
+        write_append_prepend_req(:prepend, key, value, nil, nil, options)
         response_processor.meta_set_append_prepend unless quiet?
       end
 
       # rubocop:disable Metrics/ParameterLists
-      def write_append_prepend_req(mode, key, value, ttl = nil, cas = nil, _options = {})
+      def write_append_prepend_req(mode, key, value, ttl = nil, cas = nil, options = {})
         ttl = TtlSanitizer.sanitize(ttl) if ttl
         req = RequestFormatter.meta_set(key: key, value: value,
-                                        cas: cas, ttl: ttl, mode: mode, quiet: quiet?)
+                                        cas: cas, ttl: ttl, mode: mode, quiet: quiet?,
+                                        **routing_token_kwargs(options))
         write("#{req}#{value}#{TERMINATOR}")
         @connection_manager.flush unless quiet?
       end
       # rubocop:enable Metrics/ParameterLists
 
       # Delete Commands
-      def delete(key, cas)
-        req = RequestFormatter.meta_delete(key: key, cas: cas, quiet: quiet?)
+      # `options` supports tombstone keys (:invalidate, :tombstone_ttl,
+      # :drop_value) and routing tokens (:p_token, :l_token).
+      def delete(key, cas, options = nil)
+        req = RequestFormatter.meta_delete(key: key, cas: cas, quiet: quiet?,
+                                           **routing_token_kwargs(options),
+                                           **tombstone_kwargs(options))
         write(req)
         @connection_manager.flush unless quiet?
         response_processor.meta_delete unless quiet?
@@ -173,8 +190,10 @@ module Dalli
 
       # Pipelined delete - writes a quiet delete request without reading response.
       # Used by PipelinedDeleter for bulk operations.
-      def pipelined_delete(key)
-        req = RequestFormatter.meta_delete(key: key, quiet: true)
+      def pipelined_delete(key, req_options = nil)
+        req = RequestFormatter.meta_delete(key: key, quiet: true,
+                                           **routing_token_kwargs(req_options),
+                                           **tombstone_kwargs(req_options))
         write(req)
       end
 
@@ -184,21 +203,23 @@ module Dalli
       end
 
       # Arithmetic Commands
-      def decr(key, count, ttl, initial)
-        decr_incr false, key, count, ttl, initial
+      def decr(key, count, ttl, initial, options = nil)
+        decr_incr false, key, count, ttl, initial, options
       end
 
-      def incr(key, count, ttl, initial)
-        decr_incr true, key, count, ttl, initial
+      def incr(key, count, ttl, initial, options = nil)
+        decr_incr true, key, count, ttl, initial, options
       end
 
-      def decr_incr(incr, key, delta, ttl, initial)
+      # rubocop:disable Metrics/ParameterLists
+      def decr_incr(incr, key, delta, ttl, initial, options = nil)
         ttl = initial ? TtlSanitizer.sanitize(ttl) : nil # Only set a TTL if we want to set a value on miss
         write(RequestFormatter.meta_arithmetic(key: key, delta: delta, initial: initial, incr: incr, ttl: ttl,
-                                               quiet: quiet?))
+                                               quiet: quiet?, **routing_token_kwargs(options)))
         @connection_manager.flush unless quiet?
         response_processor.decr_incr unless quiet?
       end
+      # rubocop:enable Metrics/ParameterLists
 
       # Other Commands
       def flush(delay = 0)
@@ -236,12 +257,49 @@ module Dalli
       # Single-server fast path for get_multi. Inlines request formatting and
       # response parsing to minimize per-key overhead. Avoids the PipelinedGetter
       # machinery (IO.select, response buffering, server grouping).
-      def read_multi_req(keys)
+      def read_multi_req(keys, req_options = nil)
         is_raw = raw_mode?
-        buffer = RequestFormatter.multi_meta_get(keys, skip_flags: is_raw)
+        buffer = RequestFormatter.multi_meta_get(keys, skip_flags: is_raw, **routing_token_kwargs(req_options))
         flushed_write(buffer)
         buffer.clear
         read_multi_get_responses(is_raw)
+      end
+
+      # Stale-aware bulk get. Returns { key => metadata Hash } for every
+      # requested key — misses are included as { miss: true } entries so
+      # callers can distinguish a true miss from a tombstoned/stale item.
+      # Each hash contains :value, :cas, :stale and :miss (a subset of the
+      # keys returned by the single-key meta_get/get_with_metadata).
+      def read_multi_with_metadata_req(keys, req_options = nil)
+        is_raw = raw_mode?
+        buffer = RequestFormatter.multi_meta_get(keys, skip_flags: is_raw, return_cas: true,
+                                                       **routing_token_kwargs(req_options))
+        flushed_write(buffer)
+        buffer.clear
+        results = read_multi_metadata_responses(is_raw)
+        keys.each do |key|
+          results[key] = { value: nil, cas: 0, stale: false, miss: true } unless results.key?(key)
+        end
+        results
+      end
+
+      def read_multi_metadata_responses(is_raw)
+        hash = {}
+        while (line = @connection_manager.read_line)
+          break if line.start_with?('MN')
+          next unless line.start_with?('VA ')
+
+          tokens = line.chomp!(TERMINATOR).split
+          value = @connection_manager.read(tokens[1].to_i + TERMINATOR.bytesize)&.chomp!(TERMINATOR)
+          stale = response_processor.stale_from_tokens(tokens)
+          cas = response_processor.cas_from_tokens(tokens)
+          bitflags = is_raw ? 0 : response_processor.bitflags_from_tokens(tokens)
+          key = response_processor.key_from_tokens(tokens)
+          next if key.nil?
+
+          hash[key] = { value: @value_marshaller.retrieve(value, bitflags), cas: cas, stale: stale, miss: false }
+        end
+        hash
       end
 
       def read_multi_get_responses(is_raw)
@@ -277,7 +335,7 @@ module Dalli
           [key, @value_marshaller.store(key, raw_value, req_options)]
         end
 
-        buffer = RequestFormatter.multi_meta_set(entries, ttl: ttl)
+        buffer = RequestFormatter.multi_meta_set(entries, ttl: ttl, **routing_token_kwargs(req_options))
         flushed_write(buffer)
         buffer.clear
         response_processor.consume_all_responses_until_mn
@@ -285,8 +343,11 @@ module Dalli
 
       # Single-server fast path for delete_multi. Writes all quiet delete requests
       # terminated by a noop, then consumes all responses.
-      def delete_multi_req(keys)
-        buffer = RequestFormatter.multi_meta_delete(keys)
+      # `req_options` supports tombstone keys (:invalidate, :tombstone_ttl,
+      # :drop_value) and routing tokens (:p_token, :l_token), applied to every key.
+      def delete_multi_req(keys, req_options = nil)
+        buffer = RequestFormatter.multi_meta_delete(keys, **routing_token_kwargs(req_options),
+                                                          **tombstone_kwargs(req_options))
         flushed_write(buffer)
         buffer.clear
         keys.size - response_processor.pipelined_delete_non_deletions

--- a/lib/dalli/protocol/request_formatter.rb
+++ b/lib/dalli/protocol/request_formatter.rb
@@ -36,27 +36,34 @@ module Dalli
         # - l<N>: Seconds since last access
         def meta_get(key:, value: true, return_cas: false, ttl: nil, quiet: false,
                      vivify_ttl: nil, recache_ttl: nil,
-                     return_hit_status: false, return_last_access: false, skip_lru_bump: false,
-                     skip_flags: false)
+                     return_hit_status: false, return_last_access: false, return_ttl_remaining: false,
+                     skip_lru_bump: false, skip_flags: false, p_token: nil, l_token: nil)
           cmd = "mg #{encoded_key(key)}"
           # In raw mode (skip_flags: true), we don't request bitflags since they're not used.
           # This saves 2 bytes per request and skips parsing on response.
           cmd << (skip_flags ? ' v' : ' v f') if value
           cmd << ' c' if return_cas
           cmd << " T#{ttl}" if ttl
+          cmd << routing_tokens(p_token: p_token, l_token: l_token)
           cmd << ' k q s' if quiet # Return the key in the response if quiet
           cmd << " N#{vivify_ttl}" if vivify_ttl # Thundering herd: vivify on miss
           cmd << " R#{recache_ttl}" if recache_ttl # Thundering herd: win recache if TTL below threshold
           cmd << ' h' if return_hit_status # Return hit status (0 or 1)
           cmd << ' l' if return_last_access # Return seconds since last access
+          cmd << ' t' if return_ttl_remaining # Return seconds of TTL remaining (-1 = no TTL)
           cmd << ' u' if skip_lru_bump # Don't bump LRU or update access stats
           cmd << TERMINATOR
         end
 
-        def multi_meta_get(keys, skip_flags: false)
+        def multi_meta_get(keys, skip_flags: false, return_cas: false, p_token: nil, l_token: nil)
           # In raw mode: "mg <key> v k q s\r\n" (no f flag, key at index 2)
           # Normal mode: "mg <key> v f k q s\r\n" (key at index 3)
-          post_get = skip_flags ? " v k q s\r\n" : " v f k q s\r\n"
+          # With return_cas: a "c" flag is added after the value/bitflag flags.
+          routing = routing_tokens(p_token: p_token, l_token: l_token)
+          post_get = +' v'
+          post_get << ' f' unless skip_flags
+          post_get << ' c' if return_cas
+          post_get << ' k q s' << routing << TERMINATOR
           buffer = ''.b
           keys.each do |key|
             buffer << 'mg ' << encoded_key(key) << post_get
@@ -64,21 +71,26 @@ module Dalli
           buffer << 'mn' << TERMINATOR
         end
 
-        def meta_set(key:, value:, bitflags: nil, cas: nil, ttl: nil, mode: :set, quiet: false)
+        def meta_set(key:, value:, bitflags: nil, cas: nil, ttl: nil, mode: :set, quiet: false,
+                     p_token: nil, l_token: nil)
           base64 = KeyRegularizer.required?(key)
           key = KeyRegularizer.encode(key) if base64
           cmd = "ms #{key} #{value.bytesize}"
-          cmd << ' c' unless %i[append prepend].include?(mode)
+          # Skip the cas-return flag in quiet mode: the response is suppressed,
+          # so requesting it only adds bytes to the request.
+          cmd << ' c' if !quiet && !%i[append prepend].include?(mode)
           cmd << ' b' if base64
           cmd << " F#{bitflags}" if bitflags
           cmd << cas_string(cas)
           cmd << " T#{ttl}" if ttl
           cmd << " M#{mode_to_token(mode)}"
           cmd << ' q' if quiet
+          cmd << routing_tokens(p_token: p_token, l_token: l_token)
           cmd << TERMINATOR
         end
 
-        def multi_meta_set(entries, ttl: nil)
+        def multi_meta_set(entries, ttl: nil, p_token: nil, l_token: nil)
+          routing = routing_tokens(p_token: p_token, l_token: l_token)
           buffer = ''.b
           entries.each do |key, pair|
             value, bitflags = pair
@@ -86,37 +98,57 @@ module Dalli
             base64 = KeyRegularizer.required?(key)
             key = KeyRegularizer.encode(key) if base64
 
-            # Inline format: "ms <key> <size> c [b] F<flags> T<ttl> MS q\r\n"
+            # Inline format: "ms <key> <size> c [b] F<flags> T<ttl> MS q [P<t>] [L<t>]\r\n"
             buffer << "ms #{key} #{value.bytesize} c"
             buffer << ' b' if base64
             buffer << " F#{bitflags}" if bitflags
             buffer << " T#{ttl}" if ttl
-            buffer << ' MS q' << TERMINATOR << value << TERMINATOR
+            buffer << ' MS q' << routing << TERMINATOR << value << TERMINATOR
           end
           buffer << META_NOOP
         end
 
-        # Thundering herd protection flag:
-        # - stale (I flag): Instead of deleting the item, mark it as stale. Other clients
-        #   using N/R flags will see the X flag and know the item is being regenerated.
-        def meta_delete(key:, cas: nil, ttl: nil, quiet: false, stale: false)
+        # Tombstone / thundering herd protection flags:
+        # - stale / invalidate (I flag): Instead of deleting the item, mark it as stale.
+        #   Readers using N/R flags (or get_with_metadata) will see the X flag and know
+        #   the item is being regenerated.
+        # - tombstone_ttl (T flag): how long the stale tombstone lives; requires invalidate.
+        # - drop_value (x flag): remove the item value but leave the (stale) marker.
+        def meta_delete(key:, cas: nil, ttl: nil, quiet: false, stale: false,
+                        invalidate: false, tombstone_ttl: nil, drop_value: false,
+                        p_token: nil, l_token: nil)
+          raise ArgumentError, 'tombstone_ttl requires invalidate: true' if tombstone_ttl && !(invalidate || stale)
+
           cmd = "md #{encoded_key(key)}"
           cmd << cas_string(cas)
           cmd << " T#{ttl}" if ttl
-          cmd << ' I' if stale # Mark stale instead of deleting
+          cmd << ' I' if stale || invalidate # Mark stale instead of deleting
+          cmd << " T#{Integer(tombstone_ttl)}" if tombstone_ttl
+          cmd << ' x' if drop_value # Drop the value but keep the item
           cmd << ' q' if quiet
+          cmd << routing_tokens(p_token: p_token, l_token: l_token)
           cmd << TERMINATOR
         end
 
-        def multi_meta_delete(keys)
+        def multi_meta_delete(keys, invalidate: false, tombstone_ttl: nil, drop_value: false,
+                              p_token: nil, l_token: nil)
+          raise ArgumentError, 'tombstone_ttl requires invalidate: true' if tombstone_ttl && !invalidate
+
+          suffix = +' q'
+          suffix << ' I' if invalidate
+          suffix << " T#{Integer(tombstone_ttl)}" if tombstone_ttl
+          suffix << ' x' if drop_value
+          suffix << routing_tokens(p_token: p_token, l_token: l_token)
+          suffix << TERMINATOR
           buffer = ''.b
           keys.each do |key|
-            buffer << 'md ' << encoded_key(key) << ' q' << TERMINATOR
+            buffer << 'md ' << encoded_key(key) << suffix
           end
           buffer << META_NOOP
         end
 
-        def meta_arithmetic(key:, delta:, initial:, incr: true, cas: nil, ttl: nil, quiet: false)
+        def meta_arithmetic(key:, delta:, initial:, incr: true, cas: nil, ttl: nil, quiet: false,
+                            p_token: nil, l_token: nil)
           cmd = "ma #{encoded_key(key)} v"
           cmd << " D#{delta}" if delta
           cmd << " J#{initial}" if initial
@@ -125,7 +157,46 @@ module Dalli
           cmd << cas_string(cas)
           cmd << ' q' if quiet
           cmd << " M#{incr ? 'I' : 'D'}"
+          cmd << routing_tokens(p_token: p_token, l_token: l_token)
           cmd << TERMINATOR
+        end
+
+        # Builds the wire-format suffix for opaque routing tokens (P and L).
+        #
+        # Empty / nil tokens are treated as no-ops. CRLF and null bytes are
+        # rejected with `ArgumentError` to prevent the token from being used
+        # as a wire-protocol injection vector (e.g. `"foo\r\nflush_all\r\n"`
+        # would otherwise be parsed as a second command by memcached or any
+        # intermediate proxy/LB).
+        def routing_tokens(p_token: nil, l_token: nil)
+          p_token = nil if p_token.respond_to?(:empty?) && p_token.empty?
+          l_token = nil if l_token.respond_to?(:empty?) && l_token.empty?
+          validate_routing_token!('p_token', p_token)
+          validate_routing_token!('l_token', l_token)
+          return '' unless p_token || l_token
+
+          s = +''
+          s << " P#{p_token}" if p_token
+          s << " L#{l_token}" if l_token
+          s
+        end
+
+        # Disallowed bytes: CR, LF, NUL. Any of these embedded in a routing
+        # token would let the caller inject a second wire-protocol command
+        # (e.g. `"foo\r\nflush_all\r\n"`).
+        #
+        # Despite intuition, `match?` with a literal regex is ~2.3x faster
+        # than `s.include?("\r") || s.include?("\n") || s.include?("\0")`
+        # in microbenchmarks for short clean tokens (the hot path). Ruby's
+        # Regexp engine fuses short character classes into a single C-level
+        # scan, while the include? chain walks the string up to three times.
+        ROUTING_TOKEN_FORBIDDEN = /[\r\n\0]/
+        private_constant :ROUTING_TOKEN_FORBIDDEN
+
+        def validate_routing_token!(name, value)
+          return if value.nil?
+          raise ArgumentError, "#{name} must be a String, got #{value.class}" unless value.is_a?(String)
+          raise ArgumentError, "#{name} must not contain CRLF or null bytes" if value.match?(ROUTING_TOKEN_FORBIDDEN)
         end
         # rubocop:enable Metrics/CyclomaticComplexity
         # rubocop:enable Metrics/ParameterLists

--- a/lib/dalli/protocol/response_processor.rb
+++ b/lib/dalli/protocol/response_processor.rb
@@ -72,11 +72,13 @@ module Dalli
         #
         # Used by meta_get for comprehensive metadata retrieval.
         # Supports thundering herd protection (N/R flags) and metadata flags (h/l/u).
-        def meta_get_with_metadata(cache_nils: false, return_hit_status: false, return_last_access: false)
+        def meta_get_with_metadata(cache_nils: false, return_hit_status: false, return_last_access: false,
+                                   return_ttl_remaining: false)
           tokens = error_on_unexpected!(T_VA_EN_HD)
           result = build_metadata_result(tokens)
           result[:hit_before] = hit_status_from_tokens(tokens) if return_hit_status
           result[:last_access] = last_access_from_tokens(tokens) if return_last_access
+          result[:ttl_remaining] = ttl_remaining_from_tokens(tokens) if return_ttl_remaining
           result[:value] = parse_value_from_tokens(tokens, cache_nils)
           result
         end
@@ -85,7 +87,12 @@ module Dalli
           {
             value: nil, cas: cas_from_tokens(tokens),
             won_recache: tokens.include?('W'), stale: tokens.include?('X'),
-            lost_recache: tokens.include?('Z')
+            lost_recache: tokens.include?('Z'),
+            # Explicit miss marker: EN means the key does not exist. A
+            # tombstoned item (md key I) is NOT a miss — it responds VA/HD
+            # with the X flag set. This lets callers distinguish a true miss
+            # from a stale tombstone without relying on cas == 0.
+            miss: tokens.first == EN
           }
         end
 
@@ -225,7 +232,7 @@ module Dalli
 
           raise Dalli::ServerError, tokens.join(' ').to_s if tokens.first == SERVER_ERROR
 
-          raise Dalli::DalliError, "Response error: #{tokens.first}"
+          raise Dalli::DalliError, "Response error: #{tokens.join(' ')}"
         end
 
         def bitflags_from_tokens(tokens)
@@ -245,6 +252,14 @@ module Dalli
           end
         end
 
+        # Detects the `X` presence flag indicating the item has been marked
+        # stale via a prior `md key I`. Strict equality (Array#any?(pattern)
+        # uses `===`, which for Strings is `==`) avoids false positives if a
+        # future value-bearing flag is introduced beginning with `X`.
+        def stale_from_tokens(tokens)
+          tokens.any?('X')
+        end
+
         # Returns true if item was previously hit, false if first access, nil if not requested
         # The h flag returns h0 (first access) or h1 (previously accessed)
         def hit_status_from_tokens(tokens)
@@ -258,6 +273,12 @@ module Dalli
         # The l flag returns l<seconds>
         def last_access_from_tokens(tokens)
           value_from_tokens(tokens, 'l').to_i
+        end
+
+        # Returns seconds of TTL remaining (-1 when the item has no TTL)
+        # The t flag returns t<seconds>
+        def ttl_remaining_from_tokens(tokens)
+          value_from_tokens(tokens, 't').to_i
         end
 
         def body_len_from_tokens(tokens)

--- a/test/integration/test_fiber_concurrency.rb
+++ b/test/integration/test_fiber_concurrency.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require_relative '../helper'
+
+# Stand-in for Async::Stop: the real class inherits from Exception (not
+# StandardError) so that blanket `rescue StandardError` clauses don't
+# accidentally swallow scheduler-driven fiber cancellation.  We reproduce that
+# hierarchy locally to avoid pulling the `async` gem just for the signal class.
+# rubocop:disable Lint/InheritException
+class FiberCancellation < Exception; end
+# rubocop:enable Lint/InheritException
+
+describe 'fiber concurrency' do
+  # `Async::Stop < Exception` but NOT `< StandardError`, so when the scheduler
+  # cancels a fiber parked on a blocking read inside a Dalli request, the
+  # `rescue StandardError` branch in `Base#request` is bypassed entirely.
+  # Without an `ensure` clause, `close` is never called and `abort_request!`
+  # never runs — the connection is left with `@request_in_progress == true`
+  # and any partial response bytes remain on the wire for a subsequent caller
+  # to misread.
+  #
+  # `Base#request` gates its `ensure` on a local `request_local_completed`
+  # flag so that pipelined_get's intentional request_in_progress=true happy
+  # path is not torn down — this test proves the cleanup fires on abnormal
+  # exit for non-StandardError exceptions.
+  #
+  # NOTE: this test uses the default `threadsafe: true` config.  The yield-
+  # based interleave race (one fiber parking on IO while another enters
+  # `request`) is separately protected by `Dalli::Threadsafe`, whose
+  # `Monitor.synchronize` is fiber-aware under MRI and raises
+  # `ThreadError: deadlock` rather than corrupting shared state.
+  it 'does not leave the connection dirty when a non-StandardError aborts a request' do
+    memcached_persistent do |dc|
+      dc.flush
+      dc.set('a', 'val_a')
+
+      conn_mgr = dc.send(:ring).servers.first.instance_variable_get(:@connection_manager)
+
+      close_count = 0
+      orig_close = conn_mgr.method(:close)
+      conn_mgr.define_singleton_method(:close) do
+        close_count += 1
+        orig_close.call
+      end
+
+      # Simulate Async::Stop raised into the fiber while it's parked on the
+      # response read — i.e. the scheduler cancelling mid-request.
+      conn_mgr.define_singleton_method(:read_line) do
+        raise FiberCancellation, 'simulated fiber cancellation'
+      end
+
+      assert_raises(FiberCancellation) { dc.get('a') }
+
+      refute_predicate conn_mgr, :request_in_progress?,
+                       'connection left with @request_in_progress == true after non-StandardError abort'
+      assert_operator close_count, :>=, 1,
+                      "expected close to run during non-StandardError abort, got close_count=#{close_count}"
+    end
+  end
+
+  # A second Async::Stop landing on the fiber while it is already inside the
+  # `ensure` cleanup from the first one would interrupt `@sock.close`.
+  # `ConnectionManager#close` rescues only StandardError around the socket
+  # close, so a non-StandardError escaping `@sock.close` leaves `@sock`
+  # non-nil and skips `abort_request!` — the client is returned to the pool
+  # with `@request_in_progress == true` and a half-closed socket.
+  it 'cleans up when @sock.close itself is interrupted by a second non-StandardError' do
+    memcached_persistent do |dc|
+      dc.flush
+      dc.set('a', 'val_a') # warms up the connection so @sock exists
+
+      conn_mgr = dc.send(:ring).servers.first.instance_variable_get(:@connection_manager)
+      sock = conn_mgr.instance_variable_get(:@sock)
+
+      refute_nil sock, 'precondition: socket should be connected after set'
+
+      # Second cancellation: fires when close() reaches @sock.close.
+      sock.define_singleton_method(:close) do
+        raise FiberCancellation, 'simulated second fiber cancellation during @sock.close'
+      end
+
+      # First cancellation: fires when the request parks on a read.
+      conn_mgr.define_singleton_method(:read_line) do
+        raise FiberCancellation, 'simulated first fiber cancellation'
+      end
+
+      assert_raises(FiberCancellation) { dc.get('a') }
+
+      refute_predicate conn_mgr, :request_in_progress?,
+                       'double-exception in ensure left @request_in_progress == true'
+      refute_predicate conn_mgr, :connected?,
+                       'double-exception in ensure left @sock non-nil'
+    end
+  end
+
+  # `$!` (a.k.a. $ERROR_INFO) is preserved when a method is called from
+  # inside a `rescue` clause.  An ensure clause that reads $! to decide
+  # whether "we're unwinding from an exception" sees the *outer* rescued
+  # exception even when its own begin block completed cleanly.
+  #
+  # On the pipelined_get happy path, @request_in_progress is intentionally
+  # left true (the caller still has to drain).  An ensure that closes when
+  # `$ERROR_INFO && request_in_progress?` would therefore tear the socket
+  # out from under a pipelined_get whenever it's called from inside any
+  # rescue clause — a common cache-fallback pattern.  This test pins the
+  # local-flag implementation by exercising that exact call shape.
+  #
+  # NOTE: a block is required here.  Without one, single-server get_multi
+  # takes the `optimized_for_single_server` path which uses :read_multi_req
+  # (calls finish_request!) and would not exercise the pipelined_get
+  # ensure-close window.  Passing a block forces the :pipelined_get opkey.
+  it 'does not tear down a pipelined_get when called from inside a rescue clause' do
+    memcached_persistent do |dc|
+      dc.flush
+      dc.set('a', 'val_a')
+      dc.set('b', 'val_b')
+
+      conn_mgr = dc.send(:ring).servers.first.instance_variable_get(:@connection_manager)
+
+      close_count = 0
+      orig_close = conn_mgr.method(:close)
+      conn_mgr.define_singleton_method(:close) do
+        close_count += 1
+        orig_close.call
+      end
+
+      result = {}
+      begin
+        raise 'outer rescued exception'
+      rescue StandardError
+        # $! is set to the rescued exception while this block executes,
+        # including across the get_multi call.  Block forces :pipelined_get.
+        dc.get_multi(%w[a b]) { |k, v| result[k] = v }
+      end
+
+      assert_equal({ 'a' => 'val_a', 'b' => 'val_b' }, result)
+      assert_equal 0, close_count,
+                   "pipelined_get was torn down mid-flight (close_count=#{close_count}) " \
+                   'when called from inside a rescue clause'
+    end
+  end
+end

--- a/test/integration/test_network.rb
+++ b/test/integration/test_network.rb
@@ -516,4 +516,65 @@ describe 'Network' do
       end
     end
   end
+
+  describe 'fixed-length reads' do
+    # Regression test for truncated reads: a peer that closes the connection
+    # partway through a response body must not surface a decodable-but-wrong
+    # value. The dirty socket must be closed and the request retried on a
+    # fresh connection.
+    it 'does not return a truncated value when the peer closes mid-response body' do
+      value = 'a' * 512
+      tcp_server = TCPServer.new('127.0.0.1', 0)
+      port = tcp_server.addr[1]
+      get_count = 0
+      get_count_mutex = Mutex.new
+
+      server_thread = Thread.new do
+        loop do
+          conn = tcp_server.accept
+          Thread.new(conn) do |c|
+            while (line = c.gets("\r\n"))
+              cmd, key = line.split
+              case cmd
+              when 'version'
+                c.write("VERSION 1.6.39-fake\r\n")
+              when 'mg'
+                nth = get_count_mutex.synchronize { get_count += 1 }
+                if nth == 1
+                  # Correct header + length, only part of the body, then EOF.
+                  c.write("VA #{value.bytesize} k#{key}\r\n")
+                  c.write(value[0, value.bytesize - 16])
+                  c.close
+                  break
+                else
+                  c.write("VA #{value.bytesize} k#{key}\r\n#{value}\r\n")
+                end
+              else
+                c.write("ERROR\r\n")
+              end
+            end
+          rescue IOError, Errno::ECONNRESET, Errno::EPIPE
+            nil
+          end
+        rescue IOError
+          next
+        end
+      end
+      server_thread.abort_on_exception = true
+
+      begin
+        dc = Dalli::Client.new("127.0.0.1:#{port}", raw: true, socket_timeout: 2, socket_max_failures: 2)
+        conn_mgr = dc.send(:ring).servers.first.instance_variable_get(:@connection_manager)
+
+        assert_equal value, dc.get('trunc_key'),
+                     'a mid-response EOF must not surface a truncated value'
+        assert_equal 2, get_count,
+                     'the truncated first response should trigger a transparent retry'
+        refute_predicate conn_mgr, :request_in_progress?
+      ensure
+        tcp_server.close
+        server_thread.kill
+      end
+    end
+  end
 end

--- a/test/integration/test_operations.rb
+++ b/test/integration/test_operations.rb
@@ -88,6 +88,57 @@ describe 'operations' do
         end
       end
 
+      describe 'get_with_metadata h/l/t flags' do
+        it 'returns the value and requested hit/last-access/ttl metadata' do
+          memcached_persistent(p) do |dc|
+            dc.flush
+
+            val1 = 'meta'
+            dc.set('meta_key', val1)
+            result = dc.get_with_metadata('meta_key', return_hit_status: true, return_last_access: true,
+                                                      return_ttl_remaining: true)
+
+            assert_equal val1, result[:value]
+            assert_operator result[:cas], :>, 0
+            refute result[:miss]
+            # not yet hit, last accessed 0 from set, and no TTL so ttl_remaining is -1
+            refute result[:hit_before]
+            assert_equal 0, result[:last_access]
+            assert_equal(-1, result[:ttl_remaining])
+
+            sleep 1 # we can't simulate time in memcached so we need to sleep
+            # ensure hit true and last accessed 1
+            result = dc.get_with_metadata('meta_key', return_hit_status: true, return_last_access: true)
+
+            assert_equal val1, result[:value]
+            assert result[:hit_before]
+            assert_equal 1, result[:last_access]
+          end
+        end
+
+        it 'reports a miss with nil value' do
+          memcached_persistent(p) do |dc|
+            result = dc.get_with_metadata('notexist', return_hit_status: true, return_ttl_remaining: true)
+
+            assert_nil result[:value]
+            assert result[:miss]
+          end
+        end
+
+        it 'returns the remaining TTL for an item stored with an expiry' do
+          memcached_persistent(p) do |dc|
+            dc.flush
+
+            dc.set('meta_key', 'meta', 100)
+            result = dc.get_with_metadata('meta_key', return_ttl_remaining: true)
+
+            assert_equal 'meta', result[:value]
+            assert_operator result[:ttl_remaining], :>, 0
+            assert_operator result[:ttl_remaining], :<=, 100
+          end
+        end
+      end
+
       describe 'gat' do
         it 'returns the value and touches on a hit' do
           memcached_persistent(p) do |dc|

--- a/test/integration/test_routing_tokens_passthrough.rb
+++ b/test/integration/test_routing_tokens_passthrough.rb
@@ -1,0 +1,503 @@
+# frozen_string_literal: true
+
+require_relative '../helper'
+
+# Integration tests for the opaque routing-token passthrough (`p_token` and
+# `l_token`) on every public command. These tokens are encoded as the meta
+# protocol's `P<token>` and `L<token>` flags. The vanilla memcached meta
+# protocol does not assign any meaning to the letters `P` or `L`; vanilla
+# memcached silently ignores them. They exist as a passthrough hook for
+# proxies/routers in front of memcached.
+#
+# These tests assert three things:
+#   1. Every command accepts the routing tokens without raising.
+#   2. The operation completes successfully (the response is parsed cleanly
+#      with the extra flags on the wire).
+#   3. The presence of routing tokens DOES NOT change the return shape of
+#      any command — that's the entire point of P/L being side-band metadata.
+P_TOKEN = 'route=test-region'
+L_TOKEN = 'hint=local'
+ROUTING_OPTS = { p_token: P_TOKEN, l_token: L_TOKEN }.freeze
+
+describe 'routing tokens (p_token / l_token) passthrough' do
+  describe 'set / add / replace / set_cas' do
+    it 'accepts routing tokens and stores the value, return shape unchanged' do
+      memcached_persistent do |dc|
+        dc.flush
+
+        result = dc.set('rtk', 'val1', nil, ROUTING_OPTS)
+
+        assert op_addset_succeeds(result)
+        # set returns a CAS integer (or true) — never an Array
+        refute_kind_of Array, result
+
+        assert_equal 'val1', dc.get('rtk', ROUTING_OPTS)
+
+        assert op_addset_succeeds(dc.replace('rtk', 'val2', nil, ROUTING_OPTS))
+        assert_equal 'val2', dc.get('rtk')
+
+        # add against an existing key still fails (without raising)
+        refute dc.add('rtk', 'val3', nil, ROUTING_OPTS)
+
+        dc.delete('rtk')
+
+        assert op_addset_succeeds(dc.add('rtk', 'val4', nil, ROUTING_OPTS))
+        assert_equal 'val4', dc.get('rtk')
+      end
+    end
+  end
+
+  describe 'get / gat' do
+    it 'returns a scalar value (not a tuple) when routing tokens are passed' do
+      memcached_persistent do |dc|
+        dc.flush
+        dc.set('rtk', 'val')
+
+        result = dc.get('rtk', ROUTING_OPTS)
+
+        refute_kind_of Array, result
+        assert_equal 'val', result
+
+        # also exercise the with-only-p_token and with-only-l_token paths
+        assert_equal 'val', dc.get('rtk', p_token: P_TOKEN)
+        refute_kind_of Array, dc.get('rtk', p_token: P_TOKEN)
+
+        assert_equal 'val', dc.get('rtk', l_token: L_TOKEN)
+        refute_kind_of Array, dc.get('rtk', l_token: L_TOKEN)
+      end
+    end
+
+    it 'returns nil on a miss (not a tuple) with routing tokens' do
+      memcached_persistent do |dc|
+        dc.flush
+
+        assert_nil dc.get('absent', ROUTING_OPTS)
+      end
+    end
+
+    it 'gat returns a scalar with routing tokens' do
+      memcached_persistent do |dc|
+        dc.flush
+        dc.set('rtk', 'val')
+
+        result = dc.gat('rtk', 60, ROUTING_OPTS)
+
+        refute_kind_of Array, result
+        assert_equal 'val', result
+      end
+    end
+  end
+
+  describe 'delete' do
+    it 'accepts routing tokens and deletes the value, return shape unchanged' do
+      memcached_persistent do |dc|
+        dc.flush
+        dc.set('rtk', 'val')
+
+        assert dc.delete('rtk', ROUTING_OPTS)
+        assert_nil dc.get('rtk')
+      end
+    end
+  end
+
+  describe 'incr / decr' do
+    it 'accepts routing tokens and adjusts the counter, return shape unchanged' do
+      memcached_persistent do |dc|
+        dc.flush
+
+        v = dc.incr('counter', 1, 60, 5, ROUTING_OPTS)
+
+        assert_kind_of Integer, v
+        assert_equal 5, v
+
+        assert_equal 6, dc.incr('counter', 1, 60, 5, ROUTING_OPTS)
+        assert_equal 4, dc.decr('counter', 2, 60, 5, ROUTING_OPTS)
+      end
+    end
+  end
+
+  describe 'append / prepend' do
+    it 'accepts routing tokens and updates the value' do
+      memcached_persistent do |dc|
+        dc.flush
+        dc.set('rtk', 'middle', 0, raw: true)
+
+        assert dc.append('rtk', '_end', ROUTING_OPTS)
+        assert dc.prepend('rtk', 'start_', ROUTING_OPTS)
+
+        assert_equal 'start_middle_end', dc.get('rtk', raw: true)
+      end
+    end
+  end
+
+  describe 'cas (optimistic locking)' do
+    # Higher-order method: issues a meta-get for the read, then a meta-set for
+    # the write. Both underlying commands must carry the routing tokens.
+    it 'accepts routing tokens on both the read and write halves' do
+      memcached_persistent do |dc|
+        dc.flush
+        dc.set('rtk', 'orig')
+
+        result = dc.cas('rtk', 60, ROUTING_OPTS) { |v| "#{v}-updated" }
+
+        # Successful CAS returns truthy (CAS id), never a tuple-shape.
+        assert result
+        refute_kind_of Array, result
+        assert_equal 'orig-updated', dc.get('rtk')
+      end
+    end
+
+    it 'cas! also threads routing tokens' do
+      memcached_persistent do |dc|
+        dc.flush
+        # cas! yields even when the key is missing
+        dc.cas!('rtk', 60, ROUTING_OPTS) { |_v| 'created' }
+
+        assert_equal 'created', dc.get('rtk')
+      end
+    end
+  end
+
+  describe 'get_cas' do
+    it 'accepts routing tokens and returns [value, cas] (return shape unchanged)' do
+      memcached_persistent do |dc|
+        dc.flush
+        dc.set('rtk', 'val')
+
+        result = dc.get_cas('rtk', ROUTING_OPTS)
+
+        assert_kind_of Array, result
+        assert_equal 2, result.length
+        value, cas = result
+
+        assert_equal 'val', value
+        assert_kind_of Integer, cas
+        refute_equal 0, cas
+      end
+    end
+
+    it 'yields value and cas to the block when routing tokens are passed' do
+      memcached_persistent do |dc|
+        dc.flush
+        dc.set('rtk', 'val')
+
+        yielded_value = nil
+        yielded_cas = nil
+        dc.get_cas('rtk', ROUTING_OPTS) do |v, c|
+          yielded_value = v
+          yielded_cas = c
+        end
+
+        assert_equal 'val', yielded_value
+        assert_kind_of Integer, yielded_cas
+      end
+    end
+  end
+
+  describe 'get_multi' do
+    it 'applies routing tokens to every key in the pipeline (single-server fast path)' do
+      memcached_persistent do |dc|
+        dc.flush
+        dc.set('a', '1')
+        dc.set('b', '2')
+        dc.set('c', '3')
+
+        results = dc.get_multi('a', 'b', 'c', **ROUTING_OPTS)
+
+        assert_kind_of Hash, results
+        assert_equal({ 'a' => '1', 'b' => '2', 'c' => '3' }, results)
+      end
+    end
+
+    it 'applies routing tokens in the block form' do
+      memcached_persistent do |dc|
+        dc.flush
+        dc.set('a', '1')
+        dc.set('b', '2')
+
+        seen = {}
+        dc.get_multi('a', 'b', **ROUTING_OPTS) { |k, v| seen[k] = v }
+
+        assert_equal({ 'a' => '1', 'b' => '2' }, seen)
+      end
+    end
+
+    it 'works without routing tokens (backward-compat sanity)' do
+      memcached_persistent do |dc|
+        dc.flush
+        dc.set('a', '1')
+        dc.set('b', '2')
+
+        assert_equal({ 'a' => '1', 'b' => '2' }, dc.get_multi('a', 'b'))
+      end
+    end
+  end
+
+  describe 'get_multi_with_metadata' do
+    it 'applies routing tokens to every key in the metadata-aware pipeline' do
+      memcached_persistent do |dc|
+        dc.flush
+        dc.set('a', '1')
+        dc.set('b', '2')
+
+        results = dc.get_multi_with_metadata('a', 'b', 'missing', **ROUTING_OPTS)
+
+        assert_equal %w[a b missing], results.keys.sort
+        assert_equal '1', results['a'][:value]
+        assert_equal '2', results['b'][:value]
+        assert results['missing'][:miss]
+      end
+    end
+  end
+
+  describe 'get_with_metadata' do
+    it 'accepts routing tokens and returns the metadata hash' do
+      memcached_persistent do |dc|
+        dc.flush
+        dc.set('rt-meta', 'v1')
+
+        result = dc.get_with_metadata('rt-meta', **ROUTING_OPTS)
+
+        assert_equal 'v1', result[:value]
+        refute result[:miss]
+        refute result[:stale]
+        assert_operator result[:cas], :>, 0
+      end
+    end
+  end
+
+  describe 'set_multi (pipelined)' do
+    it 'applies routing tokens to every entry in the pipeline' do
+      memcached_persistent do |dc|
+        dc.flush
+
+        dc.set_multi({ 'a' => '1', 'b' => '2', 'c' => '3' }, 60, ROUTING_OPTS)
+
+        assert_equal({ 'a' => '1', 'b' => '2', 'c' => '3' }, dc.get_multi('a', 'b', 'c'))
+      end
+    end
+  end
+
+  describe 'delete_multi (pipelined)' do
+    it 'applies routing tokens to every entry in the pipeline' do
+      memcached_persistent do |dc|
+        dc.flush
+        dc.set('a', '1')
+        dc.set('b', '2')
+        dc.set('c', '3')
+
+        deleted = dc.delete_multi(%w[a b c], ROUTING_OPTS)
+
+        assert_equal 3, deleted
+        assert_nil dc.get('a')
+        assert_nil dc.get('b')
+        assert_nil dc.get('c')
+      end
+    end
+  end
+
+  describe 'fetch (higher-order, regression coverage)' do
+    # Previously discovered bug: when meta-protocol flags were stuffed into
+    # `meta_flags`, `get` returned a `[value, flags_hash]` tuple, which broke
+    # `fetch`'s miss-detection (`not_found?` saw a non-nil Array and treated
+    # the miss as a hit, never invoking the block). Routing tokens must NOT
+    # cause that — the `fetch` contract has to remain scalar-in / scalar-out.
+    it 'returns the cached scalar value on hit when routing tokens are passed' do
+      memcached_persistent do |dc|
+        dc.flush
+        dc.set('rtk', 'cached')
+
+        result = dc.fetch('rtk', 60, ROUTING_OPTS) { 'computed' }
+
+        assert_equal 'cached', result
+        refute_kind_of Array, result
+      end
+    end
+
+    it 'invokes the block on a miss and caches the value when routing tokens are passed' do
+      memcached_persistent do |dc|
+        dc.flush
+
+        block_invocations = 0
+        result = dc.fetch('absent', 60, ROUTING_OPTS) do
+          block_invocations += 1
+          'computed'
+        end
+
+        assert_equal 1, block_invocations, 'fetch block must be invoked on a miss'
+        assert_equal 'computed', result
+        refute_kind_of Array, result
+
+        # Confirm the value actually landed in the cache via the routing-token-bearing add.
+        assert_equal 'computed', dc.get('absent')
+
+        # Subsequent fetch should be a hit, no block invocation.
+        result2 = dc.fetch('absent', 60, ROUTING_OPTS) do
+          block_invocations += 1
+          'should not run'
+        end
+
+        assert_equal 1, block_invocations, 'fetch block must not be invoked on a hit'
+        assert_equal 'computed', result2
+      end
+    end
+
+    it 'returns nil on a miss with no block, even when routing tokens are passed' do
+      memcached_persistent do |dc|
+        dc.flush
+
+        assert_nil dc.fetch('absent', 60, ROUTING_OPTS)
+      end
+    end
+
+    it 'works with cache_nils + routing tokens on a miss' do
+      memcached_persistent(:meta, 21_345, '', cache_nils: true) do |dc|
+        dc.flush
+
+        invocations = 0
+        result = dc.fetch('absent', 60, ROUTING_OPTS) do
+          invocations += 1
+          nil
+        end
+
+        assert_equal 1, invocations
+        assert_nil result
+
+        # Second fetch should hit the cached nil and NOT invoke the block.
+        result2 = dc.fetch('absent', 60, ROUTING_OPTS) do
+          invocations += 1
+          'should not run'
+        end
+
+        assert_equal 1, invocations, 'cached nil should not trigger a re-fetch'
+        assert_nil result2
+      end
+    end
+
+    it 'works with cache_nils + routing tokens on a hit (non-nil cached value)' do
+      memcached_persistent(:meta, 21_345, '', cache_nils: true) do |dc|
+        dc.flush
+        dc.set('rtk', 'cached')
+
+        result = dc.fetch('rtk', 60, ROUTING_OPTS) { 'computed' }
+
+        assert_equal 'cached', result
+        refute_kind_of Array, result
+      end
+    end
+  end
+
+  describe 'wire-format hardening' do
+    # `p_token` and `l_token` are appended verbatim to every meta-protocol
+    # request line. Without sanitization, a value like `"foo\r\nflush_all\r\n"`
+    # would be parsed as a second command by memcached or any intermediate
+    # proxy/LB. The previous `meta_flags` API had the same hole; this PR is
+    # the right moment to close it for the routing-token surface.
+    it 'rejects p_token containing CR with ArgumentError' do
+      memcached_persistent do |dc|
+        assert_raises(ArgumentError) do
+          dc.set('safe_key', 'val', nil, p_token: "route=us\rinjected")
+        end
+      end
+    end
+
+    it 'rejects p_token containing LF with ArgumentError' do
+      memcached_persistent do |dc|
+        assert_raises(ArgumentError) do
+          dc.set('safe_key', 'val', nil, p_token: "route=us\nflush_all\n")
+        end
+      end
+    end
+
+    it 'rejects l_token containing CRLF with ArgumentError' do
+      memcached_persistent do |dc|
+        assert_raises(ArgumentError) do
+          dc.get('safe_key', l_token: "hint\r\nflush_all\r\n")
+        end
+      end
+    end
+
+    it 'rejects routing tokens containing null bytes with ArgumentError' do
+      memcached_persistent do |dc|
+        assert_raises(ArgumentError) do
+          dc.delete('safe_key', p_token: "route\0null")
+        end
+      end
+    end
+
+    it 'rejects non-String routing tokens with ArgumentError' do
+      memcached_persistent do |dc|
+        assert_raises(ArgumentError) do
+          dc.set('safe_key', 'val', nil, p_token: 12_345)
+        end
+      end
+    end
+
+    it 'rejection happens before any wire write (state is not corrupted)' do
+      memcached_persistent do |dc|
+        dc.flush
+        dc.set('safe_key', 'original')
+
+        assert_raises(ArgumentError) do
+          dc.set('safe_key', 'should-not-store', nil, p_token: "x\r\ny")
+        end
+
+        # Subsequent operations on the same connection still work; the bad
+        # set was rejected client-side, never reached the server.
+        assert_equal 'original', dc.get('safe_key')
+      end
+    end
+
+    it 'treats empty-string tokens as no-ops (no orphan P/L on the wire)' do
+      memcached_persistent do |dc|
+        dc.flush
+        dc.set('rtk', 'val')
+
+        # An orphan `P` or `L` with no value would either error at the proxy
+        # or be silently misparsed. The client normalizes '' to nil so the
+        # request is byte-identical to one with no routing tokens at all.
+        assert_equal 'val', dc.get('rtk', p_token: '', l_token: '')
+        assert op_addset_succeeds(dc.set('rtk2', 'v', nil, p_token: ''))
+        assert_equal 'v', dc.get('rtk2')
+        assert dc.delete('rtk2', l_token: '')
+      end
+    end
+  end
+
+  describe 'get_with_metadata (metadata + routing tokens together)' do
+    # The old `meta_flags` escape hatch (which switched `get` to a
+    # [value, flags_hash] tuple return) has been removed in favor of the
+    # upstream-style `get_with_metadata` API: named request options in,
+    # a stable metadata Hash out.
+    it 'returns metadata and honors routing tokens on the same request' do
+      memcached_persistent do |dc|
+        dc.flush
+        dc.set('rtk', 'val', 60)
+
+        result = dc.get_with_metadata('rtk', return_hit_status: true, return_ttl_remaining: true,
+                                             **ROUTING_OPTS)
+
+        assert_equal 'val', result[:value]
+        refute result[:miss]
+        assert_operator result[:ttl_remaining], :>, 0
+      end
+    end
+
+    it 'keeps get scalar-in/scalar-out: a stray meta_flags kwarg is quietly ignored' do
+      # Unknown req_options keys flow into the options Hash where
+      # Protocol::Meta does not look for them; the return shape stays scalar
+      # and writes/deletes succeed normally.
+      memcached_persistent do |dc|
+        dc.flush
+
+        assert op_addset_succeeds(dc.set('rtk', 'val', nil, meta_flags: ['s']))
+        assert_equal 'val', dc.get('rtk', meta_flags: ['s'])
+        assert dc.delete('rtk', meta_flags: ['s'])
+
+        v = dc.incr('cnt', 1, 60, 5, meta_flags: ['s'])
+
+        assert_kind_of Integer, v
+      end
+    end
+  end
+end

--- a/test/integration/test_tombstone.rb
+++ b/test/integration/test_tombstone.rb
@@ -1,0 +1,395 @@
+# frozen_string_literal: true
+
+require_relative '../helper'
+
+# Integration tests for memcached tombstone support: the meta-protocol's
+# `I` (mark stale), `T` (tombstone TTL on delete), and `x` (drop value)
+# flags on `md`, plus the `X` response flag on `mg` exposed via
+# Client#get_with_metadata.
+#
+# A tombstoned item lives briefly in a "stale" window where reads can tell
+# a racing repopulator from a true miss — caller checks result[:stale] vs
+# result[:miss]. Designed for high-concurrency invalidation scenarios where
+# a hard delete would let an in-flight request rewrite a stale value over
+# the deleted key.
+describe 'tombstone (mark-stale) support' do
+  describe 'Client#get_with_metadata return shape' do
+    it 'returns a metadata Hash for a normal hit' do
+      memcached_persistent do |dc|
+        dc.flush
+
+        assert op_addset_succeeds(dc.set('tk', 'val'))
+
+        result = dc.get_with_metadata('tk')
+
+        assert_kind_of Hash, result
+        assert_equal 'val', result[:value]
+        refute result[:miss]
+        refute result[:miss]
+        refute result[:stale]
+      end
+    end
+
+    it 'returns miss? on a true miss (key never existed)' do
+      memcached_persistent do |dc|
+        dc.flush
+
+        result = dc.get_with_metadata('absent')
+
+        assert_kind_of Hash, result
+        assert_nil result[:value]
+        assert result[:miss]
+        assert result[:miss]
+        refute result[:stale]
+      end
+    end
+
+    it 'returns miss? after a regular (non-tombstone) delete' do
+      memcached_persistent do |dc|
+        dc.flush
+
+        assert op_addset_succeeds(dc.set('tk', 'val'))
+        dc.delete('tk')
+
+        result = dc.get_with_metadata('tk')
+
+        assert result[:miss]
+        refute result[:stale]
+      end
+    end
+
+    it 'returns a hash containing the value, cas and stale/miss markers' do
+      memcached_persistent do |dc|
+        dc.flush
+        dc.set('tk', 'val')
+
+        result = dc.get_with_metadata('tk')
+
+        assert_equal 'val', result[:value]
+        assert_operator result[:cas], :>, 0
+        assert_includes result, :stale
+        assert_includes result, :miss
+      end
+    end
+
+    # Pins the three-state contract: callers branch on miss?/stale?/hit?,
+    # never on value.nil? — because a legitimately cached nil is a hit.
+    it 'distinguishes a cached nil (hit?), an absent key (miss?), and a tombstone (stale?)' do
+      memcached_persistent do |dc|
+        dc.flush
+
+        assert op_addset_succeeds(dc.set('tk-nil', nil))
+        cached_nil = dc.get_with_metadata('tk-nil')
+
+        refute cached_nil[:miss]
+        refute cached_nil[:miss]
+        refute cached_nil[:stale]
+        assert_nil cached_nil[:value]
+
+        absent = dc.get_with_metadata('tk-absent')
+
+        assert absent[:miss]
+        assert absent[:miss]
+        refute absent[:stale]
+        assert_nil absent[:value]
+
+        assert op_addset_succeeds(dc.set('tk-tomb', 'val'))
+        dc.delete('tk-tomb', invalidate: true, tombstone_ttl: 30)
+        tombstoned = dc.get_with_metadata('tk-tomb')
+
+        assert tombstoned[:stale]
+        refute tombstoned[:miss]
+        refute tombstoned[:miss]
+      end
+    end
+  end
+
+  describe 'Client#get_multi_with_metadata return shape' do
+    it 'returns metadata Hashes for normal hits, stale tombstones, dropped tombstones, and misses' do
+      memcached_persistent do |dc|
+        dc.flush
+
+        assert op_addset_succeeds(dc.set('multi-hit', 'hit-val'))
+        assert op_addset_succeeds(dc.set('multi-stale', 'stale-val'))
+        assert op_addset_succeeds(dc.set('multi-dropped', 'dropped-val'))
+        dc.delete('multi-stale', invalidate: true, tombstone_ttl: 30)
+        dc.delete('multi-dropped', invalidate: true, drop_value: true, tombstone_ttl: 30)
+
+        results = dc.get_multi_with_metadata('multi-hit', 'multi-stale', 'multi-dropped', 'multi-absent')
+
+        assert_equal %w[multi-absent multi-dropped multi-hit multi-stale], results.keys.sort
+
+        hit = results['multi-hit']
+
+        assert_kind_of Hash, hit
+        assert_equal 'hit-val', hit[:value]
+        refute hit[:miss]
+        refute hit[:miss]
+        refute hit[:stale]
+
+        stale = results['multi-stale']
+
+        assert_kind_of Hash, stale
+        assert_equal 'stale-val', stale[:value]
+        refute stale[:miss]
+        refute stale[:miss]
+        assert stale[:stale]
+
+        dropped = results['multi-dropped']
+
+        assert_kind_of Hash, dropped
+        assert_equal '', dropped[:value]
+        refute dropped[:miss]
+        refute dropped[:miss]
+        assert dropped[:stale]
+
+        absent = results['multi-absent']
+
+        assert_kind_of Hash, absent
+        assert_nil absent[:value]
+        assert absent[:miss]
+        assert absent[:miss]
+        refute absent[:stale]
+      end
+    end
+
+    it 'returns results under original keys when keys require base64 encoding' do
+      memcached_persistent do |dc|
+        dc.flush
+
+        unicode_key = 'multi-ƒ©åÍÎ'
+        space_key = 'multi space'
+        crlf_key = "multi-crlf\r\nkey"
+        absent_key = "multi-absent\r\nkey"
+
+        assert op_addset_succeeds(dc.set(unicode_key, 'unicode-val'))
+        assert op_addset_succeeds(dc.set(space_key, 'space-val'))
+        assert op_addset_succeeds(dc.set(crlf_key, 'crlf-val'))
+        dc.delete(unicode_key, invalidate: true, tombstone_ttl: 30)
+
+        results = dc.get_multi_with_metadata(space_key, unicode_key, crlf_key, absent_key)
+
+        assert_equal [absent_key, crlf_key, space_key, unicode_key].sort, results.keys.sort
+        assert_equal 'space-val', results[space_key][:value]
+        assert_equal 'crlf-val', results[crlf_key][:value]
+        assert_equal 'unicode-val', results[unicode_key][:value]
+        refute results[space_key][:miss]
+        refute results[crlf_key][:miss]
+        assert results[unicode_key][:stale]
+        assert results[absent_key][:miss]
+      end
+    end
+
+    it 'yields a metadata Hash for every requested key in block form' do
+      memcached_persistent do |dc|
+        dc.flush
+
+        assert op_addset_succeeds(dc.set('multi-block-hit', 'hit-val'))
+
+        seen = {}
+        dc.get_multi_with_metadata('multi-block-hit', 'multi-block-absent') do |key, result|
+          seen[key] = result
+        end
+
+        assert_equal %w[multi-block-absent multi-block-hit], seen.keys.sort
+        assert_equal 'hit-val', seen['multi-block-hit'][:value]
+        refute seen['multi-block-hit'][:miss]
+        assert seen['multi-block-absent'][:miss]
+      end
+    end
+  end
+
+  describe 'delete with drop_value only' do
+    it 'drops the value without marking the item stale' do
+      memcached_persistent do |dc|
+        dc.flush
+
+        # Use a non-raw value so this also proves the zero-byte response from
+        # `md ... x` does not try to unmarshal the previously serialized value.
+        assert op_addset_succeeds(dc.set('tk-x-only', { payload: 'should-be-dropped' }))
+
+        assert dc.delete('tk-x-only', drop_value: true)
+        result = dc.get_with_metadata('tk-x-only')
+
+        refute result[:miss]
+        refute result[:stale]
+        refute result[:miss]
+        assert_equal '', result[:value]
+        assert_equal '', dc.get('tk-x-only')
+      end
+    end
+  end
+
+  describe 'delete with invalidate: true' do
+    it 'leaves the item readable but marked stale' do
+      memcached_persistent do |dc|
+        dc.flush
+
+        assert op_addset_succeeds(dc.set('tk', 'preserved-val'))
+
+        dc.delete('tk', invalidate: true)
+        result = dc.get_with_metadata('tk')
+
+        assert result[:stale], 'expected X flag (stale) after invalidate'
+        refute result[:miss], 'invalidate without drop_value should leave value readable'
+        refute result[:miss]
+        assert_equal 'preserved-val', result[:value]
+      end
+    end
+
+    it 'leaves an empty value when drop_value is also set' do
+      memcached_persistent do |dc|
+        dc.flush
+
+        assert op_addset_succeeds(dc.set('tk', 'should-be-dropped'))
+
+        dc.delete('tk', invalidate: true, drop_value: true)
+        result = dc.get_with_metadata('tk')
+
+        assert result[:stale]
+        refute result[:miss]
+        # Value is dropped — empty string, not the original
+        assert_equal '', result[:value]
+      end
+    end
+
+    it 'transitions from stale? to miss? after tombstone_ttl elapses' do
+      memcached_persistent do |dc|
+        dc.flush
+
+        assert op_addset_succeeds(dc.set('tk', 'val'))
+
+        dc.delete('tk', invalidate: true, tombstone_ttl: 1, drop_value: true)
+
+        # Within the tombstone window
+        assert dc.get_with_metadata('tk')[:stale]
+
+        # Past the tombstone window, the X flag should be gone
+        sleep 2
+        result = dc.get_with_metadata('tk')
+
+        assert result[:miss], 'tombstone should have expired into a true miss'
+        refute result[:stale]
+      end
+    end
+
+    it 'sanitizes long tombstone_ttl intervals before sending to memcached' do
+      memcached_persistent do |dc|
+        dc.flush
+
+        assert op_addset_succeeds(dc.set('tk-long-ttl', 'val'))
+
+        long_ttl = Dalli::Protocol::TtlSanitizer::MAX_ACCEPTABLE_EXPIRATION_INTERVAL + 1
+        dc.delete('tk-long-ttl', invalidate: true, tombstone_ttl: long_ttl)
+
+        assert dc.get_with_metadata('tk-long-ttl')[:stale]
+      end
+    end
+
+    it 'does not emit a tombstone for a plain delete' do
+      memcached_persistent do |dc|
+        dc.flush
+        dc.set('tk', 'val')
+
+        dc.delete('tk') # no kwargs — regular hard delete
+        result = dc.get_with_metadata('tk')
+
+        assert result[:miss]
+        refute result[:stale]
+      end
+    end
+
+    it 'is reachable via delete_cas with explicit cas' do
+      memcached_persistent do |dc|
+        dc.flush
+        dc.set('tk', 'val')
+        cas = dc.get_cas('tk').last
+
+        dc.delete_cas('tk', cas, invalidate: true, tombstone_ttl: 30)
+
+        assert dc.get_with_metadata('tk')[:stale]
+      end
+    end
+  end
+
+  describe 'delete_multi with invalidate' do
+    it 'tombstones every key in the batch' do
+      memcached_persistent do |dc|
+        dc.flush
+        keys = %w[tm-a tm-b tm-c]
+        keys.each { |k| dc.set(k, "val-#{k}") }
+
+        deleted = dc.delete_multi(keys, invalidate: true, tombstone_ttl: 30)
+
+        assert_equal keys.length, deleted
+        keys.each do |k|
+          result = dc.get_with_metadata(k)
+
+          assert result[:stale], "expected #{k} to be stale after delete_multi(invalidate: true)"
+          assert_equal "val-#{k}", result[:value]
+        end
+      end
+    end
+
+    it 'drops values across the batch when drop_value is set' do
+      memcached_persistent do |dc|
+        dc.flush
+        keys = %w[tm-x tm-y]
+        keys.each { |k| dc.set(k, 'orig') }
+
+        dc.delete_multi(keys, invalidate: true, tombstone_ttl: 30, drop_value: true)
+
+        keys.each do |k|
+          result = dc.get_with_metadata(k)
+
+          assert result[:stale]
+          assert_equal '', result[:value]
+        end
+      end
+    end
+  end
+
+  describe 'argument validation' do
+    it 'raises ArgumentError when tombstone_ttl is supplied without invalidate' do
+      memcached_persistent do |dc|
+        dc.flush
+        dc.set('tk', 'val')
+
+        with_nil_logger do
+          assert_raises(ArgumentError) do
+            dc.delete('tk', tombstone_ttl: 30)
+          end
+        end
+      end
+    end
+  end
+
+  describe 'interaction with quiet block' do
+    it 'allows tombstone delete inside quiet (delete is in ALLOWED_QUIET_OPS)' do
+      memcached_persistent do |dc|
+        dc.flush
+        dc.set('tq', 'val')
+
+        dc.quiet do
+          dc.delete('tq', invalidate: true, tombstone_ttl: 30)
+        end
+
+        # Outside the quiet block, the tombstone should be visible
+        assert dc.get_with_metadata('tq')[:stale]
+      end
+    end
+
+    it 'raises NotPermittedMultiOpError when get_with_metadata is called inside quiet' do
+      memcached_persistent do |dc|
+        dc.flush
+        dc.set('tq', 'val')
+
+        assert_raises(Dalli::NotPermittedMultiOpError) do
+          dc.quiet do
+            dc.get_with_metadata('tq')
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/protocol/test_connection_manager.rb
+++ b/test/protocol/test_connection_manager.rb
@@ -2,6 +2,34 @@
 
 require_relative '../helper'
 
+# IO#read(maxlen) on a blocking socket returns exactly maxlen bytes unless the
+# stream hits EOF, where it returns a shorter (non-nil) buffer or nil. This
+# models that contract deterministically: one queued result per read call, so
+# we can exercise the full read and the premature-EOF cases without a real
+# socket. (JRuby uses Socket#readfull, which this fake does not implement.)
+class ContractReadSocket
+  attr_reader :read_calls
+
+  def initialize(*chunks)
+    @chunks = chunks
+    @read_calls = []
+    @closed = false
+  end
+
+  def read(count)
+    @read_calls << count
+    @chunks.shift
+  end
+
+  def close
+    @closed = true
+  end
+
+  def closed?
+    @closed
+  end
+end
+
 describe Dalli::Protocol::ConnectionManager do
   let(:hostname) { 'localhost' }
   let(:port) { 11_211 }
@@ -257,6 +285,52 @@ describe Dalli::Protocol::ConnectionManager do
         end
 
         assert_match(/is down/, error.message)
+      end
+    end
+  end
+
+  unless RUBY_ENGINE == 'jruby'
+    describe 'exact-length reads' do
+      def connection_manager_with_socket(socket)
+        manager = Dalli::Protocol::ConnectionManager.new(
+          'localhost',
+          11_211,
+          :tcp,
+          socket_failure_delay: nil,
+          socket_max_failures: 2
+        )
+        manager.instance_variable_set(:@sock, socket)
+        manager
+      end
+
+      it 'returns the full buffer from a single read, binary-safe' do
+        socket = ContractReadSocket.new("a\x00\xFFz".b)
+        manager = connection_manager_with_socket(socket)
+
+        result = manager.read_exact(4)
+
+        assert_equal "a\x00\xFFz".b, result
+        assert_equal Encoding::BINARY, result.encoding
+        assert_equal [4], socket.read_calls
+        # #read shares the same fill semantics (both delegate to read_bytes).
+        assert_equal 'xyz', connection_manager_with_socket(ContractReadSocket.new('xyz')).read(3)
+      end
+
+      it 'raises and closes the dirty socket on a premature EOF (nil)' do
+        socket = ContractReadSocket.new(nil)
+        manager = connection_manager_with_socket(socket)
+
+        assert_raises(Dalli::RetryableNetworkError) { manager.read_exact(5) }
+        assert_predicate socket, :closed?
+        refute_predicate manager, :connected?
+      end
+
+      it 'raises and closes the dirty socket on a short read (EOF mid-response)' do
+        socket = ContractReadSocket.new('abc')
+        manager = connection_manager_with_socket(socket)
+
+        assert_raises(Dalli::RetryableNetworkError) { manager.read(5) }
+        assert_predicate socket, :closed?
       end
     end
   end

--- a/test/protocol/test_request_formatter.rb
+++ b/test/protocol/test_request_formatter.rb
@@ -165,8 +165,8 @@ describe Dalli::Protocol::Meta::RequestFormatter do
                                                                     cas: "\nset importantkey 1 1000 8\ninjected")
     end
 
-    it 'sets the quiet mode if configured' do
-      assert_equal "ms #{key} #{val.bytesize} c F#{bitflags} MS q\r\n",
+    it 'sets the quiet mode if configured, skipping the cas-return flag' do
+      assert_equal "ms #{key} #{val.bytesize} F#{bitflags} MS q\r\n",
                    Dalli::Protocol::Meta::RequestFormatter.meta_set(key: key, value: val, bitflags: bitflags,
                                                                     quiet: true)
     end
@@ -461,6 +461,133 @@ describe Dalli::Protocol::Meta::RequestFormatter do
 
     it 'handles empty keys' do
       assert_raw ''
+    end
+  end
+
+  describe 'routing tokens' do
+    it 'appends P and L tokens to meta_get' do
+      assert_equal "mg foo v f Ppod1 Lzone2\r\n",
+                   Dalli::Protocol::Meta::RequestFormatter.meta_get(key: 'foo', p_token: 'pod1', l_token: 'zone2')
+    end
+
+    it 'appends routing tokens to quiet meta_get before the quiet flags' do
+      assert_equal "mg foo v f Px k q s\r\n",
+                   Dalli::Protocol::Meta::RequestFormatter.meta_get(key: 'foo', quiet: true, p_token: 'x')
+    end
+
+    it 'appends routing tokens to meta_set' do
+      assert_equal "ms foo 1 MS q Ppod1\r\n",
+                   Dalli::Protocol::Meta::RequestFormatter.meta_set(key: 'foo', value: 'v', quiet: true,
+                                                                    p_token: 'pod1')
+    end
+
+    it 'appends routing tokens to meta_delete' do
+      assert_equal "md foo Ppod1\r\n",
+                   Dalli::Protocol::Meta::RequestFormatter.meta_delete(key: 'foo', p_token: 'pod1')
+    end
+
+    it 'appends routing tokens to meta_arithmetic' do
+      assert_equal "ma c v D1 MI Lz\r\n",
+                   Dalli::Protocol::Meta::RequestFormatter.meta_arithmetic(key: 'c', delta: 1, initial: nil,
+                                                                           l_token: 'z')
+    end
+
+    it 'appends routing tokens to every line of multi_meta_get' do
+      assert_equal "mg a v k q s Px\r\nmg b v k q s Px\r\nmn\r\n",
+                   Dalli::Protocol::Meta::RequestFormatter.multi_meta_get(%w[a b], skip_flags: true, p_token: 'x')
+    end
+
+    it 'requests cas on every line of multi_meta_get when return_cas is set' do
+      assert_equal "mg a v f c k q s\r\nmg b v f c k q s\r\nmn\r\n",
+                   Dalli::Protocol::Meta::RequestFormatter.multi_meta_get(%w[a b], return_cas: true)
+    end
+
+    it 'appends routing tokens to every line of multi_meta_set' do
+      entries = [['a', ['v1', 0]], ['b', ['v2', 0]]]
+
+      assert_equal "ms a 2 c F0 MS q Px\r\nv1\r\nms b 2 c F0 MS q Px\r\nv2\r\nmn\r\n",
+                   Dalli::Protocol::Meta::RequestFormatter.multi_meta_set(entries, p_token: 'x')
+    end
+
+    it 'treats nil and empty tokens as no-ops' do
+      plain = Dalli::Protocol::Meta::RequestFormatter.meta_get(key: 'foo')
+
+      assert_equal plain, Dalli::Protocol::Meta::RequestFormatter.meta_get(key: 'foo', p_token: nil)
+      assert_equal plain, Dalli::Protocol::Meta::RequestFormatter.meta_get(key: 'foo', p_token: '', l_token: '')
+    end
+
+    it 'rejects CRLF and null bytes to prevent wire injection' do
+      %W[evil\r\nflush_all evil\rx evil\nx evil\0x].each do |token|
+        assert_raises(ArgumentError) do
+          Dalli::Protocol::Meta::RequestFormatter.meta_get(key: 'foo', p_token: token)
+        end
+      end
+    end
+
+    it 'rejects non-String tokens' do
+      assert_raises(ArgumentError) do
+        Dalli::Protocol::Meta::RequestFormatter.meta_get(key: 'foo', l_token: 42)
+      end
+    end
+  end
+
+  describe 'tombstone delete flags' do
+    it 'marks stale with invalidate' do
+      assert_equal "md foo I\r\n", Dalli::Protocol::Meta::RequestFormatter.meta_delete(key: 'foo', invalidate: true)
+    end
+
+    it 'treats stale: as an alias for invalidate:' do
+      assert_equal Dalli::Protocol::Meta::RequestFormatter.meta_delete(key: 'foo', invalidate: true),
+                   Dalli::Protocol::Meta::RequestFormatter.meta_delete(key: 'foo', stale: true)
+    end
+
+    it 'appends the tombstone TTL' do
+      assert_equal "md foo I T30\r\n",
+                   Dalli::Protocol::Meta::RequestFormatter.meta_delete(key: 'foo', invalidate: true,
+                                                                       tombstone_ttl: 30)
+    end
+
+    it 'appends the drop_value flag' do
+      assert_equal "md foo I T30 x\r\n",
+                   Dalli::Protocol::Meta::RequestFormatter.meta_delete(key: 'foo', invalidate: true,
+                                                                       tombstone_ttl: 30, drop_value: true)
+    end
+
+    it 'requires invalidate when tombstone_ttl is given' do
+      assert_raises(ArgumentError) do
+        Dalli::Protocol::Meta::RequestFormatter.meta_delete(key: 'foo', tombstone_ttl: 30)
+      end
+    end
+
+    it 'applies tombstone flags to every line of multi_meta_delete' do
+      assert_equal "md a q I x\r\nmd b q I x\r\nmn\r\n",
+                   Dalli::Protocol::Meta::RequestFormatter.multi_meta_delete(%w[a b], invalidate: true,
+                                                                                      drop_value: true)
+    end
+  end
+
+  describe 'quiet set cas flag' do
+    it 'skips the cas-return flag in quiet mode' do
+      refute_includes Dalli::Protocol::Meta::RequestFormatter.meta_set(key: 'foo', value: 'v', quiet: true), ' c'
+    end
+
+    it 'requests cas in non-quiet mode' do
+      assert_equal "ms foo 1 c MS\r\n", Dalli::Protocol::Meta::RequestFormatter.meta_set(key: 'foo', value: 'v')
+    end
+  end
+
+  describe 'ttl remaining flag' do
+    it 'appends the t flag when return_ttl_remaining is set' do
+      assert_equal "mg foo v f t\r\n",
+                   Dalli::Protocol::Meta::RequestFormatter.meta_get(key: 'foo', return_ttl_remaining: true)
+    end
+
+    it 'combines with the other metadata flags in upstream order' do
+      assert_equal "mg foo v f c h l t\r\n",
+                   Dalli::Protocol::Meta::RequestFormatter.meta_get(key: 'foo', return_cas: true,
+                                                                    return_hit_status: true,
+                                                                    return_last_access: true,
+                                                                    return_ttl_remaining: true)
     end
   end
 end

--- a/test/protocol/test_response_processor.rb
+++ b/test/protocol/test_response_processor.rb
@@ -365,4 +365,99 @@ describe Dalli::Protocol::Meta::ResponseProcessor do
       assert result[0] # ok status
     end
   end
+
+  describe 'error responses' do
+    it 'includes the full unexpected response line in DalliError messages' do
+      expect_read_line('CLIENT_ERROR bad data chunk')
+
+      err = assert_raises(Dalli::DalliError) { processor.meta_get_with_value }
+
+      assert_equal 'Response error: CLIENT_ERROR bad data chunk', err.message
+      io_source.verify
+    end
+
+    it 'includes the full server error response line in ServerError messages' do
+      expect_read_line('SERVER_ERROR object too large for cache')
+
+      err = assert_raises(Dalli::ServerError) { processor.meta_get_with_value }
+
+      assert_equal 'SERVER_ERROR object too large for cache', err.message
+      io_source.verify
+    end
+  end
+
+  describe '#meta_get_with_metadata stale/miss markers' do
+    it 'reports stale: true and miss: false on an X-flagged hit' do
+      test_value = 'hello'
+      serialized = Marshal.dump(test_value)
+
+      expect_read_line("VA #{serialized.bytesize} f1 c42 X")
+      expect_read_data(serialized, serialized.bytesize)
+
+      result = processor.meta_get_with_metadata
+
+      assert_equal test_value, result[:value]
+      assert result[:stale]
+      refute result[:miss]
+      assert_equal 42, result[:cas]
+      io_source.verify
+    end
+
+    it 'reports stale: false on a plain hit' do
+      serialized = Marshal.dump('v')
+
+      expect_read_line("VA #{serialized.bytesize} f1 c7")
+      expect_read_data(serialized, serialized.bytesize)
+
+      result = processor.meta_get_with_metadata
+
+      refute result[:stale]
+      refute result[:miss]
+      io_source.verify
+    end
+
+    it 'reports miss: true with nil value on EN' do
+      expect_read_line('EN')
+
+      result = processor.meta_get_with_metadata
+
+      assert result[:miss]
+      refute result[:stale]
+      assert_nil result[:value]
+      assert_equal 0, result[:cas]
+      io_source.verify
+    end
+  end
+
+  describe '#meta_get_with_metadata ttl_remaining' do
+    it 'parses the t flag when return_ttl_remaining is requested' do
+      test_value = 'flagged'
+      serialized = Marshal.dump(test_value)
+
+      expect_read_line("VA #{serialized.bytesize} f1 c9 h1 l5 t42")
+      expect_read_data(serialized, serialized.bytesize)
+
+      result = processor.meta_get_with_metadata(return_hit_status: true, return_last_access: true,
+                                                return_ttl_remaining: true)
+
+      assert_equal test_value, result[:value]
+      assert result[:hit_before]
+      assert_equal 5, result[:last_access]
+      assert_equal 42, result[:ttl_remaining]
+      assert_equal 9, result[:cas]
+      io_source.verify
+    end
+
+    it 'reports -1 for items with no TTL' do
+      serialized = Marshal.dump('v')
+
+      expect_read_line("VA #{serialized.bytesize} f1 c9 t-1")
+      expect_read_data(serialized, serialized.bytesize)
+
+      result = processor.meta_get_with_metadata(return_ttl_remaining: true)
+
+      assert_equal(-1, result[:ttl_remaining])
+      io_source.verify
+    end
+  end
 end


### PR DESCRIPTION
## Summary

This branch (`main-new`) rebuilds the Shopify fork on top of upstream [`petergoldstein/dalli`](https://github.com/petergoldstein/dalli) at `b9321f1` (v5.0.5). It replaces our previous base, which had diverged from upstream since September 2024:

- **183 commits ahead / 209 commits behind**
- **Dalli 3.2.9 → 5.0.5**

Rather than replaying all 183 commits, we squash-merged the fork and retained only the Shopify-specific changes that upstream does not already provide, reimplementing them in the style of the upstream 5.x API.

The complete diff against upstream is:

```text
23 files changed, +1,981 / −121
lib/: 8 files changed, +473 / −108
```

Every surviving feature is a candidate for an eventual upstream PR.

## What this fork adds to Dalli 5.0.5

### 1. Opaque routing tokens: `:p_token` and `:l_token`

From #70 and #72 — @nherson

All operations now accept per-request routing tokens, including:

- `get`, `gat`, `get_cas`, and `get_with_metadata`
- `fetch_with_lock`
- `set`, `add`, `replace`, `append`, and `prepend`
- `delete`, `incr`, and `decr`
- All multi-key and pipelined fast paths

Tokens are appended to the wire protocol as `P<token>` and `L<token>` for consumption by intermediate proxies.

Additional behavior:

- CRLF and NUL bytes are rejected with `ArgumentError` to prevent wire-protocol injection.
- Empty and `nil` tokens are no-ops.
- The implementation uses upstream’s existing per-request options hash, introducing no new API pattern.

### 2. Tombstone (`mark-stale`) deletes

From #73 — @drinkbeer

```ruby
dc.delete("key", invalidate: true, tombstone_ttl: 30, drop_value: true)
# => md key I T30 x
```

A tombstoned item remains available during a stale window, allowing concurrent readers to distinguish a racing repopulation from a true cache miss. This supports IdentityCache-style dirty-write prevention.

Tombstones are supported by:

- `delete`
- `delete_cas`
- `delete_multi`, including bulk, single-server, and multi-server paths

The implementation builds on the `I` flag that upstream already uses for `delete_stale`. Only the `x` flag, TTL plumbing, and client API are new.

### 3. `get_with_metadata` enhancements and a bulk variant

From #73, reimplemented using the upstream API

Rather than porting the old `get_with_status`/`CacheResult` API, the read path was rebuilt on upstream’s existing `get_with_metadata` API.

Enhancements include:

- An explicit `:miss` key for `EN` responses, distinguishing a true miss from a tombstone (`stale: true`)
- A `return_ttl_remaining:` option that exposes `:ttl_remaining` via the `t` flag, where `-1` means no expiry
  - This follows the same API style as upstream’s `return_hit_status:` and `return_last_access:` options
- Routing-token support, which `fetch_with_lock` inherits automatically
- A new `get_multi_with_metadata` method for stale-aware bulk reads

`get_multi_with_metadata` returns an entry for every requested key, including misses:

```ruby
{
  key => {
    value:,
    cas:,
    stale:,
    miss:
  }
}
```

### 4. Robustness fixes

#### Exact-length reads

From #77 — @ianks

If a peer closes the connection partway through a response body, Dalli now raises an error and closes the dirty socket so the request can be retried. Previously, the client could surface a truncated but still decodable value.

This includes a self-contained regression test.

#### Connection teardown for non-`StandardError` exceptions

From #68, #69, and #71

`Async::Stop` or `Thread#kill` escaping a request—or interrupting `ConnectionManager#close`—can no longer return a partially used connection to the pool.

### 5. Minor changes

- Quiet-mode `ms` requests no longer include the CAS-return flag, saving two bytes per request.
- `bin/benchmark` now:
  - Reports `set_multi` results, resolving an upstream TODO
  - Includes a `delete_multi` benchmark target
- CI now:
  - Uses memcached 1.6.41 across all workflows for `x`/`i` token support
  - Runs benchmarks on PRs

## Intentionally dropped because upstream 5.x supersedes them

| Shopify 3.x fork | Upstream replacement |
|---|---|
| `Dalli::Middlewares`, OTel middleware, and a hard `opentelemetry-api` dependency | Upstream `instrumentation.rb`: zero-dependency, automatically enabled when OTel is loaded, including hit/miss metrics |
| `meta_flags:` on `get`/`gat`, which changed the return value to `[value, { c, h, l, t }]` | `get_with_metadata` with named options; only `t` was missing and is now exposed through `return_ttl_remaining:` |
| `get_with_status` and the `CacheResult` value object | `get_with_metadata` hashes with `:miss` and `:stale` |
| Toxiproxy-based network tests | Upstream’s mock-based suite, which also covers SSL, `Thread#raise`, `Thread#kill`, and `IOError` |
| Experimental, single-server-only `set_multi` and `delete_multi` | Upstream’s complete implementations and fast paths |
| `PIDCache`, the `Dalli::Server` alias, buffered-I/O experiments, fork reconnection, `IOError` rescues, and Unix-socket timeouts | All are present in upstream 5.x |

## Migration notes for Shopify apps

This upgrade moves Shopify apps from Dalli 3.2.9 to this 5.0.5-based fork.

- Upstream 5.0 requirements apply:
  - Ruby 3.3 or later
  - memcached 1.6 or later
  - Binary protocol and SASL support have been removed
- Replace:

  ```ruby
  dc.get(
    key,
    meta_flags: [...]
  )
  ```

  with:

  ```ruby
  dc.get_with_metadata(
    key,
    return_hit_status: ...,
    return_last_access: ...,
    return_ttl_remaining: ...
  )
  ```

  A stray `meta_flags:` keyword is quietly ignored, and `get` continues to return a scalar value.

- Replace:
  - `get_with_status` → `get_with_metadata`
  - `get_multi_with_status` → `get_multi_with_metadata`
  - `CacheResult` objects → metadata hashes
- Replace `Dalli::Server` with `Dalli::Protocol::Meta`.

## Verification

- `bundle exec rake test`
  - 671 runs
  - 39,568 assertions
  - 0 failures
  - 0 errors
  - 1 skip
  - Tested locally with memcached 1.6.40; CI uses 1.6.41
- `bundle exec rubocop`
  - 88 files inspected
  - No offenses
- New test coverage includes:
  - `test_tombstone.rb` — 20 tests
  - `test_routing_tokens_passthrough.rb` — 32 tests
  - `test_fiber_concurrency.rb`
  - Wire-level formatter, processor, and connection-manager unit tests
- Wire formats were verified byte-for-byte against the #72 and #73 implementations.

## Review notes

- The linked compare view represents the entire review surface; there is no meaningful commit-by-commit history to review.
- Changes under `lib/` are additive. For callers that do not use the new options, `get`, `gat`, and `set` behavior remains byte-for-byte identical to upstream.
- Potential follow-up contributions to upstream, tracked separately:
  - `:miss`
  - `return_ttl_remaining:`
  - `get_multi_with_metadata`
  - `drop_value` and `tombstone_ttl` support for `meta_delete`