### PR TITLE
Add :miss and return_ttl_remaining to get_with_metadata

### DIFF
--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -106,17 +106,23 @@ module Dalli
     #   - :return_cas [Boolean] return the CAS value (default: true)
     #   - :return_hit_status [Boolean] return whether item was previously accessed
     #   - :return_last_access [Boolean] return seconds since last access
+    #   - :return_ttl_remaining [Boolean] return seconds of TTL remaining (-1 if no TTL)
     #   - :skip_lru_bump [Boolean] don't bump LRU or update access stats
     #
     # @return [Hash] containing:
     #   - :value - the cached value (or nil on miss)
     #   - :cas - the CAS value
+    #   - :miss - true when the key does not exist.  Always present.  Prefer it
+    #     over a nil :value, which cannot distinguish a miss from a stored nil
+    #     under cache_nils
     #   - :hit_before - true/false if previously accessed (only if return_hit_status: true)
     #   - :last_access - seconds since last access (only if return_last_access: true)
+    #   - :ttl_remaining - seconds of TTL remaining, -1 when the item has no
+    #     expiry (only if return_ttl_remaining: true)
     #
     # @example Get with hit status
     #   result = client.get_with_metadata('key', return_hit_status: true)
-    #   # => { value: "data", cas: 123, hit_before: true }
+    #   # => { value: "data", cas: 123, miss: false, hit_before: true }
     #
     # @example Get with all metadata without affecting LRU
     #   result = client.get_with_metadata('key',

--- a/lib/dalli/protocol/meta.rb
+++ b/lib/dalli/protocol/meta.rb
@@ -88,12 +88,15 @@ module Dalli
           key: key, value: true, return_cas: true,
           vivify_ttl: options[:vivify_ttl], recache_ttl: options[:recache_ttl],
           return_hit_status: options[:return_hit_status],
-          return_last_access: options[:return_last_access], skip_lru_bump: options[:skip_lru_bump]
+          return_last_access: options[:return_last_access],
+          return_ttl_remaining: options[:return_ttl_remaining],
+          skip_lru_bump: options[:skip_lru_bump]
         )
         flushed_write(req)
         response_processor.meta_get_with_metadata(
           cache_nils: cache_nils?(options), return_hit_status: options[:return_hit_status],
-          return_last_access: options[:return_last_access]
+          return_last_access: options[:return_last_access],
+          return_ttl_remaining: options[:return_ttl_remaining]
         )
       end
 

--- a/lib/dalli/protocol/request_formatter.rb
+++ b/lib/dalli/protocol/request_formatter.rb
@@ -36,8 +36,8 @@ module Dalli
         # - l<N>: Seconds since last access
         def meta_get(key:, value: true, return_cas: false, ttl: nil, quiet: false,
                      vivify_ttl: nil, recache_ttl: nil,
-                     return_hit_status: false, return_last_access: false, skip_lru_bump: false,
-                     skip_flags: false)
+                     return_hit_status: false, return_last_access: false, return_ttl_remaining: false,
+                     skip_lru_bump: false, skip_flags: false)
           cmd = "mg #{encoded_key(key)}"
           # In raw mode (skip_flags: true), we don't request bitflags since they're not used.
           # This saves 2 bytes per request and skips parsing on response.
@@ -49,6 +49,7 @@ module Dalli
           cmd << " R#{recache_ttl}" if recache_ttl # Thundering herd: win recache if TTL below threshold
           cmd << ' h' if return_hit_status # Return hit status (0 or 1)
           cmd << ' l' if return_last_access # Return seconds since last access
+          cmd << ' t' if return_ttl_remaining # Return seconds of TTL remaining (-1 = no TTL)
           cmd << ' u' if skip_lru_bump # Don't bump LRU or update access stats
           cmd << TERMINATOR
         end

--- a/lib/dalli/protocol/response_processor.rb
+++ b/lib/dalli/protocol/response_processor.rb
@@ -72,11 +72,13 @@ module Dalli
         #
         # Used by meta_get for comprehensive metadata retrieval.
         # Supports thundering herd protection (N/R flags) and metadata flags (h/l/u).
-        def meta_get_with_metadata(cache_nils: false, return_hit_status: false, return_last_access: false)
+        def meta_get_with_metadata(cache_nils: false, return_hit_status: false, return_last_access: false,
+                                   return_ttl_remaining: false)
           tokens = error_on_unexpected!(T_VA_EN_HD)
           result = build_metadata_result(tokens)
           result[:hit_before] = hit_status_from_tokens(tokens) if return_hit_status
           result[:last_access] = last_access_from_tokens(tokens) if return_last_access
+          result[:ttl_remaining] = ttl_remaining_from_tokens(tokens) if return_ttl_remaining
           result[:value] = parse_value_from_tokens(tokens, cache_nils)
           result
         end
@@ -85,7 +87,12 @@ module Dalli
           {
             value: nil, cas: cas_from_tokens(tokens),
             won_recache: tokens.include?('W'), stale: tokens.include?('X'),
-            lost_recache: tokens.include?('Z')
+            lost_recache: tokens.include?('Z'),
+            # Explicit miss marker: EN means the key does not exist.  A tombstoned
+            # item is NOT a miss -- it answers VA/HD with the X flag set -- and a
+            # stored nil under cache_nils is not one either, so neither can be
+            # inferred from value or cas alone.
+            miss: tokens.first == EN
           }
         end
 
@@ -258,6 +265,12 @@ module Dalli
         # The l flag returns l<seconds>
         def last_access_from_tokens(tokens)
           value_from_tokens(tokens, 'l').to_i
+        end
+
+        # Returns seconds of TTL remaining; -1 when the item has no expiry.
+        # The t flag returns t<seconds>.
+        def ttl_remaining_from_tokens(tokens)
+          value_from_tokens(tokens, 't').to_i
         end
 
         def body_len_from_tokens(tokens)

--- a/test/integration/test_thundering_herd.rb
+++ b/test/integration/test_thundering_herd.rb
@@ -298,6 +298,70 @@ describe 'thundering herd protection' do
           assert_equal 'simple_value', result[:value]
           refute result.key?(:hit_before), 'Should not include hit_before when not requested'
           refute result.key?(:last_access), 'Should not include last_access when not requested'
+          refute result.key?(:ttl_remaining), 'Should not include ttl_remaining when not requested'
+        end
+      end
+
+      it 'returns the remaining TTL when requested' do
+        memcached_persistent(:meta) do |dc|
+          dc.flush
+          dc.set('ttl_key', 'ttl_value', 300)
+
+          result = dc.get_with_metadata('ttl_key', return_ttl_remaining: true)
+
+          assert_equal 'ttl_value', result[:value]
+          # Bounded rather than exact: the server counts down from the moment of
+          # the set, so any assertion on a specific value races the clock.
+          assert_operator result[:ttl_remaining], :positive?
+          assert_operator result[:ttl_remaining], :<=, 300
+        end
+      end
+
+      it 'returns -1 as the remaining TTL for an item stored without an expiry' do
+        memcached_persistent(:meta) do |dc|
+          dc.flush
+          dc.set('no_ttl_key', 'no_ttl_value')
+
+          result = dc.get_with_metadata('no_ttl_key', return_ttl_remaining: true)
+
+          assert_equal(-1, result[:ttl_remaining])
+        end
+      end
+
+      it 'reports a miss for a key that does not exist' do
+        memcached_persistent(:meta) do |dc|
+          dc.flush
+
+          result = dc.get_with_metadata('never_stored')
+
+          assert result[:miss]
+          assert_nil result[:value]
+        end
+      end
+
+      it 'does not report a stored value as a miss' do
+        memcached_persistent(:meta) do |dc|
+          dc.flush
+          dc.set('present_key', 'present_value')
+
+          refute dc.get_with_metadata('present_key')[:miss]
+        end
+      end
+
+      # A nil value is indistinguishable from a miss by :value alone, which is
+      # the reason :miss reads the protocol response rather than the value.
+      it 'distinguishes a stored nil from a miss' do
+        memcached_persistent(:meta) do |dc|
+          dc.flush
+          dc.set('nil_key', nil)
+
+          stored = dc.get_with_metadata('nil_key')
+          missing = dc.get_with_metadata('never_stored')
+
+          assert_nil stored[:value]
+          assert_nil missing[:value]
+          refute stored[:miss], 'a stored nil is not a miss'
+          assert missing[:miss]
         end
       end
     end

--- a/test/protocol/test_request_formatter.rb
+++ b/test/protocol/test_request_formatter.rb
@@ -81,10 +81,17 @@ describe Dalli::Protocol::Meta::RequestFormatter do
                      Dalli::Protocol::Meta::RequestFormatter.meta_get(key: key, skip_lru_bump: true)
       end
 
+      it 'sets the t flag when return_ttl_remaining is true' do
+        assert_equal "mg #{key} v f t\r\n",
+                     Dalli::Protocol::Meta::RequestFormatter.meta_get(key: key, return_ttl_remaining: true)
+      end
+
       it 'combines all metadata flags' do
-        assert_equal "mg #{key} v f h l u\r\n",
+        assert_equal "mg #{key} v f h l t u\r\n",
                      Dalli::Protocol::Meta::RequestFormatter.meta_get(key: key, return_hit_status: true,
-                                                                      return_last_access: true, skip_lru_bump: true)
+                                                                      return_last_access: true,
+                                                                      return_ttl_remaining: true,
+                                                                      skip_lru_bump: true)
       end
     end
   end

--- a/test/protocol/test_response_processor.rb
+++ b/test/protocol/test_response_processor.rb
@@ -365,4 +365,75 @@ describe Dalli::Protocol::Meta::ResponseProcessor do
       assert result[0] # ok status
     end
   end
+  describe '#meta_get_with_metadata' do
+    it 'marks an EN response as a miss' do
+      expect_read_line('EN')
+
+      result = processor.meta_get_with_metadata
+
+      assert result[:miss]
+      assert_nil result[:value]
+      io_source.verify
+    end
+
+    it 'does not mark a found item as a miss' do
+      serialized = Marshal.dump('hello')
+      expect_read_line("VA #{serialized.bytesize} f1 c7")
+      expect_read_data(serialized, serialized.bytesize)
+
+      result = processor.meta_get_with_metadata
+
+      refute result[:miss]
+      assert_equal 'hello', result[:value]
+      assert_equal 7, result[:cas]
+      io_source.verify
+    end
+
+    # A tombstoned item answers VA with the X flag, so it must not be reported as
+    # a miss -- that distinction is the whole point of the :miss key.
+    it 'does not mark a stale item as a miss' do
+      serialized = Marshal.dump('stale value')
+      expect_read_line("VA #{serialized.bytesize} f1 X")
+      expect_read_data(serialized, serialized.bytesize)
+
+      result = processor.meta_get_with_metadata
+
+      refute result[:miss]
+      assert result[:stale]
+      io_source.verify
+    end
+
+    it 'omits ttl_remaining unless requested' do
+      serialized = Marshal.dump('v')
+      expect_read_line("VA #{serialized.bytesize} f1 t42")
+      expect_read_data(serialized, serialized.bytesize)
+
+      result = processor.meta_get_with_metadata
+
+      refute result.key?(:ttl_remaining)
+      io_source.verify
+    end
+
+    it 'returns ttl_remaining when requested' do
+      serialized = Marshal.dump('v')
+      expect_read_line("VA #{serialized.bytesize} f1 t42")
+      expect_read_data(serialized, serialized.bytesize)
+
+      result = processor.meta_get_with_metadata(return_ttl_remaining: true)
+
+      assert_equal 42, result[:ttl_remaining]
+      io_source.verify
+    end
+
+    it 'returns -1 for ttl_remaining when the item has no expiry' do
+      serialized = Marshal.dump('v')
+      expect_read_line("VA #{serialized.bytesize} f1 t-1")
+      expect_read_data(serialized, serialized.bytesize)
+
+      result = processor.meta_get_with_metadata(return_ttl_remaining: true)
+
+      assert_equal(-1, result[:ttl_remaining])
+      io_source.verify
+    end
+  end
 end


### PR DESCRIPTION
First half of §3 of #1130. The second half (`get_multi_with_metadata`) is deliberately held back — see below.

## `:miss`

Reports the protocol's answer directly instead of leaving callers to infer absence:

```ruby
client.get_with_metadata('present')  #=> {value: "v",  cas: 2, ..., miss: false}
client.get_with_metadata('absent')   #=> {value: nil,  cas: 0, ..., miss: true}
```

Neither existing field can substitute for it:

- **`:value` can't** — a stored `nil` under `cache_nils` also returns `value: nil`
- **`:cas` can't** — a tombstoned item is a *hit* (`VA` with the `X` flag), so it has a real CAS and `stale: true`; distinguishing it from a true miss is the whole point

It is **always present**, matching the fixed key set the method already returns — `won_recache`, `stale` and `lost_recache` are always-present booleans, so a conditionally-present key would be the odd one out. That's the convention question I raised; this follows #1130's choice.

## `return_ttl_remaining`

Exposes the meta protocol's `t` flag: seconds left, or `-1` when the item has no expiry. Opt-in and absent from the result unless requested, following the existing `return_hit_status` / `return_last_access` shape exactly.

Requires memcached 1.6.0 for the `t` flag — comfortably under the 1.6.27 floor set in #1140.

## Verified against a live server

| Case | `ttl_remaining` | `miss` |
|---|---|---|
| hit, no expiry | `-1` | `false` |
| hit, `ttl: 100` | `100` | `false` |
| stored `nil` | — | `false` |
| miss | `0` | `true` |

**On `ttl_remaining: 0` for a miss:** metadata values are meaningless when the item does not exist, and this matches what the existing options already do there (`last_access: 0`, `hit_before: nil`). I kept the established behavior rather than inventing a different convention for one field; callers should check `:miss` first.

## Tests

11 new tests — 6 unit on the response processor, 1 on the request formatter (plus an updated combined-flags case), 4 integration.

Mutation-checked, both directions:

| Mutation | Fails |
|---|---|
| Remove the `:miss` key | 1 unit + 2 integration |
| Drop the `t` flag from the request | 2 formatter + 2 integration |

The integration tests deliberately assert **bounded** TTL values rather than exact ones — an exact assertion races the server's countdown, which is the class of flake #1141 just cleaned up.

Full suite green (618 runs), `rubocop` clean.

## Why `get_multi_with_metadata` isn't here

Its return shape is an open question I've asked @drinkbeer on #1130: #1130 returns an entry for every requested key including misses, which inverts the convention `get_multi` and `get_multi_cas` follow. This PR is unaffected by that answer, so it shouldn't wait on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)