### PR TITLE
Benchmark set_multi and add a delete_multi target

### DIFF
--- a/bin/benchmark
+++ b/bin/benchmark
@@ -248,10 +248,9 @@ if %w[all set_multi].include?(bench_target)
         end
       end
     end
-    # TODO: uncomment this once we add PR adding set_multi
-    # x.report('multi client set_multi 100') do
-    #   multi_client.set_multi(pairs, 3600, raw: true)
-    # end
+    x.report('multi client set_multi 100') do
+      multi_client.set_multi(pairs, 3600, raw: true)
+    end
     x.report('write 100 keys rawsock') do
       count = pairs.length
       tail = ''
@@ -267,7 +266,16 @@ if %w[all set_multi].include?(bench_target)
       sock.flush
       sock.gets(TERMINATOR) # clear the buffer
     end
-    # x.report('write_mutli 100 keys') { client.set_multi(pairs, 3600, raw: true) }
+    x.report('write_multi 100 keys') { client.set_multi(pairs, 3600, raw: true) }
+    x.compare!
+  end
+end
+
+if %w[all delete_multi].include?(bench_target)
+  Benchmark.ips do |x|
+    x.config(warmup: bench_warmup, time: bench_time, suite: suite)
+    x.report('delete_multi 100 keys') { client.delete_multi(pairs.keys) }
+    x.report('delete 100 keys') { pairs.each_key { |key| client.delete(key) } }
     x.compare!
   end
 end


### PR DESCRIPTION
Second of three PRs decomposing #1130 (§5, "Minor changes"). Original work by @drinkbeer / the Shopify fork.

## Change

- Enables the two `set_multi` reports that were commented out with `# TODO: uncomment this once we add PR adding set_multi`. `set_multi` exists now, so the TODO is resolved.
- Fixes the `write_mutli` typo in the label (it was inside the commented-out line).
- Adds a `delete_multi` target comparing the pipelined path against N single deletes.

## Verified locally

```
BENCH_TARGET=set_multi
      write_multi 100 keys:     7702.9 i/s
write 100 keys meta client:     3645.5 i/s - 2.11x  slower
     write 100 keys simple:     3527.6 i/s - 2.18x  slower
    write 100 keys rawsock:     3383.1 i/s - 2.28x  slower
multi client set_multi 100:     2662.1 i/s - 2.89x  slower

BENCH_TARGET=delete_multi
delete_multi 100 keys:    11380.3 i/s
      delete 100 keys:      427.1 i/s - 26.65x  slower
```

## Caveat worth a reviewer's eye

The `delete_multi` block deletes the same 100 keys every iteration, so after the first pass it measures the **miss** path, not the hit path. Both reports are affected equally, so the A/B comparison stands, but the absolute numbers are not representative of deleting live keys. Re-seeding inside the report block would pollute the measurement, so I left the behavior as #1130 has it — flagging it in case you'd rather seed via a `x.report` wrapper or drop the target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)