### PR TITLE
Add CHANGELOG entries for #1124, #1128, #1129, #1131, #1132, #1133, #1134, #1135, #1136

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,18 @@ Features:
 
 Bug Fixes:
 
+- Raise instead of returning a truncated value when the peer closes mid-response (#1135)
+  - `IO#read(count)` on a blocking socket accumulates across TCP chunks and hands back a shorter buffer (or `nil`) in only one case: the stream hit EOF. That short buffer was passed through as the response body, so a memcached restart, proxy drop, or load balancer timeout partway through a response could surface a truncated but still decodable value to the caller, indistinguishable from a real one
+  - A short read is now treated as the premature EOF it is, raising and closing the dirty socket so the request is retried on a fresh connection
+  - CRuby only; the JRuby path already used `Socket#readfull`, which enforces the same contract
+  - Extracted from #1130; thanks to Ian Ker-Seymer for the original fix and Jianbin Chen for the port
+
+- Tear down the connection when a non-`StandardError` aborts a request (#1136)
+  - `Async::Stop` and `Thread#kill` descend from `Exception` rather than `StandardError`, so the rescue clauses in `Protocol::Base#request` never saw them; a scheduler cancelling a fiber parked on a response read skipped `close` entirely, leaving the connection marked as having a request in progress with partial response bytes still unread on the wire, and returning that half-used client to the pool under `connection_pool`
+  - `Protocol::Base#request` now closes in an `ensure` unless the request ran to completion, and `ConnectionManager#close` performs its state cleanup in an `ensure` so a second cancellation landing inside `@sock.close` cannot leave the socket non-nil with the request still marked in progress
+  - `Dalli::DalliError` and `Dalli::MarshalError` now close the connection at the point of failure rather than at the start of the next request; those paths already left the request in progress and `ConnectionManager#confirm_ready!` closed on the next call, so this changes when the close happens rather than adding one
+  - Extracted from #1130; thanks to Jianbin Chen for this contribution
+
 - Fix `ResponseBuffer` compaction logic (#1119)
   - `COMPACT_THRESHOLD` was removed in #1116 as apparently unused, but the constant was referenced by the compaction guard; its absence silently disabled buffer compaction
   - Restored the constant, corrected the compaction condition, and improved the buffer-shrinking implementation to use `String#bytesplice` (backed by `memmove`) for true in-place compaction

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Unreleased
 
 Performance:
 
+- Skip the cas-return flag on quiet `meta_set` requests (#1131)
+  - In quiet mode memcached suppresses the `ms` response entirely, so the CAS requested by the `c` flag can never be read; sending it only added two bytes to every request
+  - Applies to the bulk-write paths, where quiet sets are emitted: `Dalli::Client#multi` blocks and the pipelined setter
+  - Extracted from #1130; thanks to Jianbin Chen for this contribution
+
 - Reduce allocations in `KeyRegularizer` and multi-key request paths (#1120)
   - Decomposed `KeyRegularizer#encode` into separate `needs_encoding?` and `encode` calls so the common happy path avoids allocating an intermediate array for the two-element return value
   - Refactored `multi_get`/`multi_set`/`multi_delete` command generation into `RequestFormatter` to share its key-encoding helpers
@@ -57,6 +62,31 @@ Bug Fixes:
   - Thanks to Jean Boussier for this contribution
 
 Maintenance:
+
+- Scope `StrictWarnings` to Dalli's own source (#1134)
+  - The test suite runs under `-w` and prepends a hook to `Warning.singleton_class` that turns warnings into failures, but that hook is global: a warning emitted while loading any third-party gem aborted the whole suite before a single test ran
+  - `json` 2.21.2's pure-Ruby generator (used on JRuby, where the C extension is unavailable) warns `method redefined; discarding old to_hash` at require time, which took the `jruby-10` CI job red with no change to Dalli
+  - Warnings are now attributed to a source file and only raise for `lib/` and `test/`; attribution prefers the location Ruby embeds in the message, since the stack at that point describes the require chain rather than the offending code
+  - Portable attribution of `Kernel#warn` callers also required walking the stack rather than indexing it (Ruby 3.3/3.4 push an `<internal:warning>` frame that 4.0 does not), skipping RubyGems' `Kernel#warn` shim (active on JRuby but not CRuby), and resolving relative backtrace paths
+
+- Make raw and namespace fast path tests actually use those options (#1129)
+  - Followup to #1127: the `raw` and `namespace` variants passed those options to the helper that starts memcached, which configures the client the tests then discarded, so neither option was ever exercised
+  - Passes the options to the client under test and adds assertions that fail if they are absent
+  - Thanks to Iliana Hadzhiatanasova for this contribution
+
+- Benchmark `set_multi` and add a `delete_multi` target (#1132)
+  - Enables the two `set_multi` reports that were commented out pending the arrival of `set_multi`, resolving the accompanying TODO
+  - Adds a `delete_multi` target comparing the pipelined path against N single deletes
+  - Extracted from #1130; thanks to Jianbin Chen for this contribution
+
+- Bump CI memcached to 1.6.41 and run benchmarks on pull requests (#1133)
+  - The tests workflow moves from 1.6.40 to 1.6.41; the benchmarks and profile workflows had drifted back on 1.6.23
+  - Extracted from #1130; thanks to Jianbin Chen for this contribution
+
+- Disable RuboCop metrics cops (#1128)
+  - Thanks to Jean Boussier for this contribution
+
+- Bump `actions/checkout` from 6 to 7 (#1124)
 
 - Remove `PIDCache` module (#1125)
   - `Process.pid` is cached natively by Ruby 3.3+ (via https://bugs.ruby-lang.org/issues/19443), making the manual cache unnecessary now that Dalli requires Ruby 3.3+


### PR DESCRIPTION
Brings the Unreleased section up to date with everything merged since 5.0.5, in preparation for the 5.0.6 patch release.

I cross-checked every merge commit in `14b87ba..main` against the PR numbers cited in the Unreleased section. The only merges deliberately unlisted are #1122 and #1123, which are themselves CHANGELOG-only PRs.

## Attribution

The entries carved out of #1130 (#1131, #1132, #1133, #1135, #1136) credit **Jianbin Chen**, with an explicit "Extracted from #1130" note so the provenance is visible without digging through git history.

#1135 additionally credits **Ian Ker-Seymer**, who wrote the original fix as Shopify/dalli#77 — the entry distinguishes the original fix from the port.

#1134 carries no credit line, matching how maintainer-authored entries are already recorded (e.g. #1101, #1096).

## Categorisation

#1135 and #1136 are filed under **Bug Fixes** rather than Maintenance: both are user-visible correctness fixes, one returning wrong data to callers and one leaking a half-used connection back into the pool.

#1136's entry explicitly records the behavior change reviewers should know about — `DalliError` and `MarshalError` now close the connection at the point of failure rather than at the start of the next request. That is the same close moved earlier, not a new one (`confirm_ready!` already closed on the next call), but it is the one item in the patch release that is not purely additive or internal.

## One judgment call

I included **#1124** (dependabot's `actions/checkout` 6 → 7). There is no precedent either way — it is the first dependabot merge in the repo's history, so no convention exists to follow. I listed it because omitting it while listing #1133 (a CI workflow bump) would be inconsistent. Happy to drop it if you would rather keep dependabot noise out of the changelog; worth deciding now, since it sets the precedent for every future bump.

## Remaining for 5.0.6

Once this merges, the release needs a "Prepare 5.0.6 release" commit: bump `lib/dalli/version.rb` (currently 5.0.5) and convert the `Unreleased` heading to `5.0.6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)