### PR TITLE
Raise instead of returning a truncated value on mid-response EOF

### DIFF
--- a/lib/dalli/protocol/connection_manager.rb
+++ b/lib/dalli/protocol/connection_manager.rb
@@ -163,11 +163,15 @@ module Dalli
         end
       else
         def read(count)
-          @sock.read(count)
+          read_bytes(count)
         rescue SystemCallError, *TIMEOUT_ERRORS, *SSL_ERRORS, EOFError => e
           error_on_request!(e)
         end
       end
+
+      # Alias for callers that want to make the exact-length contract explicit
+      # at the call site.
+      alias read_exact read
 
       def write(bytes)
         @sock.write(bytes)
@@ -270,6 +274,22 @@ module Dalli
 
         time = Time.now - @down_at
         Dalli.logger.warn { format('%<name>s is back (downtime was %<time>.3f seconds)', name: name, time: time) }
+      end
+
+      private
+
+      # Reads exactly `count` bytes. IO#read(count) on a blocking socket blocks
+      # until it has `count` bytes, accumulating across TCP chunks internally,
+      # and only hands back a shorter (or nil) buffer when the stream hits EOF.
+      # So a short read means the peer closed mid-response: raise EOFError and
+      # let read's existing `rescue EOFError` route it through
+      # error_on_request!, which closes the dirty socket for a retry on a fresh
+      # connection (and preserves the $ERROR_INFO context down! relies on).
+      def read_bytes(count)
+        buffer = @sock.read(count)
+        return buffer if buffer && buffer.bytesize == count
+
+        raise EOFError, "EOF reading #{count} bytes; received #{buffer ? buffer.bytesize : 0}"
       end
     end
   end

--- a/test/integration/test_network.rb
+++ b/test/integration/test_network.rb
@@ -516,4 +516,65 @@ describe 'Network' do
       end
     end
   end
+
+  describe 'fixed-length reads' do
+    # Regression test for truncated reads: a peer that closes the connection
+    # partway through a response body must not surface a decodable-but-wrong
+    # value. The dirty socket must be closed and the request retried on a
+    # fresh connection.
+    it 'does not return a truncated value when the peer closes mid-response body' do
+      value = 'a' * 512
+      tcp_server = TCPServer.new('127.0.0.1', 0)
+      port = tcp_server.addr[1]
+      get_count = 0
+      get_count_mutex = Mutex.new
+
+      server_thread = Thread.new do
+        loop do
+          conn = tcp_server.accept
+          Thread.new(conn) do |c|
+            while (line = c.gets("\r\n"))
+              cmd, key = line.split
+              case cmd
+              when 'version'
+                c.write("VERSION 1.6.39-fake\r\n")
+              when 'mg'
+                nth = get_count_mutex.synchronize { get_count += 1 }
+                if nth == 1
+                  # Correct header + length, only part of the body, then EOF.
+                  c.write("VA #{value.bytesize} k#{key}\r\n")
+                  c.write(value[0, value.bytesize - 16])
+                  c.close
+                  break
+                else
+                  c.write("VA #{value.bytesize} k#{key}\r\n#{value}\r\n")
+                end
+              else
+                c.write("ERROR\r\n")
+              end
+            end
+          rescue IOError, Errno::ECONNRESET, Errno::EPIPE
+            nil
+          end
+        rescue IOError
+          next
+        end
+      end
+      server_thread.abort_on_exception = true
+
+      begin
+        dc = Dalli::Client.new("127.0.0.1:#{port}", raw: true, socket_timeout: 2, socket_max_failures: 2)
+        conn_mgr = dc.send(:ring).servers.first.instance_variable_get(:@connection_manager)
+
+        assert_equal value, dc.get('trunc_key'),
+                     'a mid-response EOF must not surface a truncated value'
+        assert_equal 2, get_count,
+                     'the truncated first response should trigger a transparent retry'
+        refute_predicate conn_mgr, :request_in_progress?
+      ensure
+        tcp_server.close
+        server_thread.kill
+      end
+    end
+  end
 end

--- a/test/protocol/test_connection_manager.rb
+++ b/test/protocol/test_connection_manager.rb
@@ -2,6 +2,34 @@
 
 require_relative '../helper'
 
+# IO#read(maxlen) on a blocking socket returns exactly maxlen bytes unless the
+# stream hits EOF, where it returns a shorter (non-nil) buffer or nil. This
+# models that contract deterministically: one queued result per read call, so
+# we can exercise the full read and the premature-EOF cases without a real
+# socket. (JRuby uses Socket#readfull, which this fake does not implement.)
+class ContractReadSocket
+  attr_reader :read_calls
+
+  def initialize(*chunks)
+    @chunks = chunks
+    @read_calls = []
+    @closed = false
+  end
+
+  def read(count)
+    @read_calls << count
+    @chunks.shift
+  end
+
+  def close
+    @closed = true
+  end
+
+  def closed?
+    @closed
+  end
+end
+
 describe Dalli::Protocol::ConnectionManager do
   let(:hostname) { 'localhost' }
   let(:port) { 11_211 }
@@ -257,6 +285,52 @@ describe Dalli::Protocol::ConnectionManager do
         end
 
         assert_match(/is down/, error.message)
+      end
+    end
+  end
+
+  unless RUBY_ENGINE == 'jruby'
+    describe 'exact-length reads' do
+      def connection_manager_with_socket(socket)
+        manager = Dalli::Protocol::ConnectionManager.new(
+          'localhost',
+          11_211,
+          :tcp,
+          socket_failure_delay: nil,
+          socket_max_failures: 2
+        )
+        manager.instance_variable_set(:@sock, socket)
+        manager
+      end
+
+      it 'returns the full buffer from a single read, binary-safe' do
+        socket = ContractReadSocket.new("a\x00\xFFz".b)
+        manager = connection_manager_with_socket(socket)
+
+        result = manager.read_exact(4)
+
+        assert_equal "a\x00\xFFz".b, result
+        assert_equal Encoding::BINARY, result.encoding
+        assert_equal [4], socket.read_calls
+        # #read shares the same fill semantics (both delegate to read_bytes).
+        assert_equal 'xyz', connection_manager_with_socket(ContractReadSocket.new('xyz')).read(3)
+      end
+
+      it 'raises and closes the dirty socket on a premature EOF (nil)' do
+        socket = ContractReadSocket.new(nil)
+        manager = connection_manager_with_socket(socket)
+
+        assert_raises(Dalli::RetryableNetworkError) { manager.read_exact(5) }
+        assert_predicate socket, :closed?
+        refute_predicate manager, :connected?
+      end
+
+      it 'raises and closes the dirty socket on a short read (EOF mid-response)' do
+        socket = ContractReadSocket.new('abc')
+        manager = connection_manager_with_socket(socket)
+
+        assert_raises(Dalli::RetryableNetworkError) { manager.read(5) }
+        assert_predicate socket, :closed?
       end
     end
   end


### PR DESCRIPTION
First of two PRs covering §4 ("Robustness fixes") of #1130. Originally [Shopify/dalli#77](https://github.com/Shopify/dalli/pull/77) by @ianks.

## The bug

`IO#read(count)` on a blocking socket accumulates across TCP chunks internally and blocks until it has `count` bytes. It returns a **shorter** buffer (or `nil`) in exactly one case: the stream hit EOF. `ConnectionManager#read` passed that buffer straight through as the response body.

So a peer that closes mid-response — a memcached restart, a proxy dropping the connection, an LB timeout — could hand the caller a **truncated but still decodable value**. In raw mode that is a silently short string; the caller has no way to tell it apart from a real one.

## The fix

Treat a short read as what it is and raise `EOFError`, which `read`'s existing `rescue` already routes through `error_on_request!` — closing the dirty socket so the request retries on a fresh connection.

CRuby only: the JRuby branch already calls `Socket#readfull`, which enforces the same contract. The unit tests skip on JRuby for that reason.

## Tests

- `test/integration/test_network.rb` — a fake memcached that truncates the first `mg` response body and then closes. Asserts the client returns the **full** value (via transparent retry on a fresh connection), that the retry actually happened, and that no request is left in progress.
- `test/protocol/test_connection_manager.rb` — a `ContractReadSocket` modelling `IO#read`'s contract, covering a full read (binary-safe), a `nil` EOF, and a short read.

I mutation-checked these: reverting the one-line `read` change fails the integration regression test and 2 of the 3 unit tests.

Full suite green locally (602 runs) and `rubocop` clean.

## One thing to weigh

The `read_exact` alias is currently referenced only by the new tests — no `lib/` caller uses it. It documents the contract at a call site, but it is public API surface added for tests. I kept it to stay faithful to #1130; say the word and I'll drop it and have the tests call `read`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)