### PR TITLE
Drop version gates that can no longer fire

### DIFF
--- a/test/integration/test_cas.rb
+++ b/test/integration/test_cas.rb
@@ -170,56 +170,50 @@ describe 'CAS behavior' do
         end
       end
 
-      # There's a bug in some versions of memcached where
-      # the meta delete doesn't honor the CAS argument
-      # Ensure our tests run correctly when used with
-      # either set of versions
-      if MemcachedManager.supports_delete_cas?(p)
-        it 'supports delete with CAS' do
-          memcached_persistent(p) do |dc|
-            cas = dc.set('some_key', 'some_value')
+      it 'supports delete with CAS' do
+        memcached_persistent(p) do |dc|
+          cas = dc.set('some_key', 'some_value')
 
-            # It returns falsey and doesn't delete
-            # when the CAS is wrong
-            refute dc.delete_cas('some_key', 123)
-            assert_equal 'some_value', dc.get('some_key')
+          # It returns falsey and doesn't delete
+          # when the CAS is wrong
+          refute dc.delete_cas('some_key', 123)
+          assert_equal 'some_value', dc.get('some_key')
 
-            dc.delete_cas('some_key', cas)
+          dc.delete_cas('some_key', cas)
 
-            assert_nil dc.get('some_key')
+          assert_nil dc.get('some_key')
 
-            refute dc.delete_cas('nonexist', 123)
-          end
+          refute dc.delete_cas('nonexist', 123)
         end
+      end
 
-        it 'handles CAS round-trip operations' do
-          memcached_persistent(p) do |dc|
-            dc.flush
+      it 'handles CAS round-trip operations' do
+        memcached_persistent(p) do |dc|
+          dc.flush
 
-            expected = { 'blah' => 'blerg!' }
-            dc.set('some_key', expected)
+          expected = { 'blah' => 'blerg!' }
+          dc.set('some_key', expected)
 
-            value, cas = dc.get_cas('some_key')
+          value, cas = dc.get_cas('some_key')
 
-            assert_equal value, expected
-            assert(!cas.nil? && cas != 0)
+          assert_equal value, expected
+          assert(!cas.nil? && cas != 0)
 
-            # Set operation, first with wrong then with correct CAS
-            expected = { 'blah' => 'set succeeded' }
+          # Set operation, first with wrong then with correct CAS
+          expected = { 'blah' => 'set succeeded' }
 
-            refute(dc.set_cas('some_key', expected, cas + 1))
-            assert op_addset_succeeds(cas = dc.set_cas('some_key', expected, cas))
+          refute(dc.set_cas('some_key', expected, cas + 1))
+          assert op_addset_succeeds(cas = dc.set_cas('some_key', expected, cas))
 
-            # Replace operation, first with wrong then with correct CAS
-            expected = { 'blah' => 'replace succeeded' }
+          # Replace operation, first with wrong then with correct CAS
+          expected = { 'blah' => 'replace succeeded' }
 
-            refute(dc.replace_cas('some_key', expected, cas + 1))
-            assert op_addset_succeeds(cas = dc.replace_cas('some_key', expected, cas))
+          refute(dc.replace_cas('some_key', expected, cas + 1))
+          assert op_addset_succeeds(cas = dc.replace_cas('some_key', expected, cas))
 
-            # Delete operation, first with wrong then with correct CAS
-            refute(dc.delete_cas('some_key', cas + 1))
-            assert dc.delete_cas('some_key', cas)
-          end
+          # Delete operation, first with wrong then with correct CAS
+          refute(dc.delete_cas('some_key', cas + 1))
+          assert dc.delete_cas('some_key', cas)
         end
       end
 

--- a/test/utils/memcached_manager.rb
+++ b/test/utils/memcached_manager.rb
@@ -154,20 +154,13 @@ module MemcachedManager
     @version
   end
 
-  MIN_META_VERSION = '1.6'
+  # determine_cmd refuses to return a binary below MEMCACHED_MIN_VERSION and
+  # raises when it finds none, so anything reachable from here is already known
+  # to be a supported version.  Guards that re-checked lower thresholds (the
+  # meta protocol at 1.6, the meta delete CAS fix at 1.6.13) could no longer
+  # fire once the floor moved to 1.6.27 and have been removed.
   def self.supported_protocols
-    return [] unless version
-    raise "Dalli 5.0+ requires memcached #{MIN_META_VERSION}+" unless at_least_version?(version, MIN_META_VERSION)
-
     %i[meta]
-  end
-
-  # Meta delete did not honor the CAS argument before this version.
-  META_DELETE_CAS_FIX_VERSION = '1.6.13'
-  def self.supports_delete_cas?(protocol)
-    return true unless protocol == :meta
-
-    at_least_version?(version, META_DELETE_CAS_FIX_VERSION)
   end
 
   def self.cmd_with_args(port_or_socket, args)


### PR DESCRIPTION
Follow-up to #1140, which raised the memcached floor to 1.6.27 and left three version guards that check lower thresholds.

## Why they are dead

`determine_cmd` refuses to return a binary below `MIN_SUPPORTED_MEMCACHED_VERSION` and raises `Errno::ENOENT` when it finds none. `version` is assigned nowhere else. So by the time any of these guards runs, the version is already known to be ≥ 1.6.27.

| Guard | Threshold | Reachable? |
|---|---|---|
| `supports_delete_cas?` | 1.6.13 | never false |
| `supported_protocols` raise | 1.6 | never raises |
| `supported_protocols`' `return [] unless version` | — | `version` returns a string or raises |

The first mattered most: it wrapped **two** tests in `test/integration/test_cas.rb` in an `if` that always ran, along with a comment about supporting "either set of versions" that no longer describes anything reachable.

## Kept

`test/helper.rb:22`'s `raise ... unless MemcachedManager.version`. It is technically unreachable for the same reason, but it costs nothing and its message is friendlier than the `Errno::ENOENT` that surfaces otherwise.

## Coverage

Unchanged. Both previously guarded tests already ran on every supported server, and the suite count is identical at **606 runs, 0 failures**. `rubocop` clean.

If the floor ever drops back below 1.6.13, the gate is a few lines to reintroduce — and it would need rewriting anyway, since its comment no longer names a version anyone can run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)