### PR TITLE
Scope StrictWarnings to Dalli's own source

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,15 +1,6 @@
 # frozen_string_literal: true
 
-module StrictWarnings
-  def warn(msg, **, &)
-    # Allow intentional deprecation warnings from Dalli
-    return super if msg.to_s.start_with?('[DEPRECATION]')
-
-    raise RuntimeError, msg, caller(1)
-  end
-end
-
-Warning.singleton_class.prepend(StrictWarnings)
+require_relative 'support/strict_warnings'
 
 require 'bundler/setup'
 # require 'simplecov'

--- a/test/support/strict_warnings.rb
+++ b/test/support/strict_warnings.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+# Turns warnings into test failures, but only for warnings that originate in
+# Dalli's own code.  `Warning.singleton_class.prepend` is global, so without this
+# scoping a warning emitted while loading any third-party gem aborts the entire
+# suite before a single test runs.  That is not hypothetical: json 2.21.2's
+# pure-Ruby generator (used on JRuby, where the C extension is unavailable) warns
+# 'method redefined; discarding old to_hash' at require time, which took CI red
+# with no change to Dalli.
+module StrictWarnings
+  ROOT = File.expand_path('../..', __dir__)
+  # Only lib/ and test/ are ours.  Bundler installs gems under vendor/ in CI, so
+  # allowlisting the repository root would not be enough.
+  OWN_SOURCE_PREFIXES = [File.join(ROOT, 'lib', ''), File.join(ROOT, 'test', '')].freeze
+
+  # Ruby prefixes interpreter-generated warnings with the location of the offending
+  # code: "path/to/file.rb:12: warning: ...".
+  MESSAGE_ORIGIN = /\A(.+?):\d+: warning:/
+
+  # RubyGems Kernel#warn shim, active on JRuby but not CRuby.
+  RUBYGEMS_WARN_SHIM = 'rubygems/core_ext/kernel_warn.rb'
+
+  def warn(msg, **, &)
+    # Allow intentional deprecation warnings from Dalli
+    return super if msg.to_s.start_with?('[DEPRECATION]')
+    return super unless dalli_source?(msg)
+
+    raise RuntimeError, msg, caller(1)
+  end
+
+  private
+
+  # Attribution comes from the message itself when Ruby provides it, because the
+  # call stack at that point describes the require chain rather than the code that
+  # triggered the warning -- for a warning raised while loading a gem, the stack
+  # bottoms out in whichever test file happened to require it.  Only warnings with
+  # no embedded location (Kernel#warn calls, e.g. lib/rack/session/dalli.rb) fall
+  # back to the caller.  A warning we cannot attribute is passed through rather
+  # than raised.
+  def dalli_source?(msg)
+    location = msg.to_s[MESSAGE_ORIGIN, 1] || warn_origin_from_stack
+    return false unless location
+
+    own_source?(location)
+  end
+
+  # Resolved against ROOT because the location is not always absolute: rake passes
+  # test files to the loader as relative paths, and JRuby reports them that way in
+  # backtraces (CRuby fills in absolute_path, JRuby leaves it nil).  Expanding an
+  # already-absolute path is a no-op, so this is safe for both.
+  def own_source?(location)
+    expanded = File.expand_path(location, ROOT)
+
+    OWN_SOURCE_PREFIXES.any? { |prefix| expanded.start_with?(prefix) }
+  end
+
+  # Walks the stack rather than indexing it at a fixed depth: Ruby 3.3 and 3.4 push
+  # an `<internal:warning>` frame for Kernel#warn that 4.0 does not, so any fixed
+  # offset is correct on one version and wrong on another.  Skips the warning
+  # machinery, then takes the first real caller.
+  def warn_origin_from_stack
+    caller_locations(1)&.each do |frame|
+      path = frame.absolute_path || frame.path
+      next if warn_machinery_frame?(path)
+
+      return path
+    end
+    nil
+  end
+
+  # Frames that sit between the code which called Kernel#warn and this hook, and so
+  # must not be mistaken for the origin: this file, interpreter-internal frames
+  # (`<internal:warning>`), and RubyGems' Kernel#warn shim.  That shim is active on
+  # JRuby but not CRuby, which is why a scan that stopped at the first non-internal
+  # frame attributed every Kernel#warn to RubyGems there and to the real caller here.
+  def warn_machinery_frame?(path)
+    return true if path.nil?
+
+    path.start_with?('<') || path == __FILE__ || path.end_with?(RUBYGEMS_WARN_SHIM)
+  end
+end
+
+Warning.singleton_class.prepend(StrictWarnings)

--- a/test/test_strict_warnings.rb
+++ b/test/test_strict_warnings.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require_relative 'helper'
+require 'tmpdir'
+require 'fileutils'
+
+describe StrictWarnings do
+  # Warnings emitted while loading a gem must not abort the suite.  json 2.21.2's
+  # pure-Ruby generator produces exactly this warning on JRuby at require time.
+  it 'ignores an interpreter warning originating in a gem' do
+    msg = '/app/vendor/bundle/ruby/3.4.0/gems/json-2.21.2/lib/json/ext/generator/state.rb:73: ' \
+          "warning: method redefined; discarding old to_hash\n"
+
+    _, err = capture_subprocess_io { Warning.warn(msg) }
+
+    assert_equal msg, err
+  end
+
+  it 'raises for an interpreter warning originating in lib/' do
+    msg = "#{File.expand_path('../lib/dalli/client.rb', __dir__)}:42: warning: assigned but unused variable\n"
+
+    error = assert_raises(RuntimeError) { Warning.warn(msg) }
+
+    assert_equal msg, error.message
+  end
+
+  it 'raises for an interpreter warning originating in test/' do
+    msg = "#{File.expand_path('some_test.rb', __dir__)}:42: warning: shadowing outer local variable\n"
+
+    assert_raises(RuntimeError) { Warning.warn(msg) }
+  end
+
+  # Kernel#warn produces no embedded location, so attribution falls back to the
+  # caller -- this file, which is ours.  lib/rack/session/dalli.rb relies on this.
+  it 'raises for a Kernel#warn call from Dalli code' do
+    assert_raises(RuntimeError) { warn 'no location prefix' }
+  end
+
+  # RubyGems installs a Kernel#warn shim that is active on JRuby but not CRuby, so on
+  # JRuby it sits between the caller and this hook.  Treating it as the origin
+  # attributed every Kernel#warn to RubyGems and silently disabled the fallback.
+  describe 'warning machinery frames' do
+    it 'skips RubyGems Kernel#warn shim frames' do
+      assert Warning.send(:warn_machinery_frame?,
+                          '/opt/jruby-10.1.1.0/lib/ruby/stdlib/rubygems/core_ext/kernel_warn.rb')
+    end
+
+    it 'skips interpreter-internal frames' do
+      assert Warning.send(:warn_machinery_frame?, '<internal:warning>')
+    end
+
+    it 'skips frames from the hook itself' do
+      assert Warning.send(:warn_machinery_frame?, File.expand_path('support/strict_warnings.rb', __dir__))
+    end
+
+    it 'does not skip ordinary caller frames' do
+      refute Warning.send(:warn_machinery_frame?, File.expand_path('../lib/rack/session/dalli.rb', __dir__))
+    end
+
+    # Reproduces JRuby's stack topology on any Ruby: a Kernel#warn call routed
+    # through a file at RubyGems' shim path must still be attributed to the caller
+    # below it.  Without the shim skip this passes the warning through instead.
+    it 'attributes through a shim frame to the real caller' do
+      dir = Dir.mktmpdir
+      shim_dir = File.join(dir, 'rubygems', 'core_ext')
+      FileUtils.mkdir_p(shim_dir)
+      File.write(File.join(shim_dir, 'kernel_warn.rb'), "def warn_via_shim(msg)\n  warn(msg)\nend\n")
+      require File.join(shim_dir, 'kernel_warn.rb')
+
+      assert_raises(RuntimeError) { warn_via_shim('routed through the shim') }
+    ensure
+      FileUtils.remove_entry(dir) if dir
+    end
+  end
+
+  it 'passes through intentional deprecation warnings' do
+    _, err = capture_subprocess_io { Warning.warn("[DEPRECATION] this is intentional\n") }
+
+    assert_equal "[DEPRECATION] this is intentional\n", err
+  end
+
+  # Backtrace paths are not always absolute.  Rake hands test files to the loader
+  # as relative paths and JRuby reports them that way (CRuby fills in
+  # absolute_path, JRuby leaves it nil), so attribution must resolve them.
+  describe 'source attribution' do
+    it 'recognizes a relative path under test/ as ours' do
+      assert Warning.send(:own_source?, 'test/test_strict_warnings.rb')
+    end
+
+    it 'recognizes a relative path under lib/ as ours' do
+      assert Warning.send(:own_source?, 'lib/dalli/client.rb')
+    end
+
+    it 'recognizes an absolute path under lib/ as ours' do
+      assert Warning.send(:own_source?, File.expand_path('../lib/dalli/client.rb', __dir__))
+    end
+
+    it 'does not claim a relative path outside the repository' do
+      refute Warning.send(:own_source?, '../elsewhere/lib/thing.rb')
+    end
+
+    it 'does not claim a gem path' do
+      refute Warning.send(:own_source?, '/app/vendor/bundle/gems/json-2.21.2/lib/json/ext/generator/state.rb')
+    end
+  end
+
+  it 'does not treat a path merely containing the repo name as ours' do
+    msg = "/somewhere/else/dalli-mimic/lib/thing.rb:1: warning: nope\n"
+
+    _, err = capture_subprocess_io { Warning.warn(msg) }
+
+    assert_equal msg, err
+  end
+end


### PR DESCRIPTION
Fixes the `jruby-10` job, which has been red on `main` — and therefore on every PR — since 2026-07-13.

## What broke

Not a test failure. The suite aborted during `require`, before a single test ran:

```
org.jruby.exceptions.RuntimeError: (RuntimeError)
  .../json-2.21.2-java/lib/json/ext/generator/state.rb:73:
  warning: method redefined; discarding old to_hash
    <main> at test/integration/test_compressor.rb:4
```

`Rakefile:8` runs the suite under `-w`, and `test/helper.rb` prepends `StrictWarnings` to `Warning.singleton_class` — which is **global**, so it intercepted warnings from third-party gems, not just Dalli. `json`'s pure-Ruby generator redefines `to_hash` at load time; Ruby warns; the hook turned that into a fatal error.

CRuby loads json's C extension and never executes `state.rb`, so only the JRuby job (which gets the `-java` platform gem) tripped it. There is no committed `Gemfile.lock` — CI runs `bundle lock` + `bundle install` fresh — so dependency drift alone did this. No Dalli commit is implicated: the last green run was `b9321f1` on 2026-07-13, the next run was 2026-08-01, and the only code in between was #1129's 7-line test edit.

## The fix

Attribute each warning to a source file and raise only for `lib/` and `test/`.

Attribution prefers the location Ruby embeds in the message (`path:line: warning: ...`) over the call stack, because at the moment a require-time warning fires the stack describes the *require chain* — it bottoms out in whichever test file happened to `require` the gem, which would make every gem warning look like ours. `Kernel#warn` carries no embedded location, so those fall back to the caller; `lib/rack/session/dalli.rb:200-212` depends on that path and stays strict.

Determining that caller portably turned out to need three separate rules, each found by a red CI job on this PR:

1. **Walk the stack, don't index it.** Ruby 3.3/3.4 push an `<internal:warning>` frame for `Kernel#warn` that 4.0 does not, so `caller_locations(2, 1)` was correct on 4.0 and wrong on 3.3/3.4/truffleruby.
2. **Skip RubyGems' `Kernel#warn` shim.** `rubygems/core_ext/kernel_warn.rb` is active on JRuby but not CRuby and sits between the caller and the hook. Treating it as the origin attributed every `Kernel#warn` to a stdlib path — "not ours" — silently disabling the fallback on JRuby only.
3. **Resolve relative paths.** Rake hands test files to the loader as relative paths and JRuby reports them that way, where CRuby fills in `absolute_path`.

## Tests

`StrictWarnings` moves to `test/support/` so it can be exercised under any Ruby without a `bundle install`; I verified identical behavior on 3.2, 3.3, 3.4 and 4.0 locally that way.

`test/test_strict_warnings.rb` covers each rule directly, including a regression test that **reproduces JRuby's stack topology on any Ruby** by routing a `Kernel#warn` through a file at RubyGems' shim path. I mutation-checked it: removing the shim skip fails that test on CRuby.

Full suite green locally (597 runs) and `rubocop` clean.

## Judgment call worth a look

**A warning that can't be attributed passes through instead of raising** — a gem calling `Kernel#warn` with no location and no Dalli frame beneath it. Raising would preserve maximum strictness but re-opens exactly the failure mode this PR fixes. Easy to flip if you'd rather have the stricter default.

## Unrelated flake spotted

With the suite actually running on JRuby again, `test/integration/test_failover.rb:149` ("handle graceful failover in get_multi", `Expected {"foo" => "foo1", "bar" => "bar1"} to be empty`) failed once and passed on re-run. It is unrelated to this change, and it has been invisible since July because the JRuby job never got as far as running tests. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)