### PR TITLE
Create a GitHub Release automatically on version tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+name: Release
+
+# `rake release` pushes the version tag as part of publishing the gem, so this
+# fires automatically on release.  It only creates the GitHub Release; the gem
+# itself is still pushed to RubyGems by `rake release`.
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  github-release:
+    runs-on: ubuntu-latest
+    # Forks share the tag namespace but not the release; don't have them try.
+    if: github.repository == 'petergoldstein/dalli'
+
+    steps:
+    - uses: actions/checkout@v7
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ruby
+
+    - name: Build release notes from the CHANGELOG
+      env:
+        TAG: ${{ github.ref_name }}
+      run: |
+        version="${TAG#v}"
+        echo "VERSION=${version}" >> "$GITHUB_ENV"
+        # Fails the job if the version has no CHANGELOG section, rather than
+        # publishing a release with empty notes.
+        ruby scripts/changelog_section.rb "$version" > release_notes.md
+        echo "--- release notes for ${version} ---"
+        cat release_notes.md
+
+    - name: Create the GitHub Release
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TAG: ${{ github.ref_name }}
+      run: |
+        if gh release view "$TAG" >/dev/null 2>&1; then
+          echo "Release $TAG already exists; nothing to do."
+          exit 0
+        fi
+
+        args=(--title "$TAG" --notes-file release_notes.md --verify-tag)
+        # Gem prereleases carry a letter in the version (5.1.0.rc1, 5.1.0.pre).
+        if [[ "$VERSION" =~ [a-zA-Z] ]]; then
+          args+=(--prerelease)
+        fi
+
+        gh release create "$TAG" "${args[@]}"

--- a/scripts/changelog_section.rb
+++ b/scripts/changelog_section.rb
@@ -1,0 +1,44 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Prints the CHANGELOG section for a single version, for use as GitHub release
+# notes.  Exits non-zero with a message on stderr if the version has no section,
+# so a release workflow fails loudly rather than publishing empty notes.
+#
+#   ruby scripts/changelog_section.rb 5.0.6
+#
+# Sections are setext headings: a title line followed by a line of '=' characters.
+# The section runs until the next heading of any kind.
+
+CHANGELOG = File.expand_path('../CHANGELOG.md', __dir__)
+
+def heading_at?(lines, index)
+  underline = lines[index + 1]
+  return false if underline.nil?
+
+  !lines[index].empty? && underline.match?(/\A=+\z/)
+end
+
+def section_for(lines, version)
+  start = (0...lines.size).find { |i| lines[i] == version && heading_at?(lines, i) }
+  return nil unless start
+
+  body_start = start + 2
+  body_end = ((body_start + 1)...lines.size).find { |i| heading_at?(lines, i) } || lines.size
+
+  lines[body_start...body_end]
+end
+
+version = ARGV[0].to_s.strip
+abort 'usage: changelog_section.rb VERSION' if version.empty?
+
+lines = File.readlines(CHANGELOG, chomp: true)
+section = section_for(lines, version)
+abort "No CHANGELOG section found for version #{version}" if section.nil?
+
+# Trailing blank lines separate this section from the next heading; leading ones
+# are an artifact of the heading underline.
+body = section.join("\n").strip
+abort "CHANGELOG section for version #{version} is empty" if body.empty?
+
+puts body


### PR DESCRIPTION
The repo has 71 tags and no GitHub Releases. This populates them going forward, without adding a step anyone has to remember: `rake release` already pushes the version tag while publishing the gem, so the workflow fires on that push.

## Why bother

Dependabot and Renovate render GitHub release notes directly in the upgrade PRs they open. Without a release, a bot bumping `dalli 5.0.5 → 5.0.6` in a downstream app shows a commit list or nothing; with one, the reviewer sees "connections could return truncated values on mid-response EOF" at the moment they're deciding whether to take the upgrade.

## How it works

`scripts/changelog_section.rb VERSION` prints the CHANGELOG section for one version. The CHANGELOG is already structured for this — each version is a setext heading, so the section is unambiguous.

The script **exits non-zero if the section is missing or empty**, which fails the job rather than publishing a release with empty notes. Verified locally:

| Input | Result |
|---|---|
| `5.0.6` | 111 lines, stops cleanly before the 5.0.5 heading |
| `5.0.5`, `5.0.4` | correct sections |
| `9.9.9` | exit 1, `No CHANGELOG section found for version 9.9.9` |
| `Unreleased` (currently empty) | exit 1, `CHANGELOG section for version Unreleased is empty` |
| (no argument) | exit 1, usage |

The workflow also skips forks (`github.repository ==`), is idempotent if the release already exists (so re-runs are safe), and passes `--prerelease` when the version contains a letter (`5.1.0.rc1`).

## Scope

Gem publishing is untouched — `rake release` still pushes to RubyGems. This only creates the GitHub Release.

## Security

All workflow interpolation goes through `env:` rather than inline `${{ }}` in `run:` blocks, so a tag name cannot inject shell. The only inputs are `github.ref_name` (pushable by maintainers only) and `secrets.GITHUB_TOKEN`. `permissions:` is scoped to `contents: write`, the minimum needed to create a release.

## Verification

`rubocop` clean (89 files) and full suite green (605 runs). The `gh release create` invocation itself is exercised by the v5.0.6 release I drafted from this script's output.

## Follow-up

No CHANGELOG entry here, matching the repo's practice of batching those into a separate PR. Worth including in the next batch under Maintenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)