### PR TITLE
Bump CI memcached to 1.6.41 and run benchmarks on PRs

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -3,6 +3,7 @@ name: Benchmarks
 on:
   push:
     branches: [main]
+  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -12,10 +13,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v7
-    - name: Install Memcached 1.6.23
+    - name: Install Memcached 1.6.41
       working-directory: scripts
       env:
-        MEMCACHED_VERSION: 1.6.23
+        MEMCACHED_VERSION: 1.6.41
       run: |
         chmod +x ./install_memcached.sh
         ./install_memcached.sh

--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v7
-    - name: Install Memcached 1.6.23
+    - name: Install Memcached 1.6.41
       working-directory: scripts
       env:
-        MEMCACHED_VERSION: 1.6.23
+        MEMCACHED_VERSION: 1.6.41
       run: |
         chmod +x ./install_memcached.sh
         ./install_memcached.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
           - '3.3'
           - jruby-10
           - truffleruby
-        memcached-version: ['1.6.40']
+        memcached-version: ['1.6.41']
 
     name: "Ruby ${{ matrix.ruby-version }} / Memcached ${{ matrix.memcached-version }}"
     steps:


### PR DESCRIPTION
Third of three PRs decomposing #1130 (§5, "Minor changes"). Original work by @drinkbeer / the Shopify fork.

## Change

| Workflow | Before | After |
|---|---|---|
| `tests.yml` | 1.6.40 | 1.6.41 |
| `benchmarks.yml` | 1.6.23 | 1.6.41 |
| `profile.yml` | 1.6.23 | 1.6.41 |

Benchmarks and profile had drifted well behind tests. Also adds a `pull_request:` trigger to `benchmarks.yml` so benchmarks run on every PR and regressions surface pre-merge.

## Notes

- **The 1.6.41 bump lands now, ahead of the work that needs it.** #1130 wants 1.6.41 for the `x` and `i` meta flags used by the tombstone work (§2 of that PR); nothing in this PR requires it. Bumping immediately keeps all three workflows on one version and unblocks the tombstone PR when it arrives.
- **Benchmarks on every PR** costs runner minutes and nothing gates on the output, but makes performance regressions visible before merge rather than after.

Excluded from this PR as fork-internal / out of scope for §5: the `dev.yml` `.gitignore` entry, and the `.standard.yml` `ruby_version` 3.1 → 3.3.0 bump (that one changes the lint target and reads as a support-policy decision rather than a minor change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)