### PR TITLE
Fix three flaky tests

### DIFF
--- a/test/test_key_manager.rb
+++ b/test/test_key_manager.rb
@@ -296,7 +296,12 @@ describe 'KeyManager' do
       end
 
       describe 'when the key with namespace is shorter than 250 characters' do
-        let(:keylen) { rand(250 - (half_namespace_len * 2)) + 1 }
+        # The stored key is "<namespace>:<key>", and KeyManager truncates when
+        # that exceeds 250 characters.  The namespace is SecureRandom.hex, so it
+        # is twice half_namespace_len; with the separator that leaves 249 - it
+        # for the key itself.  Generating up to 250 - it produced a 251
+        # character key roughly one run in 250, which truncated and failed.
+        let(:keylen) { rand(1..(249 - (half_namespace_len * 2))) }
         let(:alphanum) { [('a'..'z').to_a, ('A'..'Z').to_a, ('0'..'9').to_a].flatten }
         let(:key) { Array.new(keylen) { alphanum.sample }.join }
 

--- a/test/test_rack_session.rb
+++ b/test/test_rack_session.rb
@@ -202,8 +202,13 @@ describe Rack::Session::Dalli do
     assert_includes res.body, { 'counter' => 1 }.to_s
   end
 
+  # Freshness and expiry were asserted in one test against a one second TTL, so
+  # the two back-to-back requests raced the expiry: on a loaded machine the
+  # session could lapse between them and the second request saw a new session
+  # with counter 1.  Freshness needs a TTL long enough that it cannot expire
+  # mid-test; only the expiry case needs a short one.
   it 'maintains freshness of existing sessions' do
-    rsd = Rack::Session::Dalli.new(incrementor, expire_after: 1)
+    rsd = Rack::Session::Dalli.new(incrementor, expire_after: 60)
     res = Rack::MockRequest.new(rsd).get('/')
 
     assert_includes res.body, { 'counter' => 1 }.to_s
@@ -212,6 +217,17 @@ describe Rack::Session::Dalli do
 
     assert_equal cookie, res['Set-Cookie']
     assert_includes res.body, { 'counter' => 2 }.to_s
+  end
+
+  it 'expires a session that has been refreshed' do
+    rsd = Rack::Session::Dalli.new(incrementor, expire_after: 1)
+    res = Rack::MockRequest.new(rsd).get('/')
+    cookie = res['Set-Cookie']
+
+    # Refresh it, then outlast the TTL.  Deliberately asserts nothing about the
+    # refresh itself: whether it lands inside the TTL is exactly the timing this
+    # test must not depend on.
+    Rack::MockRequest.new(rsd).get('/', 'HTTP_COOKIE' => cookie)
     puts 'Sleeping to expire session' if $DEBUG
     sleep 2
     res = Rack::MockRequest.new(rsd).get('/', 'HTTP_COOKIE' => cookie)

--- a/test/utils/memcached_manager.rb
+++ b/test/utils/memcached_manager.rb
@@ -70,6 +70,8 @@ module MemcachedManager
     rescue Errno::ECHILD, Errno::ESRCH => e
       puts e.inspect
     end
+
+    confirm_stopped(port_or_socket)
   end
 
   def self.kill_and_wait(pid)
@@ -77,8 +79,49 @@ module MemcachedManager
     Process.wait(pid)
   end
 
+  # Tests that kill a server then assert on its absence depend on the port
+  # actually being free.  Reaping the pid is not on its own proof of that -- if
+  # some other process still holds the port, the client keeps getting answers
+  # and the assertion fails somewhere far from the cause.  Fail here instead,
+  # where the reason is obvious.
+  STOP_TIMEOUT_SECONDS = 5
+  def self.confirm_stopped(port_or_socket)
+    port = port_or_socket.to_i
+    return if port.zero? # UNIX socket; memcached removes the socket file itself
+
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + STOP_TIMEOUT_SECONDS
+    loop do
+      return unless port_accepting?(port)
+
+      if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+        raise "memcached on port #{port} still accepting connections " \
+              "#{STOP_TIMEOUT_SECONDS}s after being stopped"
+      end
+
+      sleep 0.05
+    end
+  end
+
+  def self.port_accepting?(port)
+    TCPSocket.new('127.0.0.1', port).close
+    true
+  rescue SystemCallError
+    false
+  end
+
+  # A start that raised may still have spawned a process holding the port.
+  # Dropping the pid without killing it leaked that process: the port stayed
+  # bound, subsequent kills targeted a pid that no longer owned it, and tests
+  # asserting a server was gone found a live one.
   def self.failed_start(port_or_socket)
-    @running_pids[port_or_socket] = nil
+    pid = @running_pids.delete(port_or_socket)
+    return unless pid
+
+    begin
+      kill_and_wait(pid)
+    rescue Errno::ECHILD, Errno::ESRCH
+      nil
+    end
   end
 
   def self.parse_port_or_socket(port)


### PR DESCRIPTION
Four PRs in a row (#1134, #1137, #1140, and a rerun of #1140) went red on tests unrelated to their changes. With #1140 doubling the matrix to 12 jobs, exposure roughly doubled too — right as the 5.1.0 feature PRs start landing.

Three distinct causes, one per test.

## 1. `test_key_manager.rb` — off-by-two, ~1 run in 250

The stored key is `"<namespace>:<key>"` and `KeyManager` truncates above 250 characters. The namespace is `SecureRandom.hex(half)`, so it is `2 * half` characters; with the separator that leaves `249 - it` for the key. The test generated up to `250 - it`:

| half | namespace | max generated keylen | full key | result |
|---|---|---|---|---|
| 1 | 2 | 248 | 251 | truncates |
| 3 | 6 | 244 | 251 | truncates |
| 5 | 10 | 240 | 251 | truncates |

The top of the range **always** produced a 251-character key, for every namespace size. Failure probability ≈ `1/(250 - namespace)` ≈ 0.4% per run.

Verified: the new bound cannot truncate for any namespace size (0/5 vs 5/5), and 400 consecutive runs of the namespace tests pass.

## 2. `test_rack_session.rb` — freshness raced its own TTL

One test asserted both freshness and expiry against `expire_after: 1`, so the two back-to-back requests raced the expiry. When they straddled it, the second request saw a new session and `counter => 1`, failing the `counter => 2` assertion at line 213 — which is exactly where CI failed.

Split into two tests: freshness now uses a TTL it cannot outlive, and the expiry case deliberately asserts nothing about its refresh, since whether the refresh lands inside the TTL is the timing it must not depend on. Coverage is preserved — the refreshed-then-expired path is still exercised.

## 3. `MemcachedManager` — a leaked process could keep serving a "killed" port

`failed_start` dropped the pid without killing it:

```ruby
def self.failed_start(port_or_socket)
  @running_pids[port_or_socket] = nil
end
```

`start_and_flush_with_retry` calls it on any error and retries. If the start had already spawned a process before failing, that process kept holding the port while the manager forgot it. A later `memcached_kill` then targeted a pid that no longer owned the port, and a test asserting the server was gone could still get answers — which is precisely the `test_failover.rb:149` symptom, `Expected {"foo" => "foo1", "bar" => "bar1"} to be empty`.

Now it kills what it forgets, and `stop` confirms the port stopped accepting connections instead of assuming that reaping the pid was enough. If a port is somehow still live, the harness raises where the cause is obvious rather than failing an assertion far downstream.

## Honesty about the failover one

The first two are proven: I reproduced the mechanism arithmetically and confirmed the fixes over 400 and 12 runs respectively.

The failover flake I could **not** reproduce locally — 25 clean runs, then 15 more under CPU contention, then 20 after the fix. The leak above is a real defect I found by reading the harness and it matches the observed symptom, but I cannot claim proof that it was the cause. If failover flakes again after this, the next suspect is Dalli's own behavior when a server dies mid-pipeline, not the harness.

## Verification

Full suite green (606 runs), `rubocop` clean, and a positive control on the new port probe: reports `true` while a server runs, `false` after `stop`, with `confirm_stopped` returning cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)