### PR TITLE
Skip the cas-return flag on quiet meta_set requests

### DIFF
--- a/lib/dalli/protocol/request_formatter.rb
+++ b/lib/dalli/protocol/request_formatter.rb
@@ -68,7 +68,9 @@ module Dalli
           base64 = KeyRegularizer.required?(key)
           key = KeyRegularizer.encode(key) if base64
           cmd = "ms #{key} #{value.bytesize}"
-          cmd << ' c' unless %i[append prepend].include?(mode)
+          # Skip the cas-return flag in quiet mode: the response is suppressed,
+          # so requesting it only adds bytes to the request.
+          cmd << ' c' if !quiet && !%i[append prepend].include?(mode)
           cmd << ' b' if base64
           cmd << " F#{bitflags}" if bitflags
           cmd << cas_string(cas)

--- a/test/protocol/test_request_formatter.rb
+++ b/test/protocol/test_request_formatter.rb
@@ -165,10 +165,16 @@ describe Dalli::Protocol::Meta::RequestFormatter do
                                                                     cas: "\nset importantkey 1 1000 8\ninjected")
     end
 
-    it 'sets the quiet mode if configured' do
-      assert_equal "ms #{key} #{val.bytesize} c F#{bitflags} MS q\r\n",
+    it 'sets the quiet mode if configured, skipping the cas-return flag' do
+      assert_equal "ms #{key} #{val.bytesize} F#{bitflags} MS q\r\n",
                    Dalli::Protocol::Meta::RequestFormatter.meta_set(key: key, value: val, bitflags: bitflags,
                                                                     quiet: true)
+    end
+
+    it 'retains the cas-return flag when not in quiet mode' do
+      assert_equal "ms #{key} #{val.bytesize} c F#{bitflags} MS\r\n",
+                   Dalli::Protocol::Meta::RequestFormatter.meta_set(key: key, value: val, bitflags: bitflags,
+                                                                    quiet: false)
     end
 
     it 'sets the base64 mode if required' do


### PR DESCRIPTION
First of three PRs decomposing #1130 (§5, "Minor changes") into independently reviewable pieces. Original work by @drinkbeer / the Shopify fork.

## Change

`meta_set` unconditionally appended the `c` (cas-return) flag for every mode except append/prepend. In quiet mode memcached suppresses the `ms` response entirely, so the returned CAS can never be read — the flag is two wasted bytes on every quiet set.

```ruby
cmd << ' c' if !quiet && !%i[append prepend].include?(mode)
```

Quiet sets are what `Dalli::Client#multi` blocks and the pipelined setter emit, so this is the bulk-write path.

## Tests

- Updated the existing quiet-mode expectation to assert `c` is absent.
- Added a companion assertion that non-quiet sets still carry `c`, so the two halves of the condition are pinned independently.

Full suite green locally (582 runs, 0 failures) and `rubocop` clean.

## Not included

`multi_meta_set` still emits `c` on every line even though it always sets `q`, so the same two bytes per key are still on the wire for the single-server `set_multi` fast path. #1130 does not change that either. Happy to extend it here or in a follow-up — it needs the `multi_meta_set` expectations in `test/protocol/test_request_formatter.rb` updated too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)