### PR TITLE
Tear down the connection when a non-StandardError aborts a request

### DIFF
--- a/lib/dalli/protocol/base.rb
+++ b/lib/dalli/protocol/base.rb
@@ -40,12 +40,14 @@ module Dalli
         verify_state(opkey)
 
         begin
+          request_completed = false
           @connection_manager.start_request!
           response = send(opkey, *args)
 
           # pipelined_get/pipelined_get_interleaved emit query but don't read the response(s)
           @connection_manager.finish_request! unless %i[pipelined_get pipelined_get_interleaved].include?(opkey)
 
+          request_completed = true
           response
         rescue Dalli::MarshalError => e
           log_marshal_err(args.first, e)
@@ -56,6 +58,18 @@ module Dalli
           log_unexpected_err(e)
           close
           raise
+        ensure
+          # If the begin block didn't complete -- any exception, including a
+          # non-StandardError such as Async::Stop or Thread#kill, which the
+          # rescue clauses above never see -- tear down the connection so a
+          # half-used client isn't returned to the pool.
+          #
+          # The local flag is deliberate: reading $ERROR_INFO here would see
+          # the *outer* exception when `request` is called from inside a
+          # rescue clause (a common cache-fallback shape), and would then
+          # falsely tear down the pipelined_get happy path, which leaves
+          # @request_in_progress true on purpose until the caller drains.
+          close unless request_completed
         end
       end
 

--- a/lib/dalli/protocol/connection_manager.rb
+++ b/lib/dalli/protocol/connection_manager.rb
@@ -115,10 +115,16 @@ module Dalli
           @sock.close
         rescue StandardError
           nil
+        ensure
+          # A non-StandardError (e.g. a second Async::Stop fired into the
+          # fiber while it is already inside this cleanup) can escape
+          # @sock.close; run the state cleanup unconditionally so the client
+          # isn't returned to the pool with a half-closed socket and
+          # @request_in_progress == true.
+          @sock = nil
+          @pid = nil
+          abort_request!
         end
-        @sock = nil
-        @pid = nil
-        abort_request!
       end
 
       def connected?

--- a/test/integration/test_fiber_concurrency.rb
+++ b/test/integration/test_fiber_concurrency.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require_relative '../helper'
+
+# Stand-in for Async::Stop: the real class inherits from Exception (not
+# StandardError) so that blanket `rescue StandardError` clauses don't
+# accidentally swallow scheduler-driven fiber cancellation.  We reproduce that
+# hierarchy locally to avoid pulling the `async` gem just for the signal class.
+# rubocop:disable Lint/InheritException
+class FiberCancellation < Exception; end
+# rubocop:enable Lint/InheritException
+
+describe 'fiber concurrency' do
+  # `Async::Stop < Exception` but NOT `< StandardError`, so when the scheduler
+  # cancels a fiber parked on a blocking read inside a Dalli request, the
+  # `rescue StandardError` branch in `Base#request` is bypassed entirely.
+  # Without an `ensure` clause, `close` is never called and `abort_request!`
+  # never runs — the connection is left with `@request_in_progress == true`
+  # and any partial response bytes remain on the wire for a subsequent caller
+  # to misread.
+  #
+  # `Base#request` gates its `ensure` on a local `request_local_completed`
+  # flag so that pipelined_get's intentional request_in_progress=true happy
+  # path is not torn down — this test proves the cleanup fires on abnormal
+  # exit for non-StandardError exceptions.
+  #
+  # NOTE: this test uses the default `threadsafe: true` config.  The yield-
+  # based interleave race (one fiber parking on IO while another enters
+  # `request`) is separately protected by `Dalli::Threadsafe`, whose
+  # `Monitor.synchronize` is fiber-aware under MRI and raises
+  # `ThreadError: deadlock` rather than corrupting shared state.
+  it 'does not leave the connection dirty when a non-StandardError aborts a request' do
+    memcached_persistent do |dc|
+      dc.flush
+      dc.set('a', 'val_a')
+
+      conn_mgr = dc.send(:ring).servers.first.instance_variable_get(:@connection_manager)
+
+      close_count = 0
+      orig_close = conn_mgr.method(:close)
+      conn_mgr.define_singleton_method(:close) do
+        close_count += 1
+        orig_close.call
+      end
+
+      # Simulate Async::Stop raised into the fiber while it's parked on the
+      # response read — i.e. the scheduler cancelling mid-request.
+      conn_mgr.define_singleton_method(:read_line) do
+        raise FiberCancellation, 'simulated fiber cancellation'
+      end
+
+      assert_raises(FiberCancellation) { dc.get('a') }
+
+      refute_predicate conn_mgr, :request_in_progress?,
+                       'connection left with @request_in_progress == true after non-StandardError abort'
+      assert_operator close_count, :>=, 1,
+                      "expected close to run during non-StandardError abort, got close_count=#{close_count}"
+    end
+  end
+
+  # A second Async::Stop landing on the fiber while it is already inside the
+  # `ensure` cleanup from the first one would interrupt `@sock.close`.
+  # `ConnectionManager#close` rescues only StandardError around the socket
+  # close, so a non-StandardError escaping `@sock.close` leaves `@sock`
+  # non-nil and skips `abort_request!` — the client is returned to the pool
+  # with `@request_in_progress == true` and a half-closed socket.
+  it 'cleans up when @sock.close itself is interrupted by a second non-StandardError' do
+    memcached_persistent do |dc|
+      dc.flush
+      dc.set('a', 'val_a') # warms up the connection so @sock exists
+
+      conn_mgr = dc.send(:ring).servers.first.instance_variable_get(:@connection_manager)
+      sock = conn_mgr.instance_variable_get(:@sock)
+
+      refute_nil sock, 'precondition: socket should be connected after set'
+
+      # Second cancellation: fires when close() reaches @sock.close.
+      sock.define_singleton_method(:close) do
+        raise FiberCancellation, 'simulated second fiber cancellation during @sock.close'
+      end
+
+      # First cancellation: fires when the request parks on a read.
+      conn_mgr.define_singleton_method(:read_line) do
+        raise FiberCancellation, 'simulated first fiber cancellation'
+      end
+
+      assert_raises(FiberCancellation) { dc.get('a') }
+
+      refute_predicate conn_mgr, :request_in_progress?,
+                       'double-exception in ensure left @request_in_progress == true'
+      refute_predicate conn_mgr, :connected?,
+                       'double-exception in ensure left @sock non-nil'
+    end
+  end
+
+  # `$!` (a.k.a. $ERROR_INFO) is preserved when a method is called from
+  # inside a `rescue` clause.  An ensure clause that reads $! to decide
+  # whether "we're unwinding from an exception" sees the *outer* rescued
+  # exception even when its own begin block completed cleanly.
+  #
+  # On the pipelined_get happy path, @request_in_progress is intentionally
+  # left true (the caller still has to drain).  An ensure that closes when
+  # `$ERROR_INFO && request_in_progress?` would therefore tear the socket
+  # out from under a pipelined_get whenever it's called from inside any
+  # rescue clause — a common cache-fallback pattern.  This test pins the
+  # local-flag implementation by exercising that exact call shape.
+  #
+  # NOTE: a block is required here.  Without one, single-server get_multi
+  # takes the `optimized_for_single_server` path which uses :read_multi_req
+  # (calls finish_request!) and would not exercise the pipelined_get
+  # ensure-close window.  Passing a block forces the :pipelined_get opkey.
+  it 'does not tear down a pipelined_get when called from inside a rescue clause' do
+    memcached_persistent do |dc|
+      dc.flush
+      dc.set('a', 'val_a')
+      dc.set('b', 'val_b')
+
+      conn_mgr = dc.send(:ring).servers.first.instance_variable_get(:@connection_manager)
+
+      close_count = 0
+      orig_close = conn_mgr.method(:close)
+      conn_mgr.define_singleton_method(:close) do
+        close_count += 1
+        orig_close.call
+      end
+
+      result = {}
+      begin
+        raise 'outer rescued exception'
+      rescue StandardError
+        # $! is set to the rescued exception while this block executes,
+        # including across the get_multi call.  Block forces :pipelined_get.
+        dc.get_multi(%w[a b]) { |k, v| result[k] = v }
+      end
+
+      assert_equal({ 'a' => 'val_a', 'b' => 'val_b' }, result)
+      assert_equal 0, close_count,
+                   "pipelined_get was torn down mid-flight (close_count=#{close_count}) " \
+                   'when called from inside a rescue clause'
+    end
+  end
+end


### PR DESCRIPTION
Second of two PRs covering §4 ("Robustness fixes") of #1130. Originally Shopify/dalli#68, #69 and #71.

Independent of #1135 — different methods, no textual conflict, merge in either order.

## The bug

`Async::Stop` and `Thread#kill` descend from `Exception`, not `StandardError`, so none of the `rescue` clauses in `Base#request` see them. When a scheduler cancels a fiber parked on a response read:

- `close` is never called, so `abort_request!` never runs
- the connection keeps `@request_in_progress == true`
- partial response bytes stay on the wire for the next caller of that connection

With `connection_pool`, that half-used client goes straight back into the pool.

A second cancellation can also land *inside* the first one's cleanup: `ConnectionManager#close` rescues only `StandardError` around `@sock.close`, so a non-`StandardError` escaping it left `@sock` non-nil and skipped `abort_request!` entirely.

## The fix

- `Base#request` gets an `ensure` that closes unless the begin block ran to completion.
- `ConnectionManager#close` moves its state cleanup (`@sock = nil`, `@pid = nil`, `abort_request!`) into an `ensure` so it runs even if `@sock.close` is interrupted.

**Why a local flag and not `$ERROR_INFO`.** `$!` is still set when a method is called from inside a `rescue` clause — a common cache-fallback shape (`rescue => e; cache.get_multi(...)`). An `ensure` that closed on `$ERROR_INFO && request_in_progress?` would tear down `pipelined_get`, which leaves `@request_in_progress` true *by design* until the caller drains the responses. The third test pins exactly that call shape.

## Behavior note for review

`DalliError` and `MarshalError` now reach the `ensure` with the flag false, so they close the connection. This makes an **existing** close eager rather than adding a new one: those paths already left `@request_in_progress` true, and `ConnectionManager#confirm_ready!` (`connection_manager.rb:101`) does `close if request_in_progress?` at the start of the next request. Same number of closes, earlier timing — the dirty socket isn't held until the next call.

## Tests

New `test/integration/test_fiber_concurrency.rb` (3 tests), using a local `FiberCancellation < Exception` stand-in so the suite doesn't need the `async` gem.

Mutation-checked, each test earning its place:

| Mutation | Fails |
|---|---|
| Drop the `Base#request` ensure | tests 1 and 2 |
| Drop the `ConnectionManager#close` ensure | test 2 |
| Use `$ERROR_INFO` instead of the local flag | test 3 |

Full suite green locally (601 runs) and `rubocop` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)